### PR TITLE
feat: change pagination logic

### DIFF
--- a/frontend/histoire.config.ts
+++ b/frontend/histoire.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   setupFile: '/src/histoire.setup.ts',
   theme: {
     title: 'SKKUding Histoire'
-  }
+  },
+  viteIgnorePlugins: ['vite-plugin-checker']
 })

--- a/frontend/src/common/components/Molecule/Pagination.story.vue
+++ b/frontend/src/common/components/Molecule/Pagination.story.vue
@@ -7,14 +7,25 @@ const currentPage = ref(1)
 
 <template>
   <Story>
-    <Variant>
+    <Variant title="light">
       <template #default>
-        <Pagination v-model="currentPage" :number-of-pages="10" />
+        <Pagination v-model="currentPage" :number-of-pages="10" mode="light" />
       </template>
       <!-- [workaround] use `source` slot to show v-model -->
       <template #source>
         <textarea v-pre>
           <Pagination v-model="currentPage" :number-of-pages="10" />
+        </textarea>
+      </template>
+    </Variant>
+    <Variant title="dark">
+      <template #default>
+        <Pagination v-model="currentPage" :number-of-pages="10" mode="dark" />
+      </template>
+      <!-- [workaround] use `source` slot to show v-model -->
+      <template #source>
+        <textarea v-pre>
+          <Pagination v-model="currentPage" :number-of-pages="10" mode="dark" />
         </textarea>
       </template>
     </Variant>

--- a/frontend/src/common/components/Molecule/Pagination.story.vue
+++ b/frontend/src/common/components/Molecule/Pagination.story.vue
@@ -9,23 +9,23 @@ const currentPage = ref(1)
   <Story>
     <Variant title="light">
       <template #default>
-        <Pagination v-model="currentPage" :number-of-pages="10" mode="light" />
+        <Pagination v-model="currentPage" :number-of-pages="19" mode="light" />
       </template>
       <!-- [workaround] use `source` slot to show v-model -->
       <template #source>
         <textarea v-pre>
-          <Pagination v-model="currentPage" :number-of-pages="10" />
+          <Pagination v-model="currentPage" :number-of-pages="19" />
         </textarea>
       </template>
     </Variant>
     <Variant title="dark">
       <template #default>
-        <Pagination v-model="currentPage" :number-of-pages="10" mode="dark" />
+        <Pagination v-model="currentPage" :number-of-pages="19" mode="dark" />
       </template>
       <!-- [workaround] use `source` slot to show v-model -->
       <template #source>
         <textarea v-pre>
-          <Pagination v-model="currentPage" :number-of-pages="10" mode="dark" />
+          <Pagination v-model="currentPage" :number-of-pages="19" mode="dark" />
         </textarea>
       </template>
     </Variant>

--- a/frontend/src/common/components/Molecule/Pagination.vue
+++ b/frontend/src/common/components/Molecule/Pagination.vue
@@ -1,35 +1,45 @@
 <script setup lang="ts">
+import { useDark } from '@vueuse/core'
 import { useClamp } from '@vueuse/math'
-import { watch } from 'vue'
+import { toRefs, watch } from 'vue'
 import IconAngleLeft from '~icons/fa6-solid/angle-left'
 import IconAngleRight from '~icons/fa6-solid/angle-right'
 import IconEllipsis from '~icons/fa6-solid/ellipsis'
 import Button from '../Atom/Button.vue'
 
-const props = defineProps<{
-  numberOfPages: number
-  modelValue: number
-  mode?: 'light' | 'dark'
-}>()
+const props = withDefaults(
+  defineProps<{
+    numberOfPages: number
+    modelValue: number
+    mode: 'light' | 'dark'
+  }>(),
+  { mode: 'light' }
+)
+
+const { numberOfPages, modelValue, mode } = toRefs(props)
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: number): void
 }>()
 
