### PR TITLE
fix(be): fix typo of cache port environment variable

### DIFF
--- a/backend/src/common/cache/cacheConfig.service.ts
+++ b/backend/src/common/cache/cacheConfig.service.ts
@@ -15,7 +15,7 @@ export class CacheConfigService implements CacheOptionsFactory {
       store: await redisStore({
         socket: {
           host: this.config.get('CACHE_DATABASE_URL'),
-          port: this.config.get('CACHE_DATABASE_R')
+          port: this.config.get('CACHE_DATABASE_PORT')
         }
       })
     }


### PR DESCRIPTION
### Description

GitPod 환경에서 redis에 연결이 되지 않는 문제를 해결합니다.
#278 에서 환경변수(`CACHE_DATABASE_PORT`) 이름에 생긴 오타를 수정합니다.

```
$ pnpm start

> backend@ start /workspace/codedang/backend
> nest start

[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [NestFactory] Starting Nest application...
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] MailerModule dependencies initialized +43ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] PassportModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] ConfigHostModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] ConfigModule dependencies initialized +1ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] ConfigModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] PrismaModule dependencies initialized +16ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] AppModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] JwtModule dependencies initialized +1ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] JwtModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] MailerCoreModule dependencies initialized +4ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] GroupModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] SubmissionModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] EmailModule dependencies initialized +1ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] NoticeModule dependencies initialized +1ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM     LOG [InstanceLoader] WorkbookModule dependencies initialized +0ms
[Nest] 3442  - 02/14/2023, 6:21:10 AM   ERROR [ExceptionHandler] connect ECONNREFUSED 127.0.0.1:6379
Error: connect ECONNREFUSED 127.0.0.1:6379
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16)
 ELIFECYCLE  Command failed with exit code 1.
```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
