### PR TITLE
feat(be): implement group admin api

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
       'error',
       {
         selector: 'default',
-        format: ['camelCase'],
+        format: ['camelCase', 'PascalCase'],
         leadingUnderscore: 'allow',
         trailingUnderscore: 'allow'
       },

--- a/backend/prisma/migrations/20220816145822_add_student_id_to_user/migration.sql
+++ b/backend/prisma/migrations/20220816145822_add_student_id_to_user/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[student_id]` on the table `user` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[user_id,group_id]` on the table `user_group` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `student_id` to the `user` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "student_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_student_id_key" ON "user"("student_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_group_user_id_group_id_key" ON "user_group"("user_id", "group_id");

--- a/backend/prisma/migrations/20220825112705_set_student_id_field_optional/migration.sql
+++ b/backend/prisma/migrations/20220825112705_set_student_id_field_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ALTER COLUMN "student_id" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   username              String   @unique
   password              String
   role                  Role     @default(User)
+  studentId             String   @unique @map("student_id")
   email                 String   @unique
   hasEmailAuthenticated Boolean  @default(false) @map("has_email_authenticated")
   lastLogin             DateTime @map("last_login")
@@ -65,7 +66,7 @@ model UserGroup {
   createTime     DateTime @default(now()) @map("create_time")
   updateTime     DateTime @updatedAt @map("update_time")
 
-  @@unique([user_id, group_id])
+  @@unique([userId, groupId])
   @@map("user_group")
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,6 +65,7 @@ model UserGroup {
   createTime     DateTime @default(now()) @map("create_time")
   updateTime     DateTime @updatedAt @map("update_time")
 
+  @@unique([user_id, group_id])
   @@map("user_group")
 }
 
@@ -74,7 +75,6 @@ model Group {
   createdById    Int      @map("created_by_id")
   groupName      String   @map("group_name")
   private        Boolean  @default(false)
-  // 생성시 자동 발급
   invitationCode String   @map("invitation_code")
   description    String
   createTime     DateTime @default(now()) @map("create_time")

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
   username              String   @unique
   password              String
   role                  Role     @default(User)
-  studentId             String   @unique @map("student_id")
+  studentId             String?  @unique @map("student_id")
   email                 String   @unique
   hasEmailAuthenticated Boolean  @default(false) @map("has_email_authenticated")
   lastLogin             DateTime @map("last_login")

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -4,7 +4,7 @@ import { JwtService } from '@nestjs/jwt'
 import { Test, TestingModule } from '@nestjs/testing'
 
 import { Cache } from 'cache-manager'
-import { User } from '@prisma/client'
+import { Submission, User, UserProfile } from '@prisma/client'
 
 import { AuthService } from './auth.service'
 import { UserService } from 'src/user/user.service'
@@ -32,6 +32,7 @@ describe('AuthService', () => {
     username: 'user',
     password: VALID_PASSWORD,
     role: 'User',
+    studentId: null,
     email: '',
     hasEmailAuthenticated: false,
     lastLogin: undefined,

--- a/backend/src/common/exception/business.exception.ts
+++ b/backend/src/common/exception/business.exception.ts
@@ -37,3 +37,9 @@ export class EmailTransmissionFailedException extends BusinessException {
     super(message)
   }
 }
+
+export class ActionNotAllowedException extends BusinessException {
+  constructor(action, entity) {
+    super(`${action} is not allowed to this ${entity}`)
+  }
+}

--- a/backend/src/contest/contest.service.spec.ts
+++ b/backend/src/contest/contest.service.spec.ts
@@ -389,7 +389,7 @@ describe('ContestService', () => {
   describe('getAdminContests', () => {
     it('should return contests in groups whose user is group manager', async () => {
       jest
-        .spyOn(groupService, 'getUserGroupManagerList')
+        .spyOn(groupService, 'getManagingGroupIds')
         .mockResolvedValue([groupId])
 
       expect(await contestService.getAdminContests(userId)).toEqual(contests)
@@ -399,7 +399,7 @@ describe('ContestService', () => {
   describe('getAdminOngoingContests', () => {
     it('should return ongoing contests in groups whose user is group manager', async () => {
       jest
-        .spyOn(groupService, 'getUserGroupManagerList')
+        .spyOn(groupService, 'getManagingGroupIds')
         .mockResolvedValue([groupId])
 
       expect(await contestService.getAdminOngoingContests(userId)).toEqual(

--- a/backend/src/contest/contest.service.ts
+++ b/backend/src/contest/contest.service.ts
@@ -203,7 +203,7 @@ export class ContestService {
   }
 
   async getAdminContests(userId: number): Promise<Partial<Contest>[]> {
-    const groupIds = await this.groupService.getUserGroupManagerList(userId)
+    const groupIds = await this.groupService.getManagingGroupIds(userId)
     return await this.prisma.contest.findMany({
       where: {
         groupId: { in: groupIds }

--- a/backend/src/group/dto/create-member.dto.ts
+++ b/backend/src/group/dto/create-member.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsInt, IsNotEmpty } from 'class-validator'
+
+export class CreateMemberDto {
+  @IsInt()
+  @IsNotEmpty()
+  readonly user_id: number
+
+  @IsBoolean()
+  @IsNotEmpty()
+  readonly is_group_manager: boolean
+}

--- a/backend/src/group/dto/create-member.dto.ts
+++ b/backend/src/group/dto/create-member.dto.ts
@@ -3,7 +3,7 @@ import { IsBoolean, IsInt, IsNotEmpty } from 'class-validator'
 export class CreateMemberDto {
   @IsInt()
   @IsNotEmpty()
-  readonly user_id: number
+  readonly student_id: string
 
   @IsBoolean()
   @IsNotEmpty()

--- a/backend/src/group/dto/create-member.dto.ts
+++ b/backend/src/group/dto/create-member.dto.ts
@@ -3,9 +3,9 @@ import { IsBoolean, IsInt, IsNotEmpty } from 'class-validator'
 export class CreateMemberDto {
   @IsInt()
   @IsNotEmpty()
-  readonly student_id: string
+  readonly studentId: string
 
   @IsBoolean()
   @IsNotEmpty()
-  readonly is_group_manager: boolean
+  readonly isGroupManager: boolean
 }

--- a/backend/src/group/dto/request-group.dto.ts
+++ b/backend/src/group/dto/request-group.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator'
+
+export class RequestGroupDto {
+  @IsString()
+  @IsNotEmpty()
+  readonly group_name: string
+
+  @IsBoolean()
+  @IsNotEmpty()
+  readonly private: boolean
+
+  @IsString()
+  @IsNotEmpty()
+  readonly description: string
+}

--- a/backend/src/group/dto/request-group.dto.ts
+++ b/backend/src/group/dto/request-group.dto.ts
@@ -3,7 +3,7 @@ import { IsBoolean, IsNotEmpty, IsString } from 'class-validator'
 export class RequestGroupDto {
   @IsString()
   @IsNotEmpty()
-  readonly group_name: string
+  readonly groupName: string
 
   @IsBoolean()
   @IsNotEmpty()

--- a/backend/src/group/group-admin.controller.ts
+++ b/backend/src/group/group-admin.controller.ts
@@ -157,7 +157,7 @@ export class GroupMemberController {
   @Delete(':id')
   async deleteMember(@Param('id', ParseIntPipe) id: number) {
     try {
-      return await this.groupService.deleteGroup(id)
+      return await this.groupService.deleteMember(id)
     } catch (error) {
       if (error instanceof EntityNotExistException) {
         throw new NotFoundException(error.message)

--- a/backend/src/group/group-admin.controller.ts
+++ b/backend/src/group/group-admin.controller.ts
@@ -42,7 +42,7 @@ export class GroupAdminController {
     @Body() groupDto: RequestGroupDto
   ): Promise<Group> {
     return await this.groupService.createGroup(req.user.id, groupDto)
-  } // TODO: 사용자로 UserGroup 생성
+  }
 
   @Get()
   async getGroups(@Req() req: AuthenticatedRequest): Promise<Partial<Group>[]> {

--- a/backend/src/group/group-admin.controller.ts
+++ b/backend/src/group/group-admin.controller.ts
@@ -27,7 +27,7 @@ import {
   EntityNotExistException
 } from 'src/common/exception/business.exception'
 import { RequestGroupDto } from './dto/request-group.dto'
-import { Membership } from './interface/membership'
+import { Membership } from './interface/membership.interface'
 import { CreateMemberDto } from './dto/create-member.dto'
 
 @Controller('admin/group')

--- a/backend/src/group/group-admin.controller.ts
+++ b/backend/src/group/group-admin.controller.ts
@@ -1,0 +1,168 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  InternalServerErrorException,
+  MethodNotAllowedException,
+  NotFoundException,
+  Param,
+  ParseArrayPipe,
+  ParseBoolPipe,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards
+} from '@nestjs/common'
+import { GroupService } from './group.service'
+import { Group, Role, UserGroup } from '@prisma/client'
+import { Roles } from 'src/common/decorator/roles.decorator'
+import { RolesGuard } from 'src/user/guard/roles.guard'
+import { GroupManagerGuard } from './guard/group-manager.guard'
+import { AuthenticatedRequest } from 'src/auth/interface/authenticated-request.interface'
+import {
+  ActionNotAllowedException,
+  EntityNotExistException
+} from 'src/common/exception/business.exception'
+import { RequestGroupDto } from './dto/request-group.dto'
+import { Membership } from './interface/membership'
+import { CreateMemberDto } from './dto/create-member.dto'
+
+@Controller('admin/group')
+@Roles(Role.GroupAdmin)
+@UseGuards(RolesGuard)
+export class GroupAdminController {
+  constructor(private readonly groupService: GroupService) {}
+
+  @Post()
+  async createGroup(
+    @Req() req: AuthenticatedRequest,
+    @Body() groupDto: RequestGroupDto
+  ): Promise<Group> {
+    return await this.groupService.createGroup(req.user.id, groupDto)
+  } // TODO: 사용자로 UserGroup 생성
+
+  @Get()
+  async getGroups(@Req() req: AuthenticatedRequest): Promise<Partial<Group>[]> {
+    return await this.groupService.getAdminGroups(req.user.id)
+  }
+
+  @Get(':group_id')
+  @UseGuards(GroupManagerGuard)
+  async getGroup(
+    @Param('group_id', ParseIntPipe) id: number
+  ): Promise<Partial<Group>> {
+    try {
+      return await this.groupService.getAdminGroup(id)
+    } catch (error) {
+      if (error instanceof EntityNotExistException) {
+        throw new NotFoundException(error.message)
+      }
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @Patch(':group_id')
+  @UseGuards(GroupManagerGuard)
+  async updateGroup(
+    @Param('group_id', ParseIntPipe) id: number,
+    @Body() groupDto: RequestGroupDto
+  ): Promise<Group> {
+    try {
+      return await this.groupService.updateGroup(id, groupDto)
+    } catch (error) {
+      if (error instanceof EntityNotExistException) {
+        throw new NotFoundException(error.message)
+      }
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @Delete(':group_id')
+  @UseGuards(GroupManagerGuard)
+  async deleteGroup(@Param('group_id', ParseIntPipe) id: number) {
+    try {
+      return await this.groupService.deleteGroup(id)
+    } catch (error) {
+      if (error instanceof EntityNotExistException) {
+        throw new NotFoundException(error.message)
+      }
+      throw new InternalServerErrorException()
+    }
+  }
+}
+
+@Controller('admin/group/:group_id/member')
+@UseGuards(GroupManagerGuard)
+export class GroupMemberController {
+  constructor(private readonly groupService: GroupService) {}
+
+  @Post()
+  async createMembers(
+    @Param('group_id', ParseIntPipe) groupId: number,
+    @Body() memberDto: CreateMemberDto[]
+  ) {
+    return await this.groupService.createMembers(groupId, memberDto)
+  }
+
+  @Get()
+  async getMembers(
+    @Param('group_id', ParseIntPipe) groupId: number,
+    @Query('offset', ParseIntPipe) offset: number
+  ): Promise<Membership[]> {
+    return await this.groupService.getAdminMembers(groupId, offset - 1)
+  }
+
+  @Get('manager')
+  async getManagers(
+    @Param('group_id', ParseIntPipe) groupId: number
+  ): Promise<Membership[]> {
+    return await this.groupService.getAdminManagers(groupId)
+  }
+
+  @Get('pending')
+  async getPendingMembers(
+    @Param('group_id', ParseIntPipe) groupId: number,
+    @Query('offset', ParseIntPipe) offset: number
+  ): Promise<Membership[]> {
+    return await this.groupService.getAdminPendingMembers(groupId, offset - 1)
+  }
+
+  @Patch('pending')
+  async registerMember(
+    @Body('ids', ParseArrayPipe) ids: number[]
+  ): Promise<{ count: number }> {
+    return await this.groupService.registerMembers(ids)
+  }
+
+  @Patch(':id')
+  async gradeMember(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('is_group_manager', ParseBoolPipe) role: boolean
+  ): Promise<UserGroup> {
+    try {
+      return await this.groupService.gradeMember(id, role)
+    } catch (error) {
+      if (error instanceof EntityNotExistException) {
+        throw new NotFoundException(error.message)
+      } else if (error instanceof ActionNotAllowedException) {
+        throw new MethodNotAllowedException(error.message)
+      }
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @Delete(':id')
+  async deleteMember(@Param('id', ParseIntPipe) id: number) {
+    try {
+      return await this.groupService.deleteGroup(id)
+    } catch (error) {
+      if (error instanceof EntityNotExistException) {
+        throw new NotFoundException(error.message)
+      }
+      throw new InternalServerErrorException()
+    }
+  }
+}

--- a/backend/src/group/group-admin.controller.ts
+++ b/backend/src/group/group-admin.controller.ts
@@ -49,10 +49,10 @@ export class GroupAdminController {
     return await this.groupService.getAdminGroups(req.user.id)
   }
 
-  @Get(':group_id')
+  @Get(':groupId')
   @UseGuards(GroupManagerGuard)
   async getGroup(
-    @Param('group_id', ParseIntPipe) id: number
+    @Param('groupId', ParseIntPipe) id: number
   ): Promise<Partial<Group>> {
     try {
       return await this.groupService.getAdminGroup(id)
@@ -64,10 +64,10 @@ export class GroupAdminController {
     }
   }
 
-  @Patch(':group_id')
+  @Patch(':groupId')
   @UseGuards(GroupManagerGuard)
   async updateGroup(
-    @Param('group_id', ParseIntPipe) id: number,
+    @Param('groupId', ParseIntPipe) id: number,
     @Body() groupDto: RequestGroupDto
   ): Promise<Group> {
     try {
@@ -80,9 +80,9 @@ export class GroupAdminController {
     }
   }
 
-  @Delete(':group_id')
+  @Delete(':groupId')
   @UseGuards(GroupManagerGuard)
-  async deleteGroup(@Param('group_id', ParseIntPipe) id: number) {
+  async deleteGroup(@Param('groupId', ParseIntPipe) id: number) {
     try {
       return await this.groupService.deleteGroup(id)
     } catch (error) {
@@ -94,14 +94,14 @@ export class GroupAdminController {
   }
 }
 
-@Controller('admin/group/:group_id/member')
+@Controller('admin/group/:groupId/member')
 @UseGuards(GroupManagerGuard)
 export class GroupMemberController {
   constructor(private readonly groupService: GroupService) {}
 
   @Post()
   async createMembers(
-    @Param('group_id', ParseIntPipe) groupId: number,
+    @Param('groupId', ParseIntPipe) groupId: number,
     @Body() memberDto: CreateMemberDto[]
   ) {
     return await this.groupService.createMembers(groupId, memberDto)
@@ -109,7 +109,7 @@ export class GroupMemberController {
 
   @Get()
   async getMembers(
-    @Param('group_id', ParseIntPipe) groupId: number,
+    @Param('groupId', ParseIntPipe) groupId: number,
     @Query('offset', ParseIntPipe) offset: number
   ): Promise<Membership[]> {
     return await this.groupService.getAdminMembers(groupId, offset - 1)
@@ -117,14 +117,14 @@ export class GroupMemberController {
 
   @Get('manager')
   async getManagers(
-    @Param('group_id', ParseIntPipe) groupId: number
+    @Param('groupId', ParseIntPipe) groupId: number
   ): Promise<Membership[]> {
     return await this.groupService.getAdminManagers(groupId)
   }
 
   @Get('pending')
   async getPendingMembers(
-    @Param('group_id', ParseIntPipe) groupId: number,
+    @Param('groupId', ParseIntPipe) groupId: number,
     @Query('offset', ParseIntPipe) offset: number
   ): Promise<Membership[]> {
     return await this.groupService.getAdminPendingMembers(groupId, offset - 1)
@@ -140,7 +140,7 @@ export class GroupMemberController {
   @Patch(':id')
   async gradeMember(
     @Param('id', ParseIntPipe) id: number,
-    @Body('is_group_manager', ParseBoolPipe) role: boolean
+    @Body('isGroupManager', ParseBoolPipe) role: boolean
   ): Promise<UserGroup> {
     try {
       return await this.groupService.gradeMember(id, role)

--- a/backend/src/group/group-admin.controller.ts
+++ b/backend/src/group/group-admin.controller.ts
@@ -103,7 +103,7 @@ export class GroupMemberController {
   async createMembers(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Body() memberDto: CreateMemberDto[]
-  ) {
+  ): Promise<number[]> {
     return await this.groupService.createMembers(groupId, memberDto)
   }
 

--- a/backend/src/group/group.controller.spec.ts
+++ b/backend/src/group/group.controller.spec.ts
@@ -1,4 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { UserService } from 'src/user/user.service'
+import {
+  GroupAdminController,
+  GroupMemberController
+} from './group-admin.controller'
 import { GroupController } from './group.controller'
 import { GroupService } from './group.service'
 
@@ -12,6 +17,46 @@ describe('GroupController', () => {
     }).compile()
 
     controller = module.get<GroupController>(GroupController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+})
+
+describe('GroupAdminController', () => {
+  let controller: GroupAdminController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupAdminController],
+      providers: [
+        { provide: GroupService, useValue: {} },
+        { provide: UserService, useValue: {} }
+      ]
+    }).compile()
+
+    controller = module.get<GroupAdminController>(GroupAdminController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+})
+
+describe('GroupMemberController', () => {
+  let controller: GroupMemberController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupMemberController],
+      providers: [
+        { provide: GroupService, useValue: {} },
+        { provide: UserService, useValue: {} }
+      ]
+    }).compile()
+
+    controller = module.get<GroupMemberController>(GroupMemberController)
   })
 
   it('should be defined', () => {

--- a/backend/src/group/group.module.ts
+++ b/backend/src/group/group.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common'
+import { UserModule } from 'src/user/user.module'
+import {
+  GroupAdminController,
+  GroupMemberController
+} from './group-admin.controller'
 import { GroupController } from './group.controller'
 import { GroupService } from './group.service'
 
 @Module({
-  controllers: [GroupController],
+  imports: [UserModule],
+  controllers: [GroupController, GroupAdminController, GroupMemberController],
   providers: [GroupService],
   exports: [GroupService]
 })

--- a/backend/src/group/group.service.spec.ts
+++ b/backend/src/group/group.service.spec.ts
@@ -1,10 +1,93 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { Group, UserGroup } from '@prisma/client'
 import { PrismaService } from 'src/prisma/prisma.service'
+import { RequestGroupDto } from './dto/request-group.dto'
+import { CreateMemberDto } from './dto/create-member.dto'
 import { GroupService } from './group.service'
+import * as hash from '../common/hash'
+import { Membership } from './interface/membership.interface'
+import {
+  ActionNotAllowedException,
+  EntityNotExistException
+} from 'src/common/exception/business.exception'
 
-const mockPrismaService = {
+const userId = 1
+const groupId = 3
+const membershipId = 1
+
+const group: Group = {
+  id: groupId,
+  created_by_id: userId,
+  group_name: 'group_name',
+  private: true,
+  invitation_code: '',
+  description: 'description',
+  create_time: new Date(),
+  update_time: new Date()
+}
+
+const userGroup: UserGroup = {
+  id: membershipId,
+  user_id: userId,
+  group_id: groupId,
+  is_registered: true,
+  is_group_manager: true,
+  create_time: new Date(),
+  update_time: new Date()
+}
+
+const membership: Membership = {
+  id: userGroup.id,
+  user: {
+    username: 'example',
+    student_id: '2020710000',
+    email: 'example@skku.edu',
+    UserProfile: {
+      real_name: 'Hong Gildong'
+    }
+  }
+}
+
+const requestGroupDto: RequestGroupDto = {
+  group_name: group.group_name,
+  private: group.private,
+  description: group.description
+}
+
+const createMemberDto: CreateMemberDto = {
+  student_id: '2020310000',
+  is_group_manager: false
+}
+
+const db = {
+  group: {
+    findUnique: jest.fn().mockResolvedValue(group),
+    findMany: jest.fn(),
+    create: jest.fn().mockResolvedValue(group),
+    update: jest.fn().mockResolvedValue(group),
+    delete: jest.fn()
+  },
   userGroup: {
-    findFirst: jest.fn()
+    findUnique: jest.fn().mockResolvedValue(userGroup),
+    findFirst: jest.fn(),
+    findMany: jest.fn().mockResolvedValue([membership]),
+    create: jest.fn().mockResolvedValue(userGroup),
+    update: jest.fn().mockResolvedValue(userGroup),
+    updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    delete: jest.fn(),
+    deleteMany: jest.fn()
+  },
+  user: {
+    findUnique: jest.fn().mockResolvedValue({ id: userId })
+  },
+  problem: {
+    update: jest.fn()
+  },
+  contest: {
+    update: jest.fn()
+  },
+  workbook: {
+    update: jest.fn()
   }
 }
 
@@ -13,16 +96,292 @@ describe('GroupService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        GroupService,
-        { provide: PrismaService, useValue: mockPrismaService }
-      ]
+      providers: [GroupService, { provide: PrismaService, useValue: db }]
     }).compile()
 
     service = module.get<GroupService>(GroupService)
   })
 
+  beforeAll(async () => {
+    group.invitation_code = (
+      await hash.encrypt(userId + group.group_name)
+    ).split('$')[5]
+  })
+
   it('should be defined', () => {
     expect(service).toBeDefined()
+  })
+
+  describe('getUserGroupMembershipInfo', () => {
+    const membership = {
+      is_registered: userGroup.is_registered,
+      is_group_manager: userGroup.is_group_manager
+    }
+
+    it('should return specified membership', async () => {
+      db.userGroup.findFirst.mockResolvedValueOnce(membership)
+
+      const getUserGroup = await service.getUserGroupMembershipInfo(
+        userId,
+        groupId
+      )
+      expect(getUserGroup).toEqual(membership)
+    })
+  })
+
+  describe('getManagingGroupIds', () => {
+    db.userGroup.findMany.mockResolvedValueOnce([{ group_id: groupId }])
+
+    it('should return all managing group ids', async () => {
+      const getIds = await service.getManagingGroupIds(userId)
+      expect(getIds).toEqual([groupId])
+    })
+  })
+
+  describe('createGroup', () => {
+    it('should return newly created group', async () => {
+      const encryptSpy = jest.spyOn(hash, 'encrypt')
+      const createGroup = await service.createGroup(userId, requestGroupDto)
+      expect(createGroup).toEqual(group)
+      expect(encryptSpy).toBeCalledWith(userId + group.group_name)
+    })
+  })
+
+  describe('getAdminGroups', () => {
+    const adminGroup = {
+      id: group.id,
+      group_name: group.group_name,
+      private: group.private,
+      description: group.private,
+      UserGroup: [userGroup]
+    }
+
+    it('should return all managing groups', async () => {
+      db.group.findMany.mockResolvedValueOnce([adminGroup])
+
+      const getGroups = await service.getAdminGroups(userId)
+      expect(getGroups).toEqual([{ ...adminGroup, UserGroup: 1 }])
+    })
+  })
+
+  describe('getAdminGroup', () => {
+    const adminGroup = {
+      id: group.id,
+      group_name: group.group_name,
+      private: group.private,
+      invitation_code: group.invitation_code,
+      description: group.private,
+      create_time: group.create_time,
+      update_time: group.update_time,
+      UserGroup: [userGroup]
+    }
+
+    it('should return specified group', async () => {
+      db.group.findUnique.mockResolvedValueOnce(adminGroup)
+
+      const getGroup = await service.getAdminGroup(groupId)
+      expect(getGroup).toEqual({
+        ...adminGroup,
+        UserGroup: 1,
+        ManagerGroup: ['example']
+      })
+    })
+
+    it('should throw error when the group does not exist', async () => {
+      db.group.findUnique.mockRejectedValueOnce(
+        new EntityNotExistException('group')
+      )
+
+      await expect(service.getAdminGroup(groupId)).rejects.toThrow(
+        EntityNotExistException
+      )
+    })
+  })
+
+  describe('updateGroup', () => {
+    it('should return updated group', async () => {
+      const updateGroup = await service.updateGroup(groupId, requestGroupDto)
+      expect(updateGroup).toEqual(group)
+    })
+
+    it('should throw error when the group does not exist', async () => {
+      db.group.findUnique.mockRejectedValueOnce(
+        new EntityNotExistException('group')
+      )
+
+      await expect(
+        service.updateGroup(groupId, requestGroupDto)
+      ).rejects.toThrow(EntityNotExistException)
+    })
+  })
+
+  describe('deleteGroup', () => {
+    afterEach(() => {
+      db.group.delete.mockClear()
+      db.userGroup.deleteMany.mockClear()
+      db.problem.update.mockClear()
+      db.contest.update.mockClear()
+      db.workbook.update.mockClear()
+    })
+
+    const relatedData = {
+      Problem: [
+        {
+          id: 1
+        }
+      ],
+      Contest: [
+        {
+          id: 1
+        }
+      ],
+      Workbook: [
+        {
+          id: 1
+        }
+      ]
+    }
+
+    it('should successfully delete the group and move related data', async () => {
+      db.group.findUnique.mockResolvedValueOnce(relatedData)
+
+      await service.deleteGroup(groupId)
+      expect(db.group.delete).toBeCalledTimes(1)
+      expect(db.userGroup.deleteMany).toBeCalledTimes(1)
+      expect(db.problem.update).toBeCalledTimes(1)
+      expect(db.contest.update).toBeCalledTimes(1)
+      expect(db.workbook.update).toBeCalledTimes(1)
+    })
+
+    it('should throw error when the group does not exist', async () => {
+      db.group.findUnique.mockRejectedValueOnce(
+        new EntityNotExistException('group')
+      )
+
+      await expect(service.deleteGroup(groupId)).rejects.toThrow(
+        EntityNotExistException
+      )
+      expect(db.group.delete).toBeCalledTimes(0)
+      expect(db.userGroup.deleteMany).toBeCalledTimes(0)
+      expect(db.problem.update).toBeCalledTimes(0)
+      expect(db.contest.update).toBeCalledTimes(0)
+      expect(db.workbook.update).toBeCalledTimes(0)
+    })
+  })
+
+  describe('createMembers', () => {
+    it('should return newly created group', async () => {
+      const createMembers = await service.createMembers(groupId, [
+        createMemberDto
+      ])
+      expect(createMembers).toEqual([userGroup])
+    })
+  })
+
+  describe('getAdminManagers', () => {
+    it('should return managers of the group', async () => {
+      const getUserGroups = await service.getAdminManagers(groupId)
+      expect(getUserGroups).toEqual([membership])
+    })
+  })
+
+  describe('getAdminMembers', () => {
+    const memberMembership = {
+      ...membership,
+      is_group_manager: userGroup.is_group_manager
+    }
+
+    it('should return members of the group', async () => {
+      db.userGroup.findMany.mockResolvedValueOnce([memberMembership])
+
+      const getUserGroups = await service.getAdminMembers(groupId, 0)
+      expect(getUserGroups).toEqual([memberMembership])
+    })
+  })
+
+  describe('getAdminPendingMembers', () => {
+    it('should return members of the group', async () => {
+      const getUserGroups = await service.getAdminPendingMembers(groupId, 0)
+      expect(getUserGroups).toEqual([membership])
+    })
+  })
+
+  describe('getAdminPendingMembers', () => {
+    it('should return pending members of the group', async () => {
+      const getUserGroups = await service.getAdminPendingMembers(groupId, 0)
+      expect(getUserGroups).toEqual([membership])
+    })
+  })
+
+  describe('gradeMember', () => {
+    afterEach(() => {
+      db.userGroup.update.mockClear()
+    })
+
+    const memberUserGroup = {
+      ...userGroup,
+      is_group_manager: false
+    }
+
+    it('should successfully grade selected member', async () => {
+      await service.gradeMember(userGroup.id, false)
+      expect(db.userGroup.update).toBeCalledTimes(1)
+    })
+
+    it('should fail to upgrade manager', async () => {
+      await expect(service.gradeMember(userGroup.id, true)).rejects.toThrow(
+        ActionNotAllowedException
+      )
+      expect(db.userGroup.update).toBeCalledTimes(0)
+    })
+
+    it('should fail to downgrade member', async () => {
+      db.userGroup.findUnique.mockResolvedValueOnce(memberUserGroup)
+
+      await expect(
+        service.gradeMember(memberUserGroup.id, false)
+      ).rejects.toThrow(ActionNotAllowedException)
+      expect(db.userGroup.update).toBeCalledTimes(0)
+    })
+
+    it('should throw error when the member does not exist', async () => {
+      db.userGroup.findUnique.mockRejectedValueOnce(
+        new EntityNotExistException('membership')
+      )
+
+      await expect(
+        service.gradeMember(memberUserGroup.id, false)
+      ).rejects.toThrow(EntityNotExistException)
+      expect(db.userGroup.update).toBeCalledTimes(0)
+    })
+  })
+
+  describe('registerMembers', () => {
+    it('should successfully register selected members', async () => {
+      const updateUserGroup = await service.registerMembers([userId])
+      expect(updateUserGroup).toEqual({ count: 1 })
+    })
+  })
+
+  describe('deleteMember', () => {
+    afterEach(() => {
+      db.userGroup.delete.mockClear()
+    })
+
+    it('should successfully delete the member', async () => {
+      await service.deleteMember(userGroup.id)
+      expect(db.userGroup.delete).toBeCalledTimes(1)
+    })
+
+    it('should throw error when the member does not exist', async () => {
+      db.userGroup.findFirst.mockRejectedValueOnce(
+        new EntityNotExistException('membership')
+      )
+
+      await expect(service.deleteMember(userGroup.id)).rejects.toThrow(
+        EntityNotExistException
+      )
+      expect(db.userGroup.delete).toBeCalledTimes(0)
+    })
   })
 })

--- a/backend/src/group/group.service.spec.ts
+++ b/backend/src/group/group.service.spec.ts
@@ -4,15 +4,15 @@ import { PrismaService } from 'src/prisma/prisma.service'
 import { RequestGroupDto } from './dto/request-group.dto'
 import { CreateMemberDto } from './dto/create-member.dto'
 import { GroupService } from './group.service'
-import * as hash from '../common/hash'
 import { Membership } from './interface/membership.interface'
 import {
   ActionNotAllowedException,
   EntityNotExistException
 } from 'src/common/exception/business.exception'
+import { randomBytes } from 'crypto'
 
 const userId = 1
-const groupId = 3
+const groupId = 2
 const membershipId = 1
 
 const group: Group = {
@@ -20,7 +20,7 @@ const group: Group = {
   created_by_id: userId,
   group_name: 'group_name',
   private: true,
-  invitation_code: '',
+  invitation_code: randomBytes(6).toString('base64').padStart(8, 'A'),
   description: 'description',
   create_time: new Date(),
   update_time: new Date()
@@ -102,11 +102,7 @@ describe('GroupService', () => {
     service = module.get<GroupService>(GroupService)
   })
 
-  beforeAll(async () => {
-    group.invitation_code = (
-      await hash.encrypt(userId + group.group_name)
-    ).split('$')[5]
-  })
+  //beforeAll(() => {})
 
   it('should be defined', () => {
     expect(service).toBeDefined()
@@ -140,10 +136,10 @@ describe('GroupService', () => {
 
   describe('createGroup', () => {
     it('should return newly created group', async () => {
-      const encryptSpy = jest.spyOn(hash, 'encrypt')
+      const encryptSpy = jest.spyOn(service, 'createCode')
       const createGroup = await service.createGroup(userId, requestGroupDto)
       expect(createGroup).toEqual(group)
-      expect(encryptSpy).toBeCalledWith(userId + group.group_name)
+      expect(encryptSpy).toBeCalledTimes(1)
     })
   })
 

--- a/backend/src/group/group.service.spec.ts
+++ b/backend/src/group/group.service.spec.ts
@@ -17,46 +17,46 @@ const membershipId = 1
 
 const group: Group = {
   id: groupId,
-  created_by_id: userId,
-  group_name: 'group_name',
+  createdById: userId,
+  groupName: 'groupName',
   private: true,
-  invitation_code: randomBytes(6).toString('base64').padStart(8, 'A'),
+  invitationCode: randomBytes(6).toString('base64').padStart(8, 'A'),
   description: 'description',
-  create_time: new Date(),
-  update_time: new Date()
+  createTime: new Date(),
+  updateTime: new Date()
 }
 
 const userGroup: UserGroup = {
   id: membershipId,
-  user_id: userId,
-  group_id: groupId,
-  is_registered: true,
-  is_group_manager: true,
-  create_time: new Date(),
-  update_time: new Date()
+  userId: userId,
+  groupId: groupId,
+  isRegistered: true,
+  isGroupManager: true,
+  createTime: new Date(),
+  updateTime: new Date()
 }
 
 const membership: Membership = {
   id: userGroup.id,
   user: {
     username: 'example',
-    student_id: '2020710000',
+    studentId: '2020710000',
     email: 'example@skku.edu',
     UserProfile: {
-      real_name: 'Hong Gildong'
+      realName: 'Hong Gildong'
     }
   }
 }
 
 const requestGroupDto: RequestGroupDto = {
-  group_name: group.group_name,
+  groupName: group.groupName,
   private: group.private,
   description: group.description
 }
 
 const createMemberDto: CreateMemberDto = {
-  student_id: '2020310000',
-  is_group_manager: false
+  studentId: '2020310000',
+  isGroupManager: false
 }
 
 const db = {
@@ -110,8 +110,8 @@ describe('GroupService', () => {
 
   describe('getUserGroupMembershipInfo', () => {
     const membership = {
-      is_registered: userGroup.is_registered,
-      is_group_manager: userGroup.is_group_manager
+      isRegistered: userGroup.isRegistered,
+      isGroupManager: userGroup.isGroupManager
     }
 
     it('should return specified membership', async () => {
@@ -126,7 +126,7 @@ describe('GroupService', () => {
   })
 
   describe('getManagingGroupIds', () => {
-    db.userGroup.findMany.mockResolvedValueOnce([{ group_id: groupId }])
+    db.userGroup.findMany.mockResolvedValueOnce([{ groupId: groupId }])
 
     it('should return all managing group ids', async () => {
       const getIds = await service.getManagingGroupIds(userId)
@@ -146,7 +146,7 @@ describe('GroupService', () => {
   describe('getAdminGroups', () => {
     const adminGroup = {
       id: group.id,
-      group_name: group.group_name,
+      groupName: group.groupName,
       private: group.private,
       description: group.private,
       UserGroup: [userGroup]
@@ -163,12 +163,12 @@ describe('GroupService', () => {
   describe('getAdminGroup', () => {
     const adminGroup = {
       id: group.id,
-      group_name: group.group_name,
+      groupName: group.groupName,
       private: group.private,
-      invitation_code: group.invitation_code,
+      invitationCode: group.invitationCode,
       description: group.private,
-      create_time: group.create_time,
-      update_time: group.update_time,
+      createTime: group.createTime,
+      updateTime: group.updateTime,
       UserGroup: [userGroup]
     }
 
@@ -284,7 +284,7 @@ describe('GroupService', () => {
   describe('getAdminMembers', () => {
     const memberMembership = {
       ...membership,
-      is_group_manager: userGroup.is_group_manager
+      isGroupManager: userGroup.isGroupManager
     }
 
     it('should return members of the group', async () => {
@@ -316,7 +316,7 @@ describe('GroupService', () => {
 
     const memberUserGroup = {
       ...userGroup,
-      is_group_manager: false
+      isGroupManager: false
     }
 
     it('should successfully grade selected member', async () => {

--- a/backend/src/group/group.service.spec.ts
+++ b/backend/src/group/group.service.spec.ts
@@ -156,7 +156,7 @@ describe('GroupService', () => {
       db.group.findMany.mockResolvedValueOnce([adminGroup])
 
       const getGroups = await service.getAdminGroups(userId)
-      expect(getGroups).toEqual([{ ...adminGroup, UserGroup: 1 }])
+      expect(getGroups).toEqual([{ ...adminGroup, totalMember: 1 }])
     })
   })
 
@@ -178,8 +178,8 @@ describe('GroupService', () => {
       const getGroup = await service.getAdminGroup(groupId)
       expect(getGroup).toEqual({
         ...adminGroup,
-        UserGroup: 1,
-        ManagerGroup: ['example']
+        totalMember: 1,
+        managers: ['example']
       })
     })
 

--- a/backend/src/group/group.service.spec.ts
+++ b/backend/src/group/group.service.spec.ts
@@ -54,10 +54,16 @@ const requestGroupDto: RequestGroupDto = {
   description: group.description
 }
 
-const createMemberDto: CreateMemberDto = {
-  studentId: '2020310000',
-  isGroupManager: false
-}
+const createMemberDtos: CreateMemberDto[] = [
+  {
+    studentId: '0000000000',
+    isGroupManager: false
+  },
+  {
+    studentId: '2020310000',
+    isGroupManager: false
+  }
+]
 
 const db = {
   group: {
@@ -266,11 +272,11 @@ describe('GroupService', () => {
   })
 
   describe('createMembers', () => {
-    it('should return newly created group', async () => {
-      const createMembers = await service.createMembers(groupId, [
-        createMemberDto
-      ])
-      expect(createMembers).toEqual([userGroup])
+    it('should return not invited member ids', async () => {
+      db.user.findUnique.mockResolvedValueOnce(null)
+
+      const failedIds = await service.createMembers(groupId, createMemberDtos)
+      expect(failedIds).toEqual([0])
     })
   })
 

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -51,11 +51,11 @@ export class GroupService {
   async createGroup(userId: number, groupDto: RequestGroupDto): Promise<Group> {
     return await this.prisma.group.create({
       data: {
-        group_name: groupDto.group_name,
+        groupName: groupDto.groupName,
         private: groupDto.private,
-        invitation_code: this.createCode(),
+        invitationCode: this.createCode(),
         description: groupDto.description,
-        created_by: {
+        createdBy: {
           connect: { id: userId }
         }
       }
@@ -78,7 +78,7 @@ export class GroupService {
         },
         select: {
           id: true,
-          group_name: true,
+          groupName: true,
           private: true,
           description: true,
           UserGroup: true
@@ -87,7 +87,7 @@ export class GroupService {
     ).map((group) => {
       return {
         ...group,
-        total_member: group.UserGroup.filter((member) => member.is_registered)
+        totalMember: group.UserGroup.filter((member) => member.isRegistered)
           .length
       }
     })
@@ -100,12 +100,12 @@ export class GroupService {
       },
       select: {
         id: true,
-        group_name: true,
+        groupName: true,
         private: true,
-        invitation_code: true,
+        invitationCode: true,
         description: true,
-        create_time: true,
-        update_time: true,
+        createTime: true,
+        updateTime: true,
         UserGroup: true
       },
       rejectOnNotFound: () => new EntityNotExistException('group')
@@ -113,7 +113,7 @@ export class GroupService {
 
     return {
       ...group,
-      total_member: group.UserGroup.filter((member) => member.is_registered)
+      totalMember: group.UserGroup.filter((member) => member.isRegistered)
         .length,
       managers: (await this.getAdminManagers(id)).map(
         (manager) => manager.user.username
@@ -172,7 +172,7 @@ export class GroupService {
 
     await this.prisma.userGroup.deleteMany({
       where: {
-        group_id: id
+        groupId: id
       }
     })
 
@@ -217,7 +217,7 @@ export class GroupService {
       const id = (
         await this.prisma.user.findUnique({
           where: {
-            student_id: memberDto.student_id
+            studentId: memberDto.studentId
           },
           select: {
             id: true
@@ -232,7 +232,7 @@ export class GroupService {
           group: {
             connect: { id: groupId }
           },
-          is_group_manager: memberDto.is_group_manager
+          isGroupManager: memberDto.isGroupManager
         }
       })
     })
@@ -243,20 +243,20 @@ export class GroupService {
   async getAdminManagers(groupId: number): Promise<Membership[]> {
     return await this.prisma.userGroup.findMany({
       where: {
-        group_id: groupId,
-        is_registered: true,
-        is_group_manager: true
+        groupId: groupId,
+        isRegistered: true,
+        isGroupManager: true
       },
       select: {
         id: true,
         user: {
           select: {
             username: true,
-            student_id: true,
+            studentId: true,
             email: true,
             UserProfile: {
               select: {
-                real_name: true
+                realName: true
               }
             }
           }
@@ -268,24 +268,24 @@ export class GroupService {
   async getAdminMembers(groupId: number, skip: number): Promise<Membership[]> {
     return await this.prisma.userGroup.findMany({
       where: {
-        group_id: groupId,
-        is_registered: true
+        groupId: groupId,
+        isRegistered: true
       },
       select: {
         id: true,
         user: {
           select: {
             username: true,
-            student_id: true,
+            studentId: true,
             email: true,
             UserProfile: {
               select: {
-                real_name: true
+                realName: true
               }
             }
           }
         },
-        is_group_manager: true
+        isGroupManager: true
       },
       skip: skip,
       take: 10
@@ -298,19 +298,19 @@ export class GroupService {
   ): Promise<Membership[]> {
     return await this.prisma.userGroup.findMany({
       where: {
-        group_id: groupId,
-        is_registered: false
+        groupId: groupId,
+        isRegistered: false
       },
       select: {
         id: true,
         user: {
           select: {
             username: true,
-            student_id: true,
+            studentId: true,
             email: true,
             UserProfile: {
               select: {
-                real_name: true
+                realName: true
               }
             }
           }
@@ -328,11 +328,11 @@ export class GroupService {
           id: id
         },
         select: {
-          is_group_manager: true
+          isGroupManager: true
         },
         rejectOnNotFound: () => new EntityNotExistException('membership')
       })
-    ).is_group_manager
+    ).isGroupManager
 
     if (currentRole === role) {
       if (role) throw new ActionNotAllowedException('upgrade', 'manager')
@@ -344,7 +344,7 @@ export class GroupService {
         id: id
       },
       data: {
-        is_group_manager: role
+        isGroupManager: role
       }
     })
   }
@@ -357,7 +357,7 @@ export class GroupService {
         }
       },
       data: {
-        is_registered: true
+        isRegistered: true
       }
     })
   }

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -87,7 +87,8 @@ export class GroupService {
     ).map((group) => {
       return {
         ...group,
-        UserGroup: group.UserGroup.length
+        total_member: group.UserGroup.filter((member) => member.is_registered)
+          .length
       }
     })
   }
@@ -112,8 +113,9 @@ export class GroupService {
 
     return {
       ...group,
-      UserGroup: group.UserGroup.length,
-      ManagerGroup: (await this.getAdminManagers(id)).map(
+      total_member: group.UserGroup.filter((member) => member.is_registered)
+        .length,
+      managers: (await this.getAdminManagers(id)).map(
         (manager) => manager.user.username
       )
     }
@@ -235,7 +237,7 @@ export class GroupService {
       })
     })
 
-    return Promise.all(members)
+    return await Promise.all(members)
   }
 
   async getAdminManagers(groupId: number): Promise<Membership[]> {

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -1,11 +1,27 @@
 import { Injectable } from '@nestjs/common'
+import { Group, UserGroup } from '@prisma/client'
 import { PrismaService } from 'src/prisma/prisma.service'
+import { RequestGroupDto } from './dto/request-group.dto'
+import { encrypt } from 'src/common/hash'
+import {
+  ActionNotAllowedException,
+  EntityNotExistException
+} from 'src/common/exception/business.exception'
+import { AdminGroup } from './interface/admin-group.interface'
+import { Membership } from './interface/membership'
+import { CreateMemberDto } from './dto/create-member.dto'
+
+// TODO: group id 확정 필요
+const DEPRECATED = 0
 
 @Injectable()
 export class GroupService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getUserGroupMembershipInfo(userId: number, groupId: number) {
+  async getUserGroupMembershipInfo(
+    userId: number,
+    groupId: number
+  ): Promise<Partial<UserGroup>> {
     return await this.prisma.userGroup.findFirst({
       where: {
         userId: userId,
@@ -18,7 +34,7 @@ export class GroupService {
     })
   }
 
-  async getUserGroupManagerList(userId: number): Promise<number[]> {
+  async getManagingGroupIds(userId: number): Promise<number[]> {
     return (
       await this.prisma.userGroup.findMany({
         where: {
@@ -31,5 +47,330 @@ export class GroupService {
         }
       })
     ).map((group) => group.groupId)
+  }
+
+  async createGroup(userId: number, groupDto: RequestGroupDto): Promise<Group> {
+    const code = (await encrypt(userId + groupDto.group_name)).split('$')[5]
+
+    return await this.prisma.group.create({
+      data: {
+        group_name: groupDto.group_name,
+        private: groupDto.private,
+        invitation_code: code,
+        description: groupDto.description,
+        created_by: {
+          connect: { id: userId }
+        }
+      }
+    })
+  }
+
+  async getAdminGroups(userId: number): Promise<AdminGroup[]> {
+    const groupIds = await this.getManagingGroupIds(userId)
+
+    return (
+      await this.prisma.group.findMany({
+        where: {
+          id: {
+            in: groupIds
+          }
+        },
+        select: {
+          id: true,
+          group_name: true,
+          private: true,
+          description: true,
+          UserGroup: true
+        }
+      })
+    ).map((group) => {
+      return {
+        ...group,
+        UserGroup: group.UserGroup.length
+      }
+    })
+  }
+
+  async getAdminGroup(id: number): Promise<AdminGroup> {
+    const group = await this.prisma.group.findUnique({
+      where: {
+        id: id
+      },
+      select: {
+        id: true,
+        group_name: true,
+        private: true,
+        invitation_code: true,
+        description: true,
+        create_time: true,
+        update_time: true,
+        UserGroup: true
+      },
+      rejectOnNotFound: () => new EntityNotExistException('group')
+    })
+
+    return {
+      ...group,
+      UserGroup: group.UserGroup.length,
+      ManagerGroup: (await this.getAdminManagers(id)).map(
+        (manager) => manager.user.username
+      )
+    }
+  }
+
+  async updateGroup(id: number, groupDto: RequestGroupDto): Promise<Group> {
+    await this.prisma.group.findUnique({
+      where: {
+        id: id
+      },
+      rejectOnNotFound: () => new EntityNotExistException('group')
+    })
+
+    return await this.prisma.group.update({
+      where: {
+        id: id
+      },
+      data: {
+        ...groupDto
+      }
+    })
+  }
+
+  async deleteGroup(id: number) {
+    const group = await this.prisma.group.findUnique({
+      where: {
+        id: id
+      },
+      select: {
+        Problem: {
+          select: {
+            id: true
+          }
+        },
+        Contest: {
+          select: {
+            id: true
+          }
+        },
+        Workbook: {
+          select: {
+            id: true
+          }
+        }
+      },
+      rejectOnNotFound: () => new EntityNotExistException('group')
+    })
+
+    await this.prisma.group.delete({
+      where: {
+        id: id
+      }
+    })
+
+    await this.prisma.userGroup.deleteMany({
+      where: {
+        group_id: id
+      }
+    })
+
+    const deprecate = async (query: {
+      model: string
+      related: { id: number }[]
+    }) => {
+      await this.prisma[query.model].update({
+        where: {
+          id: {
+            in: query.related.map((record) => record.id)
+          }
+        },
+        data: {
+          group: {
+            connect: { id: DEPRECATED }
+          }
+        }
+      })
+    }
+    ;[
+      {
+        model: 'problem',
+        related: group.Problem
+      },
+      {
+        model: 'contest',
+        related: group.Contest
+      },
+      {
+        model: 'workbook',
+        related: group.Workbook
+      }
+    ].forEach((query) => deprecate(query))
+  }
+
+  async createMembers(
+    groupId: number,
+    memberDtos: CreateMemberDto[]
+  ): Promise<UserGroup[]> {
+    const members = memberDtos.map(async (memberDto) => {
+      const id = (
+        await this.prisma.userProfile.findUnique({
+          where: {
+            user_id: memberDto.user_id
+          },
+          select: {
+            id: true
+          }
+        })
+      ).id
+      return await this.prisma.userGroup.create({
+        data: {
+          user: {
+            connect: { id: id }
+          },
+          group: {
+            connect: { id: groupId }
+          },
+          is_group_manager: memberDto.is_group_manager
+        }
+      })
+    })
+
+    return Promise.all(members)
+  }
+
+  async getAdminManagers(groupId: number): Promise<Membership[]> {
+    return await this.prisma.userGroup.findMany({
+      where: {
+        group_id: groupId,
+        is_registered: true,
+        is_group_manager: true
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            username: true,
+            email: true,
+            UserProfile: {
+              select: {
+                user_id: true,
+                real_name: true
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+
+  async getAdminMembers(groupId: number, skip: number): Promise<Membership[]> {
+    return await this.prisma.userGroup.findMany({
+      where: {
+        group_id: groupId,
+        is_registered: true
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            username: true,
+            email: true,
+            UserProfile: {
+              select: {
+                user_id: true,
+                real_name: true
+              }
+            }
+          }
+        },
+        is_group_manager: true
+      },
+      skip: skip,
+      take: 10
+    })
+  }
+
+  async getAdminPendingMembers(
+    groupId: number,
+    skip: number
+  ): Promise<Membership[]> {
+    return await this.prisma.userGroup.findMany({
+      where: {
+        group_id: groupId,
+        is_registered: false
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            username: true,
+            email: true,
+            UserProfile: {
+              select: {
+                user_id: true,
+                real_name: true
+              }
+            }
+          }
+        }
+      },
+      skip: skip,
+      take: 10
+    })
+  }
+
+  async gradeMember(id: number, role: boolean): Promise<UserGroup> {
+    const currentRole = (
+      await this.prisma.userGroup.findUnique({
+        where: {
+          id: id
+        },
+        select: {
+          is_group_manager: true
+        },
+        rejectOnNotFound: () => new EntityNotExistException('membership')
+      })
+    ).is_group_manager
+
+    if (currentRole === role) {
+      if (role) throw new ActionNotAllowedException('upgrade', 'manager')
+      else throw new ActionNotAllowedException('downgrade', 'member')
+    }
+
+    return await this.prisma.userGroup.update({
+      where: {
+        id: id
+      },
+      data: {
+        is_group_manager: role
+      }
+    })
+  }
+
+  async registerMembers(ids: number[]): Promise<{ count: number }> {
+    return await this.prisma.userGroup.updateMany({
+      where: {
+        id: {
+          in: ids
+        }
+      },
+      data: {
+        is_registered: true
+      }
+    })
+  }
+
+  async deleteMember(id: number) {
+    await this.prisma.userGroup.findFirst({
+      where: {
+        id: id
+      },
+      rejectOnNotFound: () => new EntityNotExistException('membership')
+    })
+
+    await this.prisma.userGroup.delete({
+      where: {
+        id: id
+      }
+    })
   }
 }

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -212,9 +212,9 @@ export class GroupService {
   ): Promise<UserGroup[]> {
     const members = memberDtos.map(async (memberDto) => {
       const id = (
-        await this.prisma.userProfile.findUnique({
+        await this.prisma.user.findUnique({
           where: {
-            user_id: memberDto.user_id
+            student_id: memberDto.student_id
           },
           select: {
             id: true
@@ -249,10 +249,10 @@ export class GroupService {
         user: {
           select: {
             username: true,
+            student_id: true,
             email: true,
             UserProfile: {
               select: {
-                user_id: true,
                 real_name: true
               }
             }
@@ -273,10 +273,10 @@ export class GroupService {
         user: {
           select: {
             username: true,
+            student_id: true,
             email: true,
             UserProfile: {
               select: {
-                user_id: true,
                 real_name: true
               }
             }
@@ -303,10 +303,10 @@ export class GroupService {
         user: {
           select: {
             username: true,
+            student_id: true,
             email: true,
             UserProfile: {
               select: {
-                user_id: true,
                 real_name: true
               }
             }

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -8,7 +8,7 @@ import {
   EntityNotExistException
 } from 'src/common/exception/business.exception'
 import { AdminGroup } from './interface/admin-group.interface'
-import { Membership } from './interface/membership'
+import { Membership } from './interface/membership.interface'
 import { CreateMemberDto } from './dto/create-member.dto'
 
 // TODO: group id 확정 필요

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -213,33 +213,30 @@ export class GroupService {
     groupId: number,
     memberDtos: CreateMemberDto[]
   ): Promise<number[]> {
-    const members = []
     const failed = []
 
-    memberDtos.forEach(async (memberDto, i) => {
-      const member = await this.prisma.user.findUnique({
+    const members = memberDtos.map(async (dto, index) => {
+      const student = await this.prisma.user.findUnique({
         where: {
-          studentId: memberDto.studentId
+          studentId: dto.studentId
         },
         select: {
           id: true
         }
       })
-      if (member === null) failed.push(i)
+      if (student === null) failed.push(index)
       else {
-        members.push(
-          this.prisma.userGroup.create({
-            data: {
-              user: {
-                connect: { id: member.id }
-              },
-              group: {
-                connect: { id: groupId }
-              },
-              isGroupManager: memberDto.isGroupManager
-            }
-          })
-        )
+        return this.prisma.userGroup.create({
+          data: {
+            user: {
+              connect: { id: student.id }
+            },
+            group: {
+              connect: { id: groupId }
+            },
+            isGroupManager: dto.isGroupManager
+          }
+        })
       }
     })
     await Promise.all(members)

--- a/backend/src/group/interface/admin-group.interface.ts
+++ b/backend/src/group/interface/admin-group.interface.ts
@@ -1,0 +1,11 @@
+export interface AdminGroup {
+  id: number
+  group_name: string
+  private: boolean
+  invitation_code?: string
+  description: string
+  create_time?: Date
+  update_time?: Date
+  UserGroup: number
+  ManagerGroup?: string[]
+}

--- a/backend/src/group/interface/admin-group.interface.ts
+++ b/backend/src/group/interface/admin-group.interface.ts
@@ -6,6 +6,6 @@ export interface AdminGroup {
   description: string
   create_time?: Date
   update_time?: Date
-  UserGroup: number
-  ManagerGroup?: string[]
+  total_member: number
+  managers?: string[]
 }

--- a/backend/src/group/interface/admin-group.interface.ts
+++ b/backend/src/group/interface/admin-group.interface.ts
@@ -1,11 +1,11 @@
 export interface AdminGroup {
   id: number
-  group_name: string
+  groupName: string
   private: boolean
-  invitation_code?: string
+  invitationCode?: string
   description: string
-  create_time?: Date
-  update_time?: Date
-  total_member: number
+  createTime?: Date
+  updateTime?: Date
+  totalMember: number
   managers?: string[]
 }

--- a/backend/src/group/interface/membership.interface.ts
+++ b/backend/src/group/interface/membership.interface.ts
@@ -2,11 +2,11 @@ export interface Membership {
   id: number
   user: {
     username: string
-    student_id: string
+    studentId: string
     email: string
     UserProfile: {
-      real_name: string
+      realName: string
     }
   }
-  is_group_manager?: boolean
+  isGroupManager?: boolean
 }

--- a/backend/src/group/interface/membership.interface.ts
+++ b/backend/src/group/interface/membership.interface.ts
@@ -2,9 +2,9 @@ export interface Membership {
   id: number
   user: {
     username: string
+    student_id: string
     email: string
     UserProfile: {
-      user_id: number
       real_name: string
     }
   }

--- a/backend/src/group/interface/membership.ts
+++ b/backend/src/group/interface/membership.ts
@@ -1,0 +1,12 @@
+export interface Membership {
+  id: number
+  user: {
+    username: string
+    email: string
+    UserProfile: {
+      user_id: number
+      real_name: string
+    }
+  }
+  is_group_manager?: boolean
+}

--- a/backend/src/notice/notice.service.spec.ts
+++ b/backend/src/notice/notice.service.spec.ts
@@ -288,7 +288,7 @@ describe('NoticeService', () => {
     it('should return notice list of the group', async () => {
       const getUserGroupManagerListSpy = jest.spyOn(
         groupService,
-        'getUserGroupManagerList'
+        'getManagingGroupIds'
       )
       db.notice.findMany.mockResolvedValue(noticeArray)
 

--- a/backend/src/notice/notice.service.spec.ts
+++ b/backend/src/notice/notice.service.spec.ts
@@ -286,14 +286,14 @@ describe('NoticeService', () => {
     ]
 
     it('should return notice list of the group', async () => {
-      const getUserGroupManagerListSpy = jest.spyOn(
+      const getManagingGroupIdsSpy = jest.spyOn(
         groupService,
         'getManagingGroupIds'
       )
       db.notice.findMany.mockResolvedValue(noticeArray)
 
       const getNoticesByGroupId = await service.getAdminNotices(userId, 1)
-      expect(getUserGroupManagerListSpy).toBeCalledWith(userId)
+      expect(getManagingGroupIdsSpy).toBeCalledWith(userId)
       expect(getNoticesByGroupId).toEqual(noticeArray)
     })
   })

--- a/backend/src/notice/notice.service.ts
+++ b/backend/src/notice/notice.service.ts
@@ -112,7 +112,7 @@ export class NoticeService {
     userId: number,
     offset: number
   ): Promise<Partial<Notice>[]> {
-    const groupIds = await this.group.getUserGroupManagerList(userId)
+    const groupIds = await this.group.getManagingGroupIds(userId)
 
     return await this.prisma.notice.findMany({
       where: {

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -38,6 +38,7 @@ describe('UserService', () => {
     username: 'user',
     password: 'password',
     role: 'User',
+    studentId: null,
     email: EMAIL_ADDRESS,
     hasEmailAuthenticated: false,
     lastLogin: undefined,


### PR DESCRIPTION
### Description

> Resolves #170
- group CRUD API
- group member 관리(추가, 가입 승인/거부, 추방, manager로 변경)
- group manager 관리(추가, 추방, 일반 member로 변경)

### Additional context

- group 생성 시에는 argon2의 해시 함수를 활용하여 초대 코드가 자동으로 발급됩니다.
  + 이 정도로 긴 코드가 필요할까요?
- group manager 관리 권한은 group admin에게만 부여해야 하지 않을까요?
  + 목적: group manager여도 Role이 일반 user라면 group manager 관리가 불가능하도록
  + 이 경우 group guard 및 role 관련 api를 서비스단에서 사용할 수 있도록 추가 구현이 필요합니다.
- deprecated group id 확정이 필요합니다.
  + 실존하는 그룹이 아니라는 점에서 가능하다면 0번인 게 좋을 것 같은데, 어떻게 생각하시나요?

~~:checkered_flag:  테스트 코드는 현재 작성 중입니다.~~ 테스트 코드 작성 완료되었습니다.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