-const currentPage = useClamp(props.modelValue, 1, props.numberOfPages)
+const currentPage = useClamp(modelValue.value, 1, numberOfPages)
+
+const dark = useDark()
 watch(
-  () => props.modelValue,
-  (modelValue) => (currentPage.value = modelValue)
+  mode,
+  (mode) => {
+    dark.value = mode === 'dark'
+  },
+  { immediate: true }
 )
 
 const currentPageColor = (page: number) => {
-  if (!props.mode || props.mode === 'light')
-    return currentPage.value === page ? 'gray-dark' : 'gray'
-  else return currentPage.value === page ? 'gray' : 'indigo'
+  if (dark.value) return currentPage.value === page ? 'gray' : 'indigo'
+  return currentPage.value === page ? 'gray-dark' : 'gray'
 }
 
-watch(currentPage, (value) => {
-  emit('update:modelValue', value)
+watch(currentPage, () => {
+  emit('update:modelValue', currentPage.value)
 })
 </script>
 
@@ -37,7 +47,7 @@ watch(currentPage, (value) => {
   <div class="flex flex-row gap-1">
     <Button
       outline
-      :color="!mode || mode === 'light' ? 'gray-dark' : 'white'"
+      :color="dark ? 'white' : 'gray-dark'"
       :class="{ 'pointer-events-none': currentPage === 1 }"
       class="aspect-square rounded-lg"
       @click="currentPage--"
@@ -67,7 +77,7 @@ watch(currentPage, (value) => {
     <div
       v-if="currentPage > 3 && numberOfPages > 4"
       class="p-2"
-      :class="!mode || mode === 'light' ? 'text-gray-dark' : 'text-white'"
+      :class="dark ? 'text-white' : 'text-gray-dark'"
     >
       <IconEllipsis />
     </div>
@@ -101,7 +111,7 @@ watch(currentPage, (value) => {
     <div
       v-if="currentPage < numberOfPages - 2 && numberOfPages > 4"
       class="p-2"
-      :class="!mode || mode === 'light' ? 'text-gray-dark' : 'text-white'"
+      :class="dark ? 'text-white' : 'text-gray-dark'"
     >
       <IconEllipsis />
     </div>
@@ -128,7 +138,7 @@ watch(currentPage, (value) => {
 
     <Button
       outline
-      :color="!mode || mode === 'light' ? 'gray-dark' : 'white'"
+      :color="dark ? 'white' : 'gray-dark'"
       :class="{ 'pointer-events-none': currentPage === numberOfPages }"
       class="aspect-square rounded-lg"
       @click="currentPage++"

--- a/frontend/src/common/components/Molecule/Pagination.vue
+++ b/frontend/src/common/components/Molecule/Pagination.vue
@@ -1,22 +1,22 @@
 <script setup lang="ts">
 import { useDark } from '@vueuse/core'
 import { useClamp } from '@vueuse/math'
-import { toRefs, watch } from 'vue'
+import { computed, toRefs, watch } from 'vue'
 import IconAngleLeft from '~icons/fa6-solid/angle-left'
 import IconAngleRight from '~icons/fa6-solid/angle-right'
-import IconEllipsis from '~icons/fa6-solid/ellipsis'
 import Button from '../Atom/Button.vue'
 
 const props = withDefaults(
   defineProps<{
     numberOfPages: number
+    pageSlot?: number
     modelValue: number
     mode: 'light' | 'dark'
   }>(),
-  { mode: 'light' }
+  { pageSlot: 5, mode: 'light' }
 )
 
-const { numberOfPages, modelValue, mode } = toRefs(props)
+const { numberOfPages, pageSlot, modelValue, mode } = toRefs(props)
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: number): void
@@ -38,7 +38,26 @@ const currentPageColor = (page: number) => {
   return currentPage.value === page ? 'gray-dark' : 'gray'
 }
 
+const start = computed(
+  () => currentPage.value - ((currentPage.value - 1) % pageSlot.value)
+)
+
+const end = computed(() =>
+  Math.min(numberOfPages.value, start.value + pageSlot.value - 1)
+)
+
+const shownPages = computed(() => {
+  const pages = []
+  for (let i = start.value; i <= end.value; i++) {
+    pages.push(i)
+  }
+  return pages
+})
+
 watch(currentPage, () => {
+  console.log('currentPage', currentPage.value)
+  console.log('start', start.value)
+  console.log('end', end.value)
   emit('update:modelValue', currentPage.value)
 })
 </script>
@@ -48,100 +67,31 @@ watch(currentPage, () => {
     <Button
       outline
       :color="dark ? 'white' : 'gray-dark'"
+      :disabled="start === 1"
       :class="{ 'pointer-events-none': currentPage === 1 }"
       class="aspect-square rounded-lg"
-      @click="currentPage--"
+      @click="currentPage = start - 1"
     >
       <IconAngleLeft />
     </Button>
 
     <Button
-      :color="currentPageColor(1)"
-      :class="{ 'pointer-events-none': currentPage === 1 }"
+      v-for="page in shownPages"
+      :key="page"
+      :color="currentPageColor(page)"
       class="aspect-square w-9 rounded-lg"
-      @click="currentPage = 1"
+      @click="currentPage = page"
     >
-      1
-    </Button>
-
-    <!-- edge case workaround -->
-    <Button
-      v-if="currentPage === 4 && numberOfPages === 4"
-      :color="currentPageColor(2)"
-      class="aspect-square w-9 rounded-lg"
-      @click="currentPage = 2"
-    >
-      2
-    </Button>
-
-    <div
-      v-if="currentPage > 3 && numberOfPages > 4"
-      class="p-2"
-      :class="dark ? 'text-white' : 'text-gray-dark'"
-    >
-      <IconEllipsis />
-    </div>
-
-    <Button
-      v-if="currentPage > 2"
-      :color="currentPageColor(currentPage - 1)"
-      class="aspect-square w-9 rounded-lg"
-      @click="currentPage--"
-    >
-      {{ currentPage - 1 }}
-    </Button>
-
-    <Button
-      v-if="![1, numberOfPages].includes(currentPage)"
-      :color="currentPageColor(currentPage)"
-      class="pointer-events-none aspect-square w-9 rounded-lg"
-    >
-      {{ currentPage }}
-    </Button>
-
-    <Button
-      v-if="currentPage + 1 < numberOfPages"
-      :color="currentPageColor(currentPage + 1)"
-      class="aspect-square w-9 rounded-lg"
-      @click="currentPage++"
-    >
-      {{ currentPage + 1 }}
-    </Button>
-
-    <div
-      v-if="currentPage < numberOfPages - 2 && numberOfPages > 4"
-      class="p-2"
-      :class="dark ? 'text-white' : 'text-gray-dark'"
-    >
-      <IconEllipsis />
-    </div>
-
-    <!-- edge case workaround -->
-    <Button
-      v-if="currentPage === 1 && numberOfPages === 4"
-      :color="currentPageColor(3)"
-      class="aspect-square w-9 rounded-lg"
-      @click="currentPage = 3"
-    >
-      3
-    </Button>
-
-    <Button
-      v-if="numberOfPages > 1"
-      :color="currentPageColor(numberOfPages)"
-      :class="{ 'pointer-events-none': currentPage === numberOfPages }"
-      class="aspect-square w-9 rounded-lg"
-      @click="currentPage = numberOfPages"
-    >
-      {{ numberOfPages }}
+      {{ page }}
     </Button>
 
     <Button
       outline
       :color="dark ? 'white' : 'gray-dark'"
+      :disabled="end === numberOfPages"
       :class="{ 'pointer-events-none': currentPage === numberOfPages }"
       class="aspect-square rounded-lg"
-      @click="currentPage++"
+      @click="currentPage = end + 1"
     >
       <IconAngleRight />
     </Button>


### PR DESCRIPTION
### Description

Close #529 

한 번에 n개의 페이지만 보여주고, 양 끝 페이지는 보여주지 않도록 바꿉니다.

![chrome-capture-2023-5-27](https://github.com/skkuding/codedang/assets/19747913/463a6112-4ce0-402b-aeec-528442145264)

props로 `pageSlot`을 전달해 리스트에 몇 개의 페이지를 보여줄지 정합니다. (default: 5)

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
