### PR TITLE
feat(be): fix mocha config to give custom directory

### DIFF
--- a/backend/.mocharc.json
+++ b/backend/.mocharc.json
@@ -1,5 +1,4 @@
 {
-  "extension": "ts",
-  "spec": ["*/**/*.spec.ts"],
+  "extension": "spec.ts",
   "require": ["@swc/register", "mocha-fixture.ts"]
 }

--- a/backend/.mocharc.json
+++ b/backend/.mocharc.json
@@ -1,4 +1,5 @@
 {
   "extension": "spec.ts",
-  "require": ["@swc/register", "mocha-fixture.ts"]
+  "require": ["@swc/register", "mocha-fixture.ts"],
+  "reporter": "dot"
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "start:debug": "rimraf dist && nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "mocha",
+    "test": "mocha \"*/**/*.spec.ts\"",
     "test:watch": "mocha --watch"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

Closes #398 

mocha config 중 "spec" option이 CLI에서 준 custom directory를 override하여 적용되지 않는 문제가 있습니다.
예를 들어 config의 `"spec": ["*/**/*.spec.ts"]`을 적용하면, CLI에서 `mocha src/user/user.service.ts`를 실행해도 모든 파일(`*/**/*.spec.ts`)에 대해 test가 수행됩니다.

따라서 config의 spec option을 제거하고, package.json의 `"test"` script는 `mocha "*/**/*.spec.ts"`로 직접 경로를 지정합니다.

**결론: 앞으로는 `pnpm mocha src/user`처럼 경로 지정해서 테스트할 수 있습니다!**

### Additional context

간결한 mocha 출력을 위해 reporter를 변경하였습니다.
참고: https://mochajs.org/#reporters

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
