### PR TITLE
fix(be): fix throw inappropriate exception

### DIFF
--- a/backend/src/common/exception/business.exception.ts
+++ b/backend/src/common/exception/business.exception.ts
@@ -49,9 +49,3 @@ export class EmailTransmissionFailedException extends BusinessException {
     super(message)
   }
 }
-
-export class EntityAlreadyExistException extends BusinessException {
-  constructor(entity) {
-    super(`${entity} already exists`)
-  }
-}

--- a/backend/src/group/group.controller.ts
+++ b/backend/src/group/group.controller.ts
@@ -36,9 +36,6 @@ export class GroupController {
     try {
       return await this.groupService.getGroups(cursor, take)
     } catch (error) {
-      if (error instanceof EntityNotExistException) {
-        throw new NotFoundException(error.message)
-      }
       throw new InternalServerErrorException()
     }
   }
@@ -50,9 +47,6 @@ export class GroupController {
     try {
       return await this.groupService.getJoinedGroups(req.user.id)
     } catch (error) {
-      if (error instanceof EntityNotExistException) {
-        throw new NotFoundException(error.message)
-      }
       throw new InternalServerErrorException()
     }
   }

--- a/backend/src/group/group.controller.ts
+++ b/backend/src/group/group.controller.ts
@@ -108,9 +108,6 @@ export class GroupController {
     try {
       return await this.groupService.getGroupLeaders(groupId)
     } catch (error) {
-      if (error instanceof EntityNotExistException) {
-        throw new NotFoundException(error.message)
-      }
       throw new InternalServerErrorException()
     }
   }
@@ -123,9 +120,6 @@ export class GroupController {
     try {
       return await this.groupService.getGroupMembers(groupId)
     } catch (error) {
-      if (error instanceof EntityNotExistException) {
-        throw new NotFoundException(error.message)
-      }
       throw new InternalServerErrorException()
     }
   }

--- a/backend/src/group/group.controller.ts
+++ b/backend/src/group/group.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Delete,
@@ -16,7 +17,7 @@ import { UserGroup } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime'
 import { AuthenticatedRequest } from 'src/auth/interface/authenticated-request.interface'
 import {
-  EntityAlreadyExistException,
+  ActionNotAllowedException,
   EntityNotExistException
 } from 'src/common/exception/business.exception'
 import { GroupService } from './group.service'
@@ -82,8 +83,8 @@ export class GroupController {
     } catch (error) {
       if (error instanceof EntityNotExistException) {
         throw new NotFoundException(error.message)
-      } else if (error instanceof EntityAlreadyExistException) {
-        throw new NotFoundException(error.message)
+      } else if (error instanceof ActionNotAllowedException) {
+        throw new BadRequestException(error.message)
       }
       throw new InternalServerErrorException()
     }

--- a/backend/src/group/group.controller.ts
+++ b/backend/src/group/group.controller.ts
@@ -93,9 +93,6 @@ export class GroupController {
     try {
       return await this.groupService.leaveGroup(req.user.id, groupId)
     } catch (error) {
-      if (error instanceof PrismaClientKnownRequestError) {
-        throw new NotFoundException(error.message)
-      }
       throw new InternalServerErrorException()
     }
   }

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -270,26 +270,15 @@ export class GroupService {
   }
 
   async leaveGroup(userId: number, groupId: number): Promise<UserGroup> {
-    try {
-      const deletedUserGroup = await this.prisma.userGroup.delete({
-        where: {
-          userId_groupId: {
-            userId: userId,
-            groupId: groupId
-          }
+    const deletedUserGroup = await this.prisma.userGroup.delete({
+      where: {
+        userId_groupId: {
+          userId: userId,
+          groupId: groupId
         }
-      })
-      return deletedUserGroup
-    } catch (error) {
-      if (
-        error instanceof PrismaClientKnownRequestError &&
-        error.code === 'P2025'
-      ) {
-        throw new EntityNotExistException('userGroup')
-      } else {
-        throw error
       }
-    }
+    })
+    return deletedUserGroup
   }
 
   async getUserGroup(userId: number, groupId: number) {

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -239,7 +239,7 @@ export class GroupService {
         joinGroupCacheKey(userId, groupId)
       )
       if (joinGroupRequest) {
-        throw new ActionNotAllowedException('join request', 'group')
+        throw new ActionNotAllowedException('duplicated join request', 'group')
       }
 
       const userGroupValue = `user:${userId}:group:${groupId}`

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -1,8 +1,13 @@
 /* eslint-disable */
-import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  CACHE_MANAGER,
+  Inject,
+  Injectable
+} from '@nestjs/common'
 import { Group, UserGroup } from '@prisma/client'
 import {
-  EntityAlreadyExistException,
+  ActionNotAllowedException,
   EntityNotExistException
 } from 'src/common/exception/business.exception'
 import { PrismaService } from 'src/prisma/prisma.service'
@@ -12,7 +17,6 @@ import { JOIN_GROUP_REQUEST_EXPIRE_TIME } from '../common/constants'
 import { joinGroupCacheKey } from 'src/common/cache/keys'
 import { Cache } from 'cache-manager'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime'
-import { constants } from 'buffer'
 
 @Injectable()
 export class GroupService {
@@ -229,13 +233,13 @@ export class GroupService {
     )
 
     if (isJoined) {
-      throw new EntityAlreadyExistException('Group join record')
+      throw new ActionNotAllowedException('join request', 'group')
     } else if (group.config['requireApprovalBeforeJoin']) {
       const joinGroupRequest = await this.cacheManager.get(
         joinGroupCacheKey(userId, groupId)
       )
       if (joinGroupRequest) {
-        throw new EntityAlreadyExistException('Group join request')
+        throw new ActionNotAllowedException('join request', 'group')
       }
 
       const userGroupValue = `user:${userId}:group:${groupId}`

--- a/backend/src/group/group.service.ts
+++ b/backend/src/group/group.service.ts
@@ -224,7 +224,9 @@ export class GroupService {
       rejectOnNotFound: () => new EntityNotExistException('group')
     })
 
-    const isJoined = group.userGroup.includes({ userId: userId })
+    const isJoined = group.userGroup.some(
+      (joinedUser) => joinedUser.userId === userId
+    )
 
     if (isJoined) {
       throw new EntityAlreadyExistException('Group join record')


### PR DESCRIPTION
### Description

이미 가입된 그룹에 가입 요청을 보낼경우
**EntityAlreadyExistException('Group join record')** 말고
**InternalServerErrorException()** 예외를 던집니다.

joinGroupById 메소드 내에 이미 가입한 그룹인지 판단하는 부분에서 `Array.includes()` 메소드를 사용하는데,
이를 `Array.some()` 메소드로 변경합니다.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
