### PR TITLE
fix(be): fix not working authentication

### DIFF
--- a/backend/src/auth/guard/jwt-auth.guard.ts
+++ b/backend/src/auth/guard/jwt-auth.guard.ts
@@ -2,7 +2,7 @@ import { ExecutionContext, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { AuthGuard } from '@nestjs/passport'
 import { Observable } from 'rxjs'
-import { IS_AUTH_NEEDED_KEY } from 'src/common/decorator/auth-ignore.decorator'
+import { IS_AUTH_NOT_NEEDED_KEY } from 'src/common/decorator/auth-ignore.decorator'
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -13,11 +13,11 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   canActivate(
     context: ExecutionContext
   ): boolean | Promise<boolean> | Observable<boolean> {
-    const isAuthNeeded = this.reflector.getAllAndOverride<boolean>(
-      IS_AUTH_NEEDED_KEY,
+    const isAuthNotNeeded = this.reflector.getAllAndOverride<boolean>(
+      IS_AUTH_NOT_NEEDED_KEY,
       [context.getHandler(), context.getClass()]
     )
-    if (!isAuthNeeded) {
+    if (isAuthNotNeeded) {
       return true
     }
     return super.canActivate(context)

--- a/backend/src/common/decorator/auth-ignore.decorator.ts
+++ b/backend/src/common/decorator/auth-ignore.decorator.ts
@@ -1,4 +1,4 @@
 import { SetMetadata } from '@nestjs/common'
 
-export const IS_AUTH_NEEDED_KEY = 'auth-not-needed'
-export const AuthNotNeeded = () => SetMetadata(IS_AUTH_NEEDED_KEY, false)
+export const IS_AUTH_NOT_NEEDED_KEY = 'auth-not-needed'
+export const AuthNotNeeded = () => SetMetadata(IS_AUTH_NOT_NEEDED_KEY, true)


### PR DESCRIPTION
### Description

Close #386 

`@AuthNotNeeded` decorator를 사용하지 않는 endpoint에서 authentication이 이루어지지 않습니다.

#367 에서 추가된 IS_AUTH_NEEDED_KEY의 metadata가 false로 변경되었는데, JwtAuthGuard에서 reflector가 반환하는 undefined와 false가 모두 negation 후 true를 반환합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
