### PR TITLE
fix(be): modify joined group api response to include group leader info

### DIFF
--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -5,7 +5,8 @@ import {
   groups,
   userGroups,
   publicGroupDatas,
-  mockGroupData
+  mockGroupData,
+  userGroupsForJoinedGroups
 } from './mock/group.mock'
 import { stub } from 'sinon'
 import { PrismaService } from '@libs/prisma'
@@ -142,13 +143,9 @@ describe('GroupService', () => {
       //given
       const userId = 1
       db.userGroup.findMany.resolves(
-        userGroups
-          .filter(
-            (userGroup) => userGroup.userId == userId && userGroup.groupId !== 1
-          )
-          .map((userGroup) => {
-            return { groupId: userGroup.groupId }
-          })
+        userGroupsForJoinedGroups.filter(
+          (userGroup) => userGroup.userId == userId && userGroup.groupId !== 1
+        )
       )
       db.group.findMany.resolves([mockGroupData])
 
@@ -156,7 +153,9 @@ describe('GroupService', () => {
       const result = await service.getJoinedGroups(userId)
 
       //then
-      expect(result).to.deep.equal([publicGroupDatas[1]])
+      expect(result).to.deep.equal([
+        { ...publicGroupDatas[1], isGroupLeader: true }
+      ])
     })
   })
 

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -154,7 +154,7 @@ export class GroupService {
   }
 
   async getJoinedGroups(userId: number): Promise<GroupData[]> {
-    const groupIds = (
+    return (
       await this.prisma.userGroup.findMany({
         where: {
           NOT: {
@@ -163,41 +163,32 @@ export class GroupService {
           userId: userId
         },
         select: {
-          groupId: true
-        }
-      })
-    ).map((group) => group.groupId)
-
-    const groups = (
-      await this.prisma.group.findMany({
-        where: {
-          id: {
-            in: groupIds
-          }
-        },
-        select: {
-          createdBy: {
+          group: {
             select: {
-              username: true
+              createdBy: {
+                select: {
+                  username: true
+                }
+              },
+              id: true,
+              groupName: true,
+              description: true,
+              userGroup: true
             }
           },
-          id: true,
-          groupName: true,
-          description: true,
-          userGroup: true
+          isGroupLeader: true
         }
       })
-    ).map((group) => {
+    ).map((userGroup) => {
       return {
-        id: group.id,
-        groupName: group.groupName,
-        description: group.description,
-        createdBy: group.createdBy.username,
-        memberNum: group.userGroup.length
+        id: userGroup.group.id,
+        groupName: userGroup.group.groupName,
+        description: userGroup.group.description,
+        memberNum: userGroup.group.userGroup.length,
+        createdBy: userGroup.group.createdBy.username,
+        isGroupLeader: userGroup.isGroupLeader
       }
     })
-
-    return groups
   }
 
   async joinGroupById(

--- a/backend/apps/client/src/group/interface/group-data.interface.ts
+++ b/backend/apps/client/src/group/interface/group-data.interface.ts
@@ -5,4 +5,5 @@ export interface GroupData {
   memberNum: number
   createdBy: string
   leaders?: string[]
+  isGroupLeader?: boolean
 }

--- a/backend/apps/client/src/group/mock/group.mock.ts
+++ b/backend/apps/client/src/group/mock/group.mock.ts
@@ -123,6 +123,41 @@ export const userGroups: UserGroup[] = [
   }
 ]
 
+export const userGroupsForJoinedGroups = [
+  {
+    ...userGroups[0],
+    group: {
+      ...groups[0],
+      createdBy: users[0],
+      userGroup: userGroups.slice(0, 2)
+    }
+  },
+  {
+    ...userGroups[1],
+    group: {
+      ...groups[0],
+      createdBy: users[0],
+      userGroup: userGroups.slice(0, 2)
+    }
+  },
+  {
+    ...userGroups[2],
+    group: {
+      ...groups[1],
+      createdBy: users[0],
+      userGroup: userGroups.slice(2)
+    }
+  },
+  {
+    ...userGroups[3],
+    group: {
+      ...groups[1],
+      createdBy: users[0],
+      userGroup: userGroups.slice(2)
+    }
+  }
+]
+
 export const publicGroupDatas: GroupData[] = [
   {
     id: 1,

--- a/thunder-tests/thunderclient.json
+++ b/thunder-tests/thunderclient.json
@@ -3515,7 +3515,7 @@
     "method": "GET",
     "sortNum": 580000,
     "created": "2023-02-21T06:36:54.399Z",
-    "modified": "2023-04-28T12:21:43.540Z",
+    "modified": "2023-06-24T09:02:30.579Z",
     "headers": [],
     "params": [],
     "tests": [
@@ -3526,17 +3526,47 @@
         "value": "200"
       },
       {
-        "type": "json-query",
-        "custom": "json | filter(id>1)",
-        "action": "count",
-        "value": "2"
+        "type": "res-body",
+        "custom": "",
+        "action": "contains",
+        "value": "id"
+      },
+      {
+        "type": "res-body",
+        "custom": "",
+        "action": "contains",
+        "value": "groupName"
+      },
+      {
+        "type": "res-body",
+        "custom": "",
+        "action": "contains",
+        "value": "description"
+      },
+      {
+        "type": "res-body",
+        "custom": "",
+        "action": "contains",
+        "value": "createdBy"
+      },
+      {
+        "type": "res-body",
+        "custom": "",
+        "action": "contains",
+        "value": "memberNum"
+      },
+      {
+        "type": "res-body",
+        "custom": "",
+        "action": "contains",
+        "value": "isGroupLeader"
       }
     ],
-    "docs": "# Get joined groups\n\n### URL\nGET /group/joined <br><br>\n\n### Description\n가입한 그룹의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   createdBy: String\n   memberNum: Number\n} []\n```",
+    "docs": "# Get joined groups\n\n### URL\nGET /group/joined <br><br>\n\n### Description\n가입한 그룹의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   memberNum: Number\n   createdBy: String\n   isGroupLeader: Boolean\n} []\n```",
     "preReq": {
       "runRequests": [
         {
-          "reqId": "9dffba42-be8a-48c1-8243-e327ce99589b",
+          "reqId": "de1639a5-d9da-4397-8a13-ae1fc61b849b",
           "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
           "triggerCondition": "run-always",
           "triggerValue": ""


### PR DESCRIPTION
### Description

Closes #532
Joined Group GET API에서 각 그룹에 대한 사용자의 `isGroupLeader` 여부 정보를 포함하도록 코드를 수정합니다.  

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
