### PR TITLE
fix(be): connect contestProblem to contestNotice

### DIFF
--- a/backend/prisma/migrations/20230305070328_modify_relation_problem_to_contest_problem_in_contest_notice/migration.sql
+++ b/backend/prisma/migrations/20230305070328_modify_relation_problem_to_contest_problem_in_contest_notice/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "contest_notice" DROP CONSTRAINT "contest_notice_problem_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "contest_notice" ADD CONSTRAINT "contest_notice_problem_id_contest_id_fkey" FOREIGN KEY ("problem_id", "contest_id") REFERENCES "contest_problem"("contest_id", "problem_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20230328110857_modify_relation_problem_to_contest_problem_in_contest_notice/migration.sql
+++ b/backend/prisma/migrations/20230328110857_modify_relation_problem_to_contest_problem_in_contest_notice/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "contest_notice" DROP CONSTRAINT "contest_notice_problem_id_contest_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "contest_notice" ADD CONSTRAINT "contest_notice_problem_id_contest_id_fkey" FOREIGN KEY ("problem_id", "contest_id") REFERENCES "contest_problem"("problem_id", "contest_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -214,15 +214,15 @@ model Contest {
 }
 
 model ContestNotice {
-  id             Int            @id @default(autoincrement())
-  contest        Contest        @relation(fields: [contestId], references: [id])
-  contestId      Int            @map("contest_id")
-  title          String
-  description    String
-  contestProblem ContestProblem @relation(fields: [problemId, contestId], references: [contestId, problemId])
-  problemId      Int            @map("problem_id")
-  createTime     DateTime       @default(now()) @map("create_time")
-  updateTime     DateTime       @updatedAt @map("update_time")
+  id          Int            @id @default(autoincrement())
+  contest     Contest        @relation(fields: [contestId], references: [id])
+  contestId   Int            @map("contest_id")
+  title       String
+  description String
+  problem     ContestProblem @relation(fields: [problemId, contestId], references: [contestId, problemId])
+  problemId   Int            @map("problem_id")
+  createTime  DateTime       @default(now()) @map("create_time")
+  updateTime  DateTime       @updatedAt @map("update_time")
 
   @@map("contest_notice")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -219,7 +219,7 @@ model ContestNotice {
   contestId   Int            @map("contest_id")
   title       String
   description String
-  problem     ContestProblem @relation(fields: [problemId, contestId], references: [contestId, problemId])
+  problem     ContestProblem @relation(fields: [problemId, contestId], references: [problemId, contestId])
   problemId   Int            @map("problem_id")
   createTime  DateTime       @default(now()) @map("create_time")
   updateTime  DateTime       @updatedAt @map("update_time")

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -133,7 +133,6 @@ model Problem {
   contestProblem  ContestProblem[]
   workbookProblem WorkbookProblem[]
   submission      Submission[]
-  contestNotice   ContestNotice[]
 
   @@map("problem")
 }
@@ -215,15 +214,15 @@ model Contest {
 }
 
 model ContestNotice {
-  id          Int      @id @default(autoincrement())
-  contest     Contest  @relation(fields: [contestId], references: [id])
-  contestId   Int      @map("contest_id")
-  title       String
-  description String
-  problem     Problem  @relation(fields: [problemId], references: [id])
-  problemId   Int      @map("problem_id")
-  createTime  DateTime @default(now()) @map("create_time")
-  updateTime  DateTime @updatedAt @map("update_time")
+  id             Int            @id @default(autoincrement())
+  contest        Contest        @relation(fields: [contestId], references: [id])
+  contestId      Int            @map("contest_id")
+  title          String
+  description    String
+  contestProblem ContestProblem @relation(fields: [problemId, contestId], references: [contestId, problemId])
+  problemId      Int            @map("problem_id")
+  createTime     DateTime       @default(now()) @map("create_time")
+  updateTime     DateTime       @updatedAt @map("update_time")
 
   @@map("contest_notice")
 }
@@ -237,6 +236,8 @@ model ContestProblem {
   score      Int      @default(0)
   createTime DateTime @default(now()) @map("create_time")
   updateTime DateTime @updatedAt @map("update_time")
+
+  contestNotice ContestNotice[]
 
   @@id([contestId, problemId])
   @@unique([contestId, id])

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -6355,16 +6355,6 @@ const createContests = async () => {
     }
   })
 
-  // add contest notice
-  await prisma.contestNotice.create({
-    data: {
-      title: '1번 문제 수정 안내',
-      description: '<p>1번 문제가 blah blah 수정되었습니다.</p>',
-      contestId: contest.id,
-      problemId: problems[0].id
-    }
-  })
-
   // add problems to contest
   for (const problem of problems) {
     await prisma.contestProblem.create({
@@ -6375,6 +6365,16 @@ const createContests = async () => {
       }
     })
   }
+
+  // add contest notice
+  await prisma.contestNotice.create({
+    data: {
+      title: '1번 문제 수정 안내',
+      description: '<p>1번 문제가 blah blah 수정되었습니다.</p>',
+      contestId: contest.id,
+      problemId: problems[0].id
+    }
+  })
 
   // TODO: add records and ranks
 }


### PR DESCRIPTION
### Description

현재 `ContestNotice`에는 `Problem`이 참조돼있습니다.
`Problem`이 아닌 `ContestProblem`을 참조하도록 수정하였습니다.

### Additional context

간단하게 `contest_id`와 `problem_id`를 FK로 사용하였습니다.
다른 방법이 있다면 제안 부탁드립니다.
감사합니다.

Closes #434 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
