### PR TITLE
fix(fe): connect API to contest main page

### DIFF
--- a/frontend/src/user/contest/pages/index.vue
+++ b/frontend/src/user/contest/pages/index.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import PageSubtitle from '@/common/components/Atom/PageSubtitle.vue'
 import CardItem from '@/common/components/Molecule/CardItem.vue'
+import { useAuthStore } from '@/common/store/auth'
 import { useTimeAgo } from '@vueuse/core'
 import axios from 'axios'
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 import IconAnglesRight from '~icons/fa6-solid/angles-right'
 import IconCaretDown from '~icons/fa6-solid/caret-down'
 import IconCaretUp from '~icons/fa6-solid/caret-up'
@@ -28,10 +29,27 @@ const items = ref<{ [key: string]: Contest[] }>({
   finished: []
 })
 
-onMounted(async () => {
-  const response = await axios.get('/api/contest')
-  items.value = response.data
+const auth = useAuthStore()
+
+if (auth.isLoggedIn) {
+  axios.get('/api/contest/auth').then((res) => {
+    items.value.ongoing = [...res.data.ongoing, ...res.data.registeredOngoing]
+    items.value.upcoming = [
+      ...res.data.upcoming,
+      ...res.data.registeredUpcoming
+    ]
+  })
+} else {
+  axios.get('/api/contest').then((res) => {
+    items.value.ongoing = res.data.ongoing
+    items.value.upcoming = res.data.upcoming
+  })
+}
+
+axios.get('/api/contest/finished', { params: { take: 10 } }).then((res) => {
+  items.value.finished = res.data.finished
 })
+
 const coloredText = (id: string, item: Contest) => {
   if (id === 'ongoing') return 'Started ' + useTimeAgo(item.startTime).value
   else if (id === 'upcoming') return 'Start ' + useTimeAgo(item.startTime).value


### PR DESCRIPTION
### Description

contest main page에 upcoming, ongoing, finished contest들이 보이도록 API를 연결 했으며 로그인 상태에 따라 다른 API를 연결해서 자신이 속한 그룹의 contests도 보이도록 했다.

추후에 finished 쪽에는 pagination component를 추가해야 될 것 같고 finished contests 같은 경우에는 auth 옵션이 없어서 일단 생략했다.

Close #524 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
