### PR TITLE
chore(be): add auth-not-needed decorator

### DIFF
--- a/backend/src/group/group.controller.ts
+++ b/backend/src/group/group.controller.ts
@@ -14,6 +14,7 @@ import {
 import { UserGroup } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime'
 import { AuthenticatedRequest } from 'src/auth/interface/authenticated-request.interface'
+import { AuthNotNeeded } from 'src/common/decorator/auth-ignore.decorator'
 import {
   EntityAlreadyExistException,
   EntityNotExistException
@@ -28,6 +29,7 @@ export class GroupController {
   constructor(private readonly groupService: GroupService) {}
 
   @Get()
+  @AuthNotNeeded()
   async getGroups(
     @Query('cursor', CursorValidationPipe) cursor: number,
     @Query('take', ParseIntPipe) take: number

--- a/backend/src/problem/problem.controller.ts
+++ b/backend/src/problem/problem.controller.ts
@@ -28,8 +28,8 @@ import {
   WorkbookProblemService
 } from './problem.service'
 
-@AuthNotNeeded()
 @Controller('problem')
+@AuthNotNeeded()
 export class PublicProblemController {
   constructor(private readonly problemService: ProblemService) {}
 
@@ -59,8 +59,8 @@ export class PublicProblemController {
   }
 }
 
-@AuthNotNeeded()
 @Controller('contest')
+@AuthNotNeeded()
 export class PublicContestProblemController {
   constructor(private readonly contestProblemService: ContestProblemService) {}
 
@@ -105,8 +105,8 @@ export class PublicContestProblemController {
   }
 }
 
-@AuthNotNeeded()
 @Controller('workbook')
+@AuthNotNeeded()
 export class PublicWorkbookProblemController {
   constructor(
     private readonly workbookProblemService: WorkbookProblemService
@@ -149,8 +149,8 @@ export class PublicWorkbookProblemController {
   }
 }
 
-@UseGuards(RolesGuard, GroupMemberGuard)
 @Controller('group')
+@UseGuards(RolesGuard, GroupMemberGuard)
 export class GroupContestProblemController {
   constructor(private readonly contestProblemService: ContestProblemService) {}
 


### PR DESCRIPTION
### Description

Group List GET API에 `@AuthNotNeeded` 데코레이터를 추가합니다.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
