### PR TITLE
feat(be): add admin group crud apis

### DIFF
--- a/backend/apps/admin/src/admin.module.ts
+++ b/backend/apps/admin/src/admin.module.ts
@@ -7,7 +7,7 @@ import {
   JwtAuthModule,
   JwtAuthGuard,
   RolesModule,
-  RolesGuard
+  GroupLeaderGuard
 } from '@libs/auth'
 import { PrismaModule } from '@libs/prisma'
 import { AdminController } from './admin.controller'
@@ -33,7 +33,7 @@ import { UserModule } from './user/user.module'
   providers: [
     AdminService,
     { provide: APP_GUARD, useClass: JwtAuthGuard },
-    { provide: APP_GUARD, useClass: RolesGuard }
+    { provide: APP_GUARD, useClass: GroupLeaderGuard }
   ]
 })
 export class AdminModule {}

--- a/backend/apps/admin/src/admin.module.ts
+++ b/backend/apps/admin/src/admin.module.ts
@@ -12,6 +12,8 @@ import {
 import { PrismaModule } from '@libs/prisma'
 import { AdminController } from './admin.controller'
 import { AdminService } from './admin.service'
+import { GroupModule } from './group/group.module'
+import { RolesGuard } from './user/guard/roles.guard'
 import { UserModule } from './user/user.module'
 
 @Module({
@@ -25,7 +27,9 @@ import { UserModule } from './user/user.module'
     JwtAuthModule,
     RolesModule,
     UserModule,
-    PrismaModule
+    PrismaModule,
+    AuthModule,
+    GroupModule
   ],
   controllers: [AdminController],
   providers: [

--- a/backend/apps/admin/src/admin.module.ts
+++ b/backend/apps/admin/src/admin.module.ts
@@ -13,7 +13,6 @@ import { PrismaModule } from '@libs/prisma'
 import { AdminController } from './admin.controller'
 import { AdminService } from './admin.service'
 import { GroupModule } from './group/group.module'
-import { RolesGuard } from './user/guard/roles.guard'
 import { UserModule } from './user/user.module'
 
 @Module({
@@ -28,7 +27,6 @@ import { UserModule } from './user/user.module'
     RolesModule,
     UserModule,
     PrismaModule,
-    AuthModule,
     GroupModule
   ],
   controllers: [AdminController],

--- a/backend/apps/admin/src/group/group.module.ts
+++ b/backend/apps/admin/src/group/group.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common'
 import { RolesModule } from '@libs/auth'
-import { UserModule } from '@admin/user/user.module'
 import { GroupResolver } from './group.resolver'
 import { GroupService } from './group.service'
 
 @Module({
-  imports: [RolesModule, UserModule],
+  imports: [RolesModule],
   providers: [GroupResolver, GroupService]
 })
 export class GroupModule {}

--- a/backend/apps/admin/src/group/group.module.ts
+++ b/backend/apps/admin/src/group/group.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common'
+import { RolesModule } from '@libs/auth'
+import { UserModule } from '@admin/user/user.module'
 import { GroupResolver } from './group.resolver'
 import { GroupService } from './group.service'
 
 @Module({
+  imports: [RolesModule, UserModule],
   providers: [GroupResolver, GroupService]
 })
 export class GroupModule {}

--- a/backend/apps/admin/src/group/group.module.ts
+++ b/backend/apps/admin/src/group/group.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { GroupResolver } from './group.resolver'
+import { GroupService } from './group.service'
+
+@Module({
+  providers: [GroupResolver, GroupService]
+})
+export class GroupModule {}

--- a/backend/apps/admin/src/group/group.resolver.spec.ts
+++ b/backend/apps/admin/src/group/group.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, type TestingModule } from '@nestjs/testing'
+import { expect } from 'chai'
+import { GroupResolver } from './group.resolver'
+
+describe('GroupResolver', () => {
+  let resolver: GroupResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupResolver]
+    }).compile()
+
+    resolver = module.get<GroupResolver>(GroupResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).to.be.ok
+  })
+})

--- a/backend/apps/admin/src/group/group.resolver.spec.ts
+++ b/backend/apps/admin/src/group/group.resolver.spec.ts
@@ -1,13 +1,19 @@
 import { Test, type TestingModule } from '@nestjs/testing'
 import { expect } from 'chai'
+import { RolesService } from '@libs/auth'
 import { GroupResolver } from './group.resolver'
+import { GroupService } from './group.service'
 
 describe('GroupResolver', () => {
   let resolver: GroupResolver
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GroupResolver]
+      providers: [
+        GroupResolver,
+        { provide: GroupService, useValue: {} },
+        { provide: RolesService, useValue: {} }
+      ]
     }).compile()
 
     resolver = module.get<GroupResolver>(GroupResolver)

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -67,6 +67,8 @@ export class GroupResolver {
     } catch (error) {
       if (error instanceof UnprocessableDataException) {
         throw new UnprocessableEntityException(error.message)
+      } else if (error instanceof ForbiddenAccessException) {
+        throw new ForbiddenException(error.message)
       }
       throw new InternalServerErrorException()
     }
@@ -80,9 +82,7 @@ export class GroupResolver {
     try {
       return await this.groupService.deleteGroup(id, req.user)
     } catch (error) {
-      if (error instanceof UnprocessableDataException) {
-        throw new UnprocessableEntityException(error.message)
-      } else if (error instanceof ForbiddenAccessException) {
+      if (error instanceof ForbiddenAccessException) {
         throw new ForbiddenException(error.message)
       }
       throw new InternalServerErrorException()

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -1,4 +1,63 @@
-import { Resolver } from '@nestjs/graphql'
+import {
+  ForbiddenException,
+  InternalServerErrorException,
+  UseGuards
+} from '@nestjs/common'
+import { Args, Int, Query, Mutation, Resolver, Context } from '@nestjs/graphql'
+import { Role } from '@prisma/client'
+import { AuthenticatedRequest, RolesGuard, UseRolesGuard } from '@libs/auth'
+import { ForbiddenAccessException } from '@libs/exception'
+import { Group } from '@admin/@generated/group/group.model'
+import { GroupService } from './group.service'
+import { CreateGroupInput, UpdateGroupInput } from './model/group.input'
+import { FindGroup, FindManyGroup } from './model/group.output'
 
-@Resolver()
-export class GroupResolver {}
+@Resolver(() => Group)
+export class GroupResolver {
+  constructor(private readonly groupService: GroupService) {}
+
+  @Mutation(() => Group)
+  @UseRolesGuard(Role.Manager)
+  async createGroup(
+    @Context('req') req: AuthenticatedRequest,
+    @Args('input') input: CreateGroupInput
+  ): Promise<Group> {
+    return await this.groupService.createGroup(input, req.user.id)
+  }
+
+  @Query(() => [FindManyGroup])
+  @UseGuards(RolesGuard)
+  async getGroups(): Promise<Partial<FindManyGroup>[]> {
+    return await this.groupService.getGroups()
+  }
+
+  @Query(() => FindGroup)
+  async getGroup(
+    @Args('groupId', { type: () => Int }) id: number
+  ): Promise<FindGroup> {
+    return await this.groupService.getGroup(id)
+  }
+
+  @Mutation(() => Group)
+  async updateGroup(
+    @Args('groupId', { type: () => Int }) id: number,
+    @Args('input') input: UpdateGroupInput
+  ): Promise<Group> {
+    return await this.groupService.updateGroup(id, input)
+  }
+
+  @Mutation(() => String)
+  async deleteGroup(
+    @Context('req') req: AuthenticatedRequest,
+    @Args('groupId', { type: () => Int }) id: number
+  ) {
+    try {
+      return await this.groupService.deleteGroup(id, req.user)
+    } catch (error) {
+      if (error instanceof ForbiddenAccessException) {
+        throw new ForbiddenException(error.message)
+      }
+      throw new InternalServerErrorException()
+    }
+  }
+}

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -1,0 +1,4 @@
+import { Resolver } from '@nestjs/graphql'
+
+@Resolver()
+export class GroupResolver {}

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -44,7 +44,7 @@ export class GroupResolver {
   @Query(() => [FindManyGroup])
   @UseGuards(RolesGuard)
   async getGroups(
-    @Args('cursor', CursorValidationPipe) cursor: number,
+    @Args('cursor', { nullable: true }, CursorValidationPipe) cursor: number,
     @Args('take', { type: () => Int }) take: number
   ): Promise<Partial<FindManyGroup>[]> {
     return await this.groupService.getGroups(cursor, take)

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -11,6 +11,7 @@ import {
   ForbiddenAccessException,
   UnprocessableDataException
 } from '@libs/exception'
+import { CursorValidationPipe } from '@libs/pipe'
 import { Group } from '@admin/@generated/group/group.model'
 import { GroupService } from './group.service'
 import { CreateGroupInput, UpdateGroupInput } from './model/group.input'
@@ -42,8 +43,11 @@ export class GroupResolver {
 
   @Query(() => [FindManyGroup])
   @UseGuards(RolesGuard)
-  async getGroups(): Promise<Partial<FindManyGroup>[]> {
-    return await this.groupService.getGroups()
+  async getGroups(
+    @Args('cursor', CursorValidationPipe) cursor: number,
+    @Args('take', { type: () => Int }) take: number
+  ): Promise<Partial<FindManyGroup>[]> {
+    return await this.groupService.getGroups(cursor, take)
   }
 
   @Query(() => FindGroup)

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -1,12 +1,11 @@
 import {
   ForbiddenException,
   InternalServerErrorException,
-  UnprocessableEntityException,
-  UseGuards
+  UnprocessableEntityException
 } from '@nestjs/common'
 import { Args, Int, Query, Mutation, Resolver, Context } from '@nestjs/graphql'
 import { Role } from '@prisma/client'
-import { AuthenticatedRequest, RolesGuard, UseRolesGuard } from '@libs/auth'
+import { AuthenticatedRequest, UseRolesGuard } from '@libs/auth'
 import {
   ForbiddenAccessException,
   UnprocessableDataException
@@ -15,11 +14,7 @@ import { CursorValidationPipe } from '@libs/pipe'
 import { Group } from '@admin/@generated/group/group.model'
 import { GroupService } from './group.service'
 import { CreateGroupInput, UpdateGroupInput } from './model/group.input'
-import {
-  DeletedUserGroup,
-  FindGroup,
-  FindManyGroup
-} from './model/group.output'
+import { DeletedUserGroup, FindGroup } from './model/group.output'
 
 @Resolver(() => Group)
 export class GroupResolver {
@@ -41,12 +36,12 @@ export class GroupResolver {
     }
   }
 
-  @Query(() => [FindManyGroup])
-  @UseGuards(RolesGuard)
+  @Query(() => [FindGroup])
+  @UseRolesGuard()
   async getGroups(
     @Args('cursor', { nullable: true }, CursorValidationPipe) cursor: number,
     @Args('take', { type: () => Int }) take: number
-  ): Promise<Partial<FindManyGroup>[]> {
+  ): Promise<Partial<FindGroup>[]> {
     return await this.groupService.getGroups(cursor, take)
   }
 

--- a/backend/apps/admin/src/group/group.service.spec.ts
+++ b/backend/apps/admin/src/group/group.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, type TestingModule } from '@nestjs/testing'
+import { expect } from 'chai'
+import { GroupService } from './group.service'
+
+describe('GroupService', () => {
+  let service: GroupService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupService]
+    }).compile()
+
+    service = module.get<GroupService>(GroupService)
+  })
+
+  it('should be defined', () => {
+    expect(service).to.be.ok
+  })
+})

--- a/backend/apps/admin/src/group/group.service.spec.ts
+++ b/backend/apps/admin/src/group/group.service.spec.ts
@@ -1,19 +1,190 @@
 import { Test, type TestingModule } from '@nestjs/testing'
+import { Role } from '@prisma/client'
 import { expect } from 'chai'
+import { stub } from 'sinon'
+import { AuthenticatedUser } from '@libs/auth'
+import { OPEN_SPACE_ID } from '@libs/constants'
+import {
+  ForbiddenAccessException,
+  UnprocessableDataException
+} from '@libs/exception'
+import { PrismaService } from '@libs/prisma'
+import type { Group } from '@admin/@generated/group/group.model'
+import type { User } from '@admin/@generated/user/user.model'
+import { UserService } from '@admin/user/user.service'
 import { GroupService } from './group.service'
+
+const userId = 1
+const groupId = 2
+const input = {
+  groupName: 'Group',
+  description: 'Group',
+  config: {
+    showOnList: true,
+    allowJoinFromSearch: true,
+    allowJoinWithURL: false,
+    requireApprovalBeforeJoin: true
+  }
+}
+const group: Group = {
+  id: 1,
+  createdById: 1,
+  createTime: undefined,
+  updateTime: undefined,
+  userGroup: [
+    {
+      userId: 1,
+      groupId: 2,
+      isGroupLeader: true,
+      createTime: undefined,
+      updateTime: undefined
+    },
+    {
+      userId: 2,
+      groupId: 2,
+      isGroupLeader: false,
+      createTime: undefined,
+      updateTime: undefined
+    }
+  ],
+  ...input
+}
+const { userGroup, ...simpleGroup } = group
+const user: User = {
+  id: 1,
+  username: 'user',
+  email: 'example@codedang.com',
+  password: 'password',
+  role: Role.Admin,
+  lastLogin: undefined,
+  createTime: undefined,
+  updateTime: undefined
+}
+
+const db = {
+  group: {
+    findUnique: stub(),
+    findFirst: stub(),
+    findMany: stub().resolves([group]),
+    create: stub().resolves(group),
+    update: stub()
+  },
+  userGroup: {
+    create: stub().resolves(null),
+    deleteMany: stub().resolves({ count: userGroup.length })
+  }
+}
 
 describe('GroupService', () => {
   let service: GroupService
+  let userService: UserService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GroupService]
+      providers: [
+        GroupService,
+        UserService,
+        { provide: PrismaService, useValue: db }
+      ]
     }).compile()
 
     service = module.get<GroupService>(GroupService)
+    userService = module.get<UserService>(UserService)
   })
 
   it('should be defined', () => {
     expect(service).to.be.ok
+  })
+
+  describe('createGroup', () => {
+    it('should return created group', async () => {
+      db.group.findUnique.resolves(null)
+
+      const res = await service.createGroup(input, userId)
+      expect(res).to.deep.equal(group)
+    })
+
+    it('should throw error when given group name already exists', async () => {
+      db.group.findUnique.resolves(group)
+
+      await expect(service.createGroup(input, userId)).to.be.rejectedWith(
+        UnprocessableDataException
+      )
+    })
+  })
+
+  describe('getGroups', () => {
+    const group = { ...simpleGroup, memberNum: userGroup.length }
+
+    it('should return groups', async () => {
+      const res = await service.getGroups(0, 3)
+      expect(res).to.deep.equal([group])
+    })
+  })
+
+  describe('getGroup', () => {
+    const group = {
+      ...simpleGroup,
+      memberNum: userGroup.length,
+      managers: [user.username]
+    }
+
+    it('should return a group', async () => {
+      const getUsersSpy = stub(userService, 'getUsers').resolves([user])
+
+      const res = await service.getGroup(groupId)
+      expect(res).to.deep.equal(group)
+      expect(getUsersSpy.calledOnceWith({ id: { in: [user.id] } })).to.be.true
+    })
+  })
+
+  describe('updateGroup', () => {
+    const updated = { ...group, groupName: 'Updated' }
+    it('should return updated group', async () => {
+      db.group.findFirst.resolves(null)
+      db.group.update.resolves(updated)
+
+      const res = await service.updateGroup(groupId, input)
+      expect(res).to.deep.equal(updated)
+    })
+
+    it('should throw error when given group is open space', async () => {
+      await expect(
+        service.updateGroup(OPEN_SPACE_ID, input)
+      ).to.be.rejectedWith(ForbiddenAccessException)
+    })
+
+    it('should throw error when given group name exists', async () => {
+      db.group.findFirst.resolves(group)
+
+      await expect(service.updateGroup(groupId, input)).to.be.rejectedWith(
+        UnprocessableDataException
+      )
+    })
+  })
+
+  describe('deleteGroup', () => {
+    const userReq = new AuthenticatedUser(userId, user.username)
+    userReq.role = Role.User
+
+    it('should return the number of members that were in the group', async () => {
+      const res = await service.deleteGroup(groupId, userReq)
+      expect(res).to.deep.equal({ count: userGroup.length })
+    })
+
+    it('should throw error when given group is open space', async () => {
+      await expect(
+        service.deleteGroup(OPEN_SPACE_ID, userReq)
+      ).to.be.rejectedWith(ForbiddenAccessException)
+    })
+
+    it('should throw error when either user role is not higher than Admin or the group is not created by the user', async () => {
+      const userReq = new AuthenticatedUser(2, user.username)
+      db.group.findUnique.resolves(group)
+
+      await expect(service.deleteGroup(groupId, userReq)).to.be.rejectedWith(
+        ForbiddenAccessException
+      )
+    })
   })
 })

--- a/backend/apps/admin/src/group/group.service.spec.ts
+++ b/backend/apps/admin/src/group/group.service.spec.ts
@@ -20,7 +20,7 @@ const input = {
   groupName: 'Group',
   description: 'Group',
   config: {
-    showOnList: true,
+    showOnList: false,
     allowJoinFromSearch: true,
     allowJoinWithURL: false,
     requireApprovalBeforeJoin: true
@@ -47,6 +47,12 @@ const group: Group = {
       updateTime: undefined
     }
   ],
+  config: {
+    showOnList: false,
+    allowJoinFromSearch: false,
+    allowJoinWithURL: false,
+    requireApprovalBeforeJoin: true
+  },
   ...input
 }
 const { userGroup, ...simpleGroup } = group

--- a/backend/apps/admin/src/group/group.service.spec.ts
+++ b/backend/apps/admin/src/group/group.service.spec.ts
@@ -11,7 +11,6 @@ import {
 import { PrismaService } from '@libs/prisma'
 import type { Group } from '@admin/@generated/group/group.model'
 import type { User } from '@admin/@generated/user/user.model'
-import { UserService } from '@admin/user/user.service'
 import { GroupService } from './group.service'
 
 const userId = 1
@@ -83,19 +82,13 @@ const db = {
 
 describe('GroupService', () => {
   let service: GroupService
-  let userService: UserService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        GroupService,
-        UserService,
-        { provide: PrismaService, useValue: db }
-      ]
+      providers: [GroupService, { provide: PrismaService, useValue: db }]
     }).compile()
 
     service = module.get<GroupService>(GroupService)
-    userService = module.get<UserService>(UserService)
   })
 
   it('should be defined', () => {
@@ -129,18 +122,11 @@ describe('GroupService', () => {
   })
 
   describe('getGroup', () => {
-    const group = {
-      ...simpleGroup,
-      memberNum: userGroup.length,
-      managers: [user.username]
-    }
+    const group = { ...simpleGroup, memberNum: userGroup.length }
 
     it('should return a group', async () => {
-      const getUsersSpy = stub(userService, 'getUsers').resolves([user])
-
       const res = await service.getGroup(groupId)
       expect(res).to.deep.equal(group)
-      expect(getUsersSpy.calledOnceWith({ id: { in: [user.id] } })).to.be.true
     })
   })
 

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class GroupService {}

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -51,7 +51,13 @@ export class GroupService {
     return group
   }
 
-  async getGroups() {
+  async getGroups(cursor: number, take: number) {
+    let skip = 1
+    if (cursor === 0) {
+      cursor = 1
+      skip = 0
+    }
+
     return (
       await this.prisma.group.findMany({
         select: {
@@ -60,6 +66,11 @@ export class GroupService {
           description: true,
           config: true,
           userGroup: true
+        },
+        take,
+        skip,
+        cursor: {
+          id: cursor
         }
       })
     ).map((data) => {

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -1,4 +1,123 @@
 import { Injectable } from '@nestjs/common'
+import type { AuthenticatedUser } from '@libs/auth'
+import { ForbiddenAccessException } from '@libs/exception'
+import { PrismaService } from '@libs/prisma'
+import { UserService } from '@admin/user/user.service'
+import type { CreateGroupInput, UpdateGroupInput } from './model/group.input'
 
 @Injectable()
-export class GroupService {}
+export class GroupService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly userService: UserService
+  ) {}
+
+  async createGroup(input: CreateGroupInput, userId: number) {
+    const group = await this.prisma.group.create({
+      data: {
+        groupName: input.groupName,
+        description: input.description,
+        config: JSON.stringify(input.config),
+        createdBy: {
+          connect: { id: userId }
+        }
+      }
+    })
+
+    await this.prisma.userGroup.create({
+      data: {
+        user: {
+          connect: { id: userId }
+        },
+        group: {
+          connect: { id: group.id }
+        },
+        isGroupLeader: true
+      }
+    })
+    return group
+  }
+
+  async getGroups() {
+    return (
+      await this.prisma.group.findMany({
+        select: {
+          id: true,
+          groupName: true,
+          description: true,
+          userGroup: true
+        }
+      })
+    ).map((data) => {
+      const { userGroup, ...group } = data
+      return {
+        ...group,
+        memberNum: userGroup.length
+      }
+    })
+  }
+
+  async getGroup(id: number) {
+    const { userGroup, ...group } = await this.prisma.group.findUnique({
+      where: {
+        id
+      },
+      include: {
+        userGroup: true
+      }
+    })
+
+    const memberNum = userGroup.length
+    const managers = (
+      await this.userService.getUsers({
+        id: {
+          in: userGroup
+            .filter((member) => member.isGroupLeader)
+            .map((manager) => manager.userId)
+        }
+      })
+    ).map((manager) => manager.username)
+
+    return {
+      ...group,
+      memberNum,
+      managers
+    }
+  }
+
+  async updateGroup(id: number, input: UpdateGroupInput) {
+    return await this.prisma.group.update({
+      where: {
+        id
+      },
+      data: {
+        groupName: input.groupName,
+        description: input.description,
+        config: JSON.stringify(input.config)
+      }
+    })
+  }
+
+  async deleteGroup(id: number, user: AuthenticatedUser) {
+    if (!user.isAdmin() && !user.isSuperAdmin()) {
+      const group = await this.prisma.group.findUnique({
+        where: { id },
+        select: {
+          createdById: true
+        }
+      })
+      if (group.createdById !== user.id) {
+        throw new ForbiddenAccessException(
+          'If not admin, only creator can delete a group'
+        )
+      }
+    }
+
+    await this.prisma.userGroup.deleteMany({
+      where: {
+        groupId: id
+      }
+    })
+    return 'Group is successfully deleted'
+  }
+}

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -25,6 +25,9 @@ export class GroupService {
     if (duplicateName) {
       throw new UnprocessableDataException('Group name already exists')
     }
+    if (!input.config.showOnList) {
+      input.config.allowJoinFromSearch = false
+    }
 
     const group = await this.prisma.group.create({
       data: {
@@ -36,7 +39,6 @@ export class GroupService {
         }
       }
     })
-
     await this.prisma.userGroup.create({
       data: {
         user: {
@@ -126,6 +128,9 @@ export class GroupService {
       throw new UnprocessableDataException('Group name already exists')
     }
 
+    if (!input.config.showOnList) {
+      input.config.allowJoinFromSearch = false
+    }
     return await this.prisma.group.update({
       where: {
         id

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -6,15 +6,11 @@ import {
   UnprocessableDataException
 } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
-import { UserService } from '@admin/user/user.service'
 import type { CreateGroupInput, UpdateGroupInput } from './model/group.input'
 
 @Injectable()
 export class GroupService {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly userService: UserService
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async createGroup(input: CreateGroupInput, userId: number) {
     const duplicateName = await this.prisma.group.findUnique({
@@ -94,21 +90,9 @@ export class GroupService {
       }
     })
 
-    const memberNum = userGroup.length
-    const managers = (
-      await this.userService.getUsers({
-        id: {
-          in: userGroup
-            .filter((member) => member.isGroupLeader)
-            .map((manager) => manager.userId)
-        }
-      })
-    ).map((manager) => manager.username)
-
     return {
       ...group,
-      memberNum,
-      managers
+      memberNum: userGroup.length
     }
   }
 

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -111,6 +111,9 @@ export class GroupService {
   }
 
   async updateGroup(id: number, input: UpdateGroupInput) {
+    if (id === OPEN_SPACE_ID) {
+      throw new ForbiddenAccessException('Open space cannot be updated')
+    }
     const duplicateName = await this.prisma.group.findFirst({
       where: {
         NOT: {
@@ -137,7 +140,7 @@ export class GroupService {
 
   async deleteGroup(id: number, user: AuthenticatedUser) {
     if (id === OPEN_SPACE_ID) {
-      throw new UnprocessableDataException('Open space cannot be deleted')
+      throw new ForbiddenAccessException('Open space cannot be deleted')
     } else if (!user.isAdmin() && !user.isSuperAdmin()) {
       const group = await this.prisma.group.findUnique({
         where: { id },

--- a/backend/apps/admin/src/group/model/group.input.ts
+++ b/backend/apps/admin/src/group/model/group.input.ts
@@ -1,0 +1,37 @@
+import { Field } from '@nestjs/graphql'
+import { InputType } from '@nestjs/graphql'
+import { GroupCreateWithoutCreatedByInput } from '@admin/@generated/group/group-create-without-created-by.input'
+import { GroupUpdateInput } from '@admin/@generated/group/group-update.input'
+
+@InputType()
+class Config {
+  @Field(() => Boolean, { nullable: false })
+  showOnList: boolean
+
+  @Field(() => Boolean, { nullable: false })
+  allowJoinFromSearch: boolean
+
+  @Field(() => Boolean, { nullable: false })
+  allowJoinWithURL: boolean
+
+  @Field(() => Boolean, { nullable: false })
+  requireApprovalBeforeJoin: boolean
+}
+
+@InputType()
+export class CreateGroupInput extends GroupCreateWithoutCreatedByInput {
+  @Field(() => Config, { nullable: false })
+  declare config: Config
+}
+
+@InputType()
+export class UpdateGroupInput extends GroupUpdateInput {
+  @Field(() => String, { nullable: false })
+  declare groupName: string
+
+  @Field(() => String, { nullable: false })
+  declare description: string
+
+  @Field(() => Config, { nullable: false })
+  declare config: Config
+}

--- a/backend/apps/admin/src/group/model/group.output.ts
+++ b/backend/apps/admin/src/group/model/group.output.ts
@@ -3,15 +3,9 @@ import { ObjectType } from '@nestjs/graphql'
 import { Group } from '@admin/@generated/group/group.model'
 
 @ObjectType()
-export class FindManyGroup extends Group {
+export class FindGroup extends Group {
   @Field(() => Int, { nullable: false })
   memberNum!: number
-}
-
-@ObjectType()
-export class FindGroup extends FindManyGroup {
-  @Field(() => [String], { nullable: false })
-  managers!: Array<string>
 }
 
 @ObjectType()

--- a/backend/apps/admin/src/group/model/group.output.ts
+++ b/backend/apps/admin/src/group/model/group.output.ts
@@ -1,0 +1,15 @@
+import { Field, Int } from '@nestjs/graphql'
+import { ObjectType } from '@nestjs/graphql'
+import { Group } from '@admin/@generated/group/group.model'
+
+@ObjectType()
+export class FindManyGroup extends Group {
+  @Field(() => Int, { nullable: false })
+  memberNum!: number
+}
+
+@ObjectType()
+export class FindGroup extends FindManyGroup {
+  @Field(() => [String], { nullable: false })
+  managers!: Array<string>
+}

--- a/backend/apps/admin/src/group/model/group.output.ts
+++ b/backend/apps/admin/src/group/model/group.output.ts
@@ -13,3 +13,9 @@ export class FindGroup extends FindManyGroup {
   @Field(() => [String], { nullable: false })
   managers!: Array<string>
 }
+
+@ObjectType()
+export class DeletedUserGroup {
+  @Field(() => Int, { nullable: false })
+  count!: number
+}

--- a/backend/apps/admin/src/user/user.module.ts
+++ b/backend/apps/admin/src/user/user.module.ts
@@ -3,6 +3,7 @@ import { UserResolver } from './user.resolver'
 import { UserService } from './user.service'
 
 @Module({
-  providers: [UserResolver, UserService]
+  providers: [UserResolver, UserService],
+  exports: [UserService]
 })
 export class UserModule {}

--- a/backend/apps/admin/src/user/user.resolver.ts
+++ b/backend/apps/admin/src/user/user.resolver.ts
@@ -15,9 +15,9 @@ export class UserResolver {
     return this.userService.createUser(userCreateInput)
   }
 
-  @Query(() => [User], { name: 'getAllUsers' })
-  getAllUsers(): Promise<User[]> {
-    return this.userService.getAllUsers()
+  @Query(() => [User], { name: 'getUsers' })
+  getUsers(): Promise<User[]> {
+    return this.userService.getUsers()
   }
 
   @Query(() => User, { name: 'getUser' })

--- a/backend/apps/admin/src/user/user.service.ts
+++ b/backend/apps/admin/src/user/user.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from '@libs/prisma'
+import type { UserWhereInput } from '@admin/@generated/user/user-where.input'
 import type { User } from '@admin/@generated/user/user.model'
 import type { UserCreateInput } from '../@generated/user/user-create.input'
 import type { UserUpdateInput } from '../@generated/user/user-update.input'
@@ -18,8 +19,10 @@ export class UserService {
     })
   }
 
-  async getAllUsers(): Promise<User[]> {
-    return await this.prisma.user.findMany()
+  async getUsers(where: UserWhereInput = {}): Promise<User[]> {
+    return await this.prisma.user.findMany({
+      where
+    })
   }
 
   async getUser(id: number): Promise<User> {

--- a/backend/apps/client/src/group/mock/group.mock.ts
+++ b/backend/apps/client/src/group/mock/group.mock.ts
@@ -13,7 +13,6 @@ export const groups: Group[] = [
     description: 'mock public group with no approval',
     createdById: 1,
     groupName: 'mock public group',
-    isDeleted: false,
     createTime: new Date('2023-02-22T00:00:00.000Z'),
     updateTime: new Date('2023-02-22T:00:00.000Z')
   },
@@ -28,7 +27,6 @@ export const groups: Group[] = [
     description: 'mock public group with approval',
     createdById: 1,
     groupName: 'mock public group 2',
-    isDeleted: false,
     createTime: new Date('2023-02-22T00:00:00.000Z'),
     updateTime: new Date('2023-02-22T10:00:00.000Z')
   },
@@ -43,7 +41,6 @@ export const groups: Group[] = [
     description: 'mock public group with approval',
     createdById: 1,
     groupName: 'mock public group 2',
-    isDeleted: false,
     createTime: new Date('2023-02-22T00:00:00.000Z'),
     updateTime: new Date('2023-02-22T10:00:00.000Z')
   }

--- a/backend/apps/client/src/notice/notice.service.spec.ts
+++ b/backend/apps/client/src/notice/notice.service.spec.ts
@@ -54,7 +54,6 @@ const group: Group = {
   createdById: 1,
   groupName: 'group_name',
   description: 'description',
-  isDeleted: false,
   config: {
     showOnList: true,
     allowJoinFromSearch: true,

--- a/backend/apps/client/src/workbook/workbook-admin.controller.ts
+++ b/backend/apps/client/src/workbook/workbook-admin.controller.ts
@@ -13,10 +13,9 @@ import {
   Req,
   UseGuards
 } from '@nestjs/common'
-import { Role, type Workbook } from '@prisma/client'
+import type { Workbook } from '@prisma/client'
 import {
   type AuthenticatedRequest,
-  Roles,
   RolesGuard,
   GroupLeaderGuard
 } from '@libs/auth'
@@ -64,8 +63,6 @@ export class WorkbookAdminController {
   }
 
   @Post()
-  @UseGuards(RolesGuard)
-  @Roles(Role.Manager)
   async createWorkbook(
     @Req() req: AuthenticatedRequest,
     @Param('groupId', ParseIntPipe) groupId,

--- a/backend/libs/auth/src/guard.decorator.ts
+++ b/backend/libs/auth/src/guard.decorator.ts
@@ -1,0 +1,16 @@
+import { SetMetadata, UseGuards, applyDecorators } from '@nestjs/common'
+import { Role } from '@prisma/client'
+import { ROLES_KEY } from './roles/roles.decorator'
+import { RolesGuard } from './roles/roles.guard'
+
+export const AUTH_NOT_NEEDED_KEY = 'auth-not-needed'
+export const AuthNotNeeded = () => SetMetadata('auth-not-needed', true)
+
+export const LEADER_NOT_NEEDED_KEY = 'leader-not-needed'
+export const UseRolesGuard = (role: Role = Role.Admin) => {
+  return applyDecorators(
+    SetMetadata(LEADER_NOT_NEEDED_KEY, true),
+    SetMetadata(ROLES_KEY, role),
+    UseGuards(RolesGuard)
+  )
+}

--- a/backend/libs/auth/src/index.ts
+++ b/backend/libs/auth/src/index.ts
@@ -1,11 +1,11 @@
 export * from './authenticated-user.class'
 export * from './authenticated-request.interface'
+export * from './guard.decorator'
 
 export * from './jwt/jwt-auth.module'
 export * from './jwt/jwt-auth.service'
 export * from './jwt/jwt.interface'
 export * from './jwt/jwt-auth.guard'
-export * from './jwt/auth-ignore.decorator'
 
 export * from './roles/roles.module'
 export * from './roles/roles.service'

--- a/backend/libs/auth/src/jwt/auth-ignore.decorator.ts
+++ b/backend/libs/auth/src/jwt/auth-ignore.decorator.ts
@@ -1,4 +1,0 @@
-import { SetMetadata } from '@nestjs/common'
-
-export const IS_AUTH_NOT_NEEDED_KEY = 'auth-not-needed'
-export const AuthNotNeeded = () => SetMetadata(IS_AUTH_NOT_NEEDED_KEY, true)

--- a/backend/libs/auth/src/jwt/jwt-auth.guard.ts
+++ b/backend/libs/auth/src/jwt/jwt-auth.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from '@nestjs/core'
 import { type GqlContextType, GqlExecutionContext } from '@nestjs/graphql'
 import { AuthGuard } from '@nestjs/passport'
 import type { Observable } from 'rxjs'
-import { IS_AUTH_NOT_NEEDED_KEY } from './auth-ignore.decorator'
+import { AUTH_NOT_NEEDED_KEY } from '../guard.decorator'
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -15,7 +15,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     context: ExecutionContext
   ): boolean | Promise<boolean> | Observable<boolean> {
     const isAuthNotNeeded = this.reflector.getAllAndOverride<boolean>(
-      IS_AUTH_NOT_NEEDED_KEY,
+      AUTH_NOT_NEEDED_KEY,
       [context.getHandler(), context.getClass()]
     )
     if (isAuthNotNeeded) {

--- a/backend/libs/auth/src/roles/group-leader.guard.ts
+++ b/backend/libs/auth/src/roles/group-leader.guard.ts
@@ -3,6 +3,7 @@ import {
   type CanActivate,
   type ExecutionContext
 } from '@nestjs/common'
+import { type GqlContextType, GqlExecutionContext } from '@nestjs/graphql'
 import type { AuthenticatedRequest } from '../authenticated-request.interface'
 import type { AuthenticatedUser } from '../authenticated-user.class'
 import { RolesService } from './roles.service'
@@ -12,15 +13,24 @@ export class GroupLeaderGuard implements CanActivate {
   constructor(private readonly service: RolesService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request: AuthenticatedRequest = context.switchToHttp().getRequest()
-    const user: AuthenticatedUser = request.user
+    let request: AuthenticatedRequest
+    if (context.getType<GqlContextType>() === 'graphql') {
+      request = GqlExecutionContext.create(context).getContext().req
+    } else {
+      request = context.switchToHttp().getRequest()
+    }
 
+    const user: AuthenticatedUser = request.user
+    if (!user.role) {
+      const userRole = (await this.service.getUserRole(user.id)).role
+      user.role = userRole
+    }
     if (user.isAdmin() || user.isSuperAdmin()) {
       return true
     }
 
     const groupId: number = parseInt(request.params.groupId)
-    const userId: number = request.user.id
+    const userId: number = user.id
 
     const userGroup = await this.service.getUserGroup(userId, groupId)
     const isGroupLeader: boolean = userGroup && userGroup.isGroupLeader

--- a/backend/libs/auth/src/roles/group-member.guard.ts
+++ b/backend/libs/auth/src/roles/group-member.guard.ts
@@ -14,10 +14,18 @@ export class GroupMemberGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     let request: AuthenticatedRequest
+    let groupId: number
     if (context.getType<GqlContextType>() === 'graphql') {
       request = GqlExecutionContext.create(context).getContext().req
+      groupId = parseInt(
+        context
+          .getArgs()
+          .find((arg) => typeof arg === 'object' && 'groupId' in arg)
+          ?.groupId ?? 0
+      )
     } else {
       request = context.switchToHttp().getRequest()
+      groupId = parseInt(request.params.groupId)
     }
 
     const user: AuthenticatedUser = request.user
@@ -29,11 +37,7 @@ export class GroupMemberGuard implements CanActivate {
       return true
     }
 
-    const groupId: number = parseInt(request.params.groupId)
-    const userId: number = user.id
-
-    const userGroup = await this.service.getUserGroup(userId, groupId)
-
+    const userGroup = await this.service.getUserGroup(user.id, groupId)
     if (userGroup) {
       return true
     }

--- a/backend/libs/auth/src/roles/group-member.guard.ts
+++ b/backend/libs/auth/src/roles/group-member.guard.ts
@@ -3,6 +3,7 @@ import {
   type ExecutionContext,
   Injectable
 } from '@nestjs/common'
+import { type GqlContextType, GqlExecutionContext } from '@nestjs/graphql'
 import type { AuthenticatedRequest } from '../authenticated-request.interface'
 import type { AuthenticatedUser } from '../authenticated-user.class'
 import { RolesService } from './roles.service'
@@ -12,15 +13,24 @@ export class GroupMemberGuard implements CanActivate {
   constructor(private readonly service: RolesService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request: AuthenticatedRequest = context.switchToHttp().getRequest()
-    const user: AuthenticatedUser = request.user
+    let request: AuthenticatedRequest
+    if (context.getType<GqlContextType>() === 'graphql') {
+      request = GqlExecutionContext.create(context).getContext().req
+    } else {
+      request = context.switchToHttp().getRequest()
+    }
 
+    const user: AuthenticatedUser = request.user
+    if (!user.role) {
+      const userRole = (await this.service.getUserRole(user.id)).role
+      user.role = userRole
+    }
     if (user.isAdmin() || user.isSuperAdmin()) {
       return true
     }
 
     const groupId: number = parseInt(request.params.groupId)
-    const userId: number = request.user.id
+    const userId: number = user.id
 
     const userGroup = await this.service.getUserGroup(userId, groupId)
 

--- a/backend/libs/auth/src/roles/roles.guard.ts
+++ b/backend/libs/auth/src/roles/roles.guard.ts
@@ -7,6 +7,7 @@ import { Reflector } from '@nestjs/core'
 import { type GqlContextType, GqlExecutionContext } from '@nestjs/graphql'
 import { Role } from '@prisma/client'
 import type { AuthenticatedRequest } from '../authenticated-request.interface'
+import type { AuthenticatedUser } from '../authenticated-user.class'
 import { ROLES_KEY } from './roles.decorator'
 import { RolesService } from './roles.service'
 
@@ -25,22 +26,25 @@ export class RolesGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     let request: AuthenticatedRequest
-    let role = this.reflector.getAllAndOverride<Role>(ROLES_KEY, [
-      context.getHandler(),
-      context.getClass()
-    ])
-
     if (context.getType<GqlContextType>() === 'graphql') {
-      if (!role) role = Role.Admin
       request = GqlExecutionContext.create(context).getContext().req
     } else {
-      if (!role) role = Role.User
       request = context.switchToHttp().getRequest()
     }
-    const userRole = (await this.service.getUserRole(request.user.id)).role
 
-    if (this.#rolesHierarchy[userRole] >= this.#rolesHierarchy[role]) {
-      request.user.role = userRole
+    const role =
+      this.reflector.getAllAndOverride<Role>(ROLES_KEY, [
+        context.getHandler(),
+        context.getClass()
+      ]) ?? Role.User
+
+    const user: AuthenticatedUser = request.user
+    if (!user.role) {
+      const userRole = (await this.service.getUserRole(user.id)).role
+      user.role = userRole
+    }
+
+    if (this.#rolesHierarchy[user.role] >= this.#rolesHierarchy[role]) {
       return true
     }
     return false

--- a/backend/libs/auth/src/roles/roles.guard.ts
+++ b/backend/libs/auth/src/roles/roles.guard.ts
@@ -43,7 +43,6 @@ export class RolesGuard implements CanActivate {
       const userRole = (await this.service.getUserRole(user.id)).role
       user.role = userRole
     }
-
     if (this.#rolesHierarchy[user.role] >= this.#rolesHierarchy[role]) {
       return true
     }

--- a/backend/libs/pipe/src/cursor-validation.pipe.ts
+++ b/backend/libs/pipe/src/cursor-validation.pipe.ts
@@ -18,7 +18,7 @@ export class CursorValidationPipe implements PipeTransform {
         throw new BadRequestException('Cursor value must be number')
       }
       // validation for negative values
-      if (cursor < 0) {
+      if (cursor <= 0) {
         throw new InvalidCursorValueException(cursor)
       }
 

--- a/backend/libs/pipe/src/cursor-validation.pipe.ts
+++ b/backend/libs/pipe/src/cursor-validation.pipe.ts
@@ -18,7 +18,7 @@ export class CursorValidationPipe implements PipeTransform {
         throw new BadRequestException('Cursor value must be number')
       }
       // validation for negative values
-      if (cursor <= 0) {
+      if (cursor < 0) {
         throw new InvalidCursorValueException(cursor)
       }
 

--- a/backend/prisma/migrations/20230629103918_delete_is_deleted_field_from_group/migration.sql
+++ b/backend/prisma/migrations/20230629103918_delete_is_deleted_field_from_group/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_deleted` on the `group` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "group" DROP COLUMN "is_deleted";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -84,7 +84,6 @@ model Group {
   ///   "requireApprovalBeforeJoin": true
   /// }
   config      Json
-  isDeleted   Boolean  @default(false) @map("is_deleted")
   createTime  DateTime @default(now()) @map("create_time")
   updateTime  DateTime @updatedAt @map("update_time")
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -57,7 +57,7 @@ const createUsers = async () => {
   managerUser = await prisma.user.create({
     data: {
       username: 'manager',
-      password: await hash('Manager'),
+      password: await hash('Managermanager'),
       email: 'manager@example.com',
       lastLogin: new Date(),
       role: Role.Manager
@@ -121,10 +121,17 @@ const createGroups = async () => {
       }
     }
   })
+  await prisma.userGroup.create({
+    data: {
+      userId: managerUser.id,
+      groupId: privateGroup.id,
+      isGroupLeader: true
+    }
+  })
 
   // create empty private group
   // 'showOnList'가 true 이면서 가입시 사전 승인이 필요한 그룹을 테스트할 때 사용합니다
-  await prisma.group.create({
+  let tempGroup = await prisma.group.create({
     data: {
       groupName: 'Example Private Group 2',
       description:
@@ -138,10 +145,17 @@ const createGroups = async () => {
       }
     }
   })
+  await prisma.userGroup.create({
+    data: {
+      userId: managerUser.id,
+      groupId: tempGroup.id,
+      isGroupLeader: true
+    }
+  })
 
   // create empty private group
   // 'showOnList'가 true 이면서 가입시 사전 승인이 필요없는 그룹을 테스트할 때 사용합니다
-  await prisma.group.create({
+  tempGroup = await prisma.group.create({
     data: {
       groupName: 'Example Private Group 3',
       description:
@@ -153,6 +167,13 @@ const createGroups = async () => {
         allowJoinWithURL: true,
         requireApprovalBeforeJoin: false
       }
+    }
+  })
+  await prisma.userGroup.create({
+    data: {
+      userId: managerUser.id,
+      groupId: tempGroup.id,
+      isGroupLeader: true
     }
   })
 
@@ -182,14 +203,6 @@ const createGroups = async () => {
       }
     })
   }
-
-  await prisma.userGroup.create({
-    data: {
-      userId: managerUser.id,
-      groupId: 4,
-      isGroupLeader: true
-    }
-  })
 
   await prisma.userGroup.create({
     data: {

--- a/thunder-tests/collections/tc_col_codedang-admin-api.json
+++ b/thunder-tests/collections/tc_col_codedang-admin-api.json
@@ -181,7 +181,7 @@
             "method": "POST",
             "sortNum": 10000,
             "created": "2023-07-01T09:23:20.634Z",
-            "modified": "2023-07-01T09:55:55.626Z",
+            "modified": "2023-07-02T07:28:34.441Z",
             "headers": [],
             "params": [],
             "body": {
@@ -189,7 +189,7 @@
                 "raw": "",
                 "form": [],
                 "graphql": {
-                    "query": "mutation Group {\n  createGroup(input: {\n    groupName: \"New Group21\",\n    description: \"Blah Blah\",\n    config: {\n      showOnList: true,\n      allowJoinFromSearch: true,\n      allowJoinWithURL: false,\n      requireApprovalBeforeJoin: true\n    }\n  }) {\n    id\n  }\n}"
+                    "query": "mutation Group {\n  createGroup(input: {\n    groupName: \"New Group\",\n    description: \"Blah Blah\",\n    config: {\n      showOnList: false,\n      allowJoinFromSearch: true,\n      allowJoinWithURL: false,\n      requireApprovalBeforeJoin: true\n    }\n  }) {\n    id\n    config\n  }\n}"
                 }
             },
             "tests": [
@@ -200,7 +200,7 @@
                     "value": "id"
                 }
             ],
-            "docs": "# Create Group [유저 대시보드 /그룹]\n\n**⚠️ 최초 1번만 동작할 리퀘스트입니다. 다시 성공 응답을 받으려면 (1) input의 그룹명을 바꿔 리퀘스트를 전송하거나 (2) `npx prisma migrate reset`을 실행해주세요.**  \n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- Manager 이상의 role을 가진 유저만 새 그룹을 생성할 수 있습니다.\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n- 유저에게 주어지는 그룹 config의 디폴트 값은 다음과 같습니다.\n  ```json\n  showOnList: true\n  allowJoinFromSearch: true\n  allowJoinWithURL: false\n  requireApprovalBeforeJoin: true\n  ```",
+            "docs": "# Create Group [유저 대시보드 /그룹]\n\n**⚠️ 최초 1번만 동작할 리퀘스트입니다. 다시 성공 응답을 받으려면 (1) input의 그룹명을 바꿔 리퀘스트를 전송하거나 (2) `npx prisma migrate reset`을 실행해주세요.**  \n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- Manager 이상의 role을 가진 유저만 새 그룹을 생성할 수 있습니다.\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n- 유저에게 주어져야 하는 그룹 config의 디폴트 값은 다음과 같습니다.\n  ```json\n  showOnList: true\n  allowJoinFromSearch: true\n  allowJoinWithURL: false\n  requireApprovalBeforeJoin: true\n  ```\n  + `showOnList`가 false이면 `allowJoinFromSearch` 값이 항상 false로 적용됩니다.",
             "preReq": {
                 "runRequests": [
                     {
@@ -297,7 +297,7 @@
             "method": "POST",
             "sortNum": 2500,
             "created": "2023-07-01T09:38:06.086Z",
-            "modified": "2023-07-01T15:09:58.752Z",
+            "modified": "2023-07-02T07:28:39.971Z",
             "headers": [],
             "params": [],
             "body": {
@@ -305,7 +305,7 @@
                 "raw": "",
                 "form": [],
                 "graphql": {
-                    "query": "mutation Group {\n  updateGroup(\n    groupId: 3\n    input: {\n      groupName: \"Revised Group\",\n      description: \"Blah Blah\",\n      config: {\n        showOnList: true,\n        allowJoinFromSearch: true,\n        allowJoinWithURL: false\n        requireApprovalBeforeJoin: true\n      }\n    }\n  ) {\n    id\n    groupName\n    description\n    config\n  }\n}"
+                    "query": "mutation Group {\n  updateGroup(\n    groupId: 3\n    input: {\n      groupName: \"Revised Group\",\n      description: \"Blah Blah\",\n      config: {\n        showOnList: false,\n        allowJoinFromSearch: true,\n        allowJoinWithURL: false\n        requireApprovalBeforeJoin: true\n      }\n    }\n  ) {\n    id\n    groupName\n    description\n    config\n  }\n}"
                 }
             },
             "tests": [
@@ -334,7 +334,7 @@
                     "value": "config"
                 }
             ],
-            "docs": "# Update Group [그룹 대시보드]\n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n  + c.f. 422: Duplicate Group Name\n- Open Space의 정보는 업데이트할 수 없습니다.",
+            "docs": "# Update Group [그룹 대시보드]\n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n  + c.f. 422: Duplicate Group Name\n- Open Space의 정보는 업데이트할 수 없습니다.\n- `config`의 `showOnList`가 false이면 `allowJoinFromSearch` 값이 항상 false로 적용됩니다.",
             "preReq": {
                 "runRequests": [
                     {

--- a/thunder-tests/collections/tc_col_codedang-admin-api.json
+++ b/thunder-tests/collections/tc_col_codedang-admin-api.json
@@ -3,7 +3,50 @@
     "colName": "Codedang Admin API",
     "created": "2023-05-02T10:59:44.408Z",
     "sortNum": 20000,
-    "folders": [],
+    "folders": [
+        {
+            "_id": "fe52bede-3550-4899-9738-50719d9b04ef",
+            "name": "Group",
+            "containerId": "",
+            "created": "2023-07-01T08:36:12.949Z",
+            "sortNum": 10000
+        },
+        {
+            "_id": "e301836d-c693-4efe-a13b-59250583415f",
+            "name": "Get Group",
+            "containerId": "fe52bede-3550-4899-9738-50719d9b04ef",
+            "created": "2023-07-01T08:36:36.695Z",
+            "sortNum": 30000
+        },
+        {
+            "_id": "50fd1447-8e48-415a-adb8-29d7d7f742cc",
+            "name": "Get Groups (Admin)",
+            "containerId": "fe52bede-3550-4899-9738-50719d9b04ef",
+            "created": "2023-07-01T08:38:28.308Z",
+            "sortNum": 50000
+        },
+        {
+            "_id": "771ab14a-f583-4a94-a34e-4f8e8b569d8b",
+            "name": "Create Group",
+            "containerId": "fe52bede-3550-4899-9738-50719d9b04ef",
+            "created": "2023-07-01T08:38:49.546Z",
+            "sortNum": 15000
+        },
+        {
+            "_id": "2e6dd7d6-4110-4bd0-9138-660931d2a26d",
+            "name": "Update Group",
+            "containerId": "fe52bede-3550-4899-9738-50719d9b04ef",
+            "created": "2023-07-01T08:38:57.241Z",
+            "sortNum": 70000
+        },
+        {
+            "_id": "5cbf039a-6e9c-4321-93c2-e297a12b480e",
+            "name": "Delete Group",
+            "containerId": "fe52bede-3550-4899-9738-50719d9b04ef",
+            "created": "2023-07-01T08:39:04.697Z",
+            "sortNum": 80000
+        }
+    ],
     "settings": {
         "auth": {
             "type": "bearer",
@@ -13,5 +56,457 @@
             "baseUrl": "http://localhost:3000/graphql"
         }
     },
-    "requests": []
+    "requests": [
+        {
+            "_id": "71642f55-4b63-417a-8f07-b466f2b65c88",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "50fd1447-8e48-415a-adb8-29d7d7f742cc",
+            "name": "Succeed",
+            "url": "",
+            "method": "POST",
+            "sortNum": 10000,
+            "created": "2023-07-01T08:39:22.506Z",
+            "modified": "2023-07-01T09:27:13.761Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "query Group {\n  getGroups {\n    id\n    groupName\n    description\n    config\n    memberNum\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "id"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "groupName"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "description"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "config"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "memberNum"
+                }
+            ],
+            "docs": "# Get Groups [어드민 대시보드]\n\n모든 그룹의 목록을 가져옵니다.",
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "fd33c48d-00af-4dea-b600-449bef7e5bea",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "05e3046e-d43c-43d2-aaf9-a2c948b41183",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "771ab14a-f583-4a94-a34e-4f8e8b569d8b",
+            "name": "422: Duplicate Name",
+            "url": "",
+            "method": "POST",
+            "sortNum": 20000,
+            "created": "2023-07-01T09:06:26.347Z",
+            "modified": "2023-07-01T09:12:06.176Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  createGroup(input: {\n    groupName: \"Example Group\",\n    description: \"Blah Blah\",\n    config: {\n      showOnList: true,\n      allowJoinFromSearch: true,\n      allowJoinWithURL: false,\n      requireApprovalBeforeJoin: true\n    }\n  }) {\n    id\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].extensions.status",
+                    "action": "equal",
+                    "value": "422"
+                },
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].message",
+                    "action": "equal",
+                    "value": "Group name already exists"
+                }
+            ],
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "86d2ae24-54f0-4567-9a3c-a993ac915ad4",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "d69f62f2-213f-495e-b8b7-d2904e9c434a",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "771ab14a-f583-4a94-a34e-4f8e8b569d8b",
+            "name": "Succeed",
+            "url": "",
+            "method": "POST",
+            "sortNum": 10000,
+            "created": "2023-07-01T09:23:20.634Z",
+            "modified": "2023-07-01T09:55:55.626Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  createGroup(input: {\n    groupName: \"New Group21\",\n    description: \"Blah Blah\",\n    config: {\n      showOnList: true,\n      allowJoinFromSearch: true,\n      allowJoinWithURL: false,\n      requireApprovalBeforeJoin: true\n    }\n  }) {\n    id\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "id"
+                }
+            ],
+            "docs": "# Create Group [유저 대시보드 /그룹]\n\n**⚠️ 최초 1번만 동작할 리퀘스트입니다. 다시 성공 응답을 받으려면 (1) input의 그룹명을 바꿔 리퀘스트를 전송하거나 (2) `npx prisma migrate reset`을 실행해주세요.**  \n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- Manager 이상의 role을 가진 유저만 새 그룹을 생성할 수 있습니다.\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n- 유저에게 주어지는 그룹 config의 디폴트 값은 다음과 같습니다.\n  ```json\n  showOnList: true\n  allowJoinFromSearch: true\n  allowJoinWithURL: false\n  requireApprovalBeforeJoin: true\n  ```",
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "86d2ae24-54f0-4567-9a3c-a993ac915ad4",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "1448e822-f5bb-45aa-a9b0-db9ba1fbda85",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "e301836d-c693-4efe-a13b-59250583415f",
+            "name": "Succeed",
+            "url": "",
+            "method": "POST",
+            "sortNum": 10000,
+            "created": "2023-07-01T09:28:51.000Z",
+            "modified": "2023-07-01T13:32:14.311Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "query Group {\n  getGroup(groupId: 1) {\n    id\n    groupName\n    description\n    config\n    createTime\n    memberNum\n    managers\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "id"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "groupName"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "description"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "config"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "createTime"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "memberNum"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "managers"
+                }
+            ],
+            "docs": "# Get Group [그룹 대시보드]\n\n그룹의 상세 정보를 보여줍니다.  \n그룹이 존재하지 않거나 유저에게 그룹 관리 권한이 없는 경우 403이 반환됩니다.",
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "de1639a5-d9da-4397-8a13-ae1fc61b849b",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "1894da94-9c1c-4af8-8ea8-a23f8b74ed4d",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "2e6dd7d6-4110-4bd0-9138-660931d2a26d",
+            "name": "Succeed",
+            "url": "",
+            "method": "POST",
+            "sortNum": 2500,
+            "created": "2023-07-01T09:38:06.086Z",
+            "modified": "2023-07-01T10:04:35.760Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  updateGroup(\n    groupId: 3\n    input: {\n      groupName: \"Revised Group\",\n      description: \"Blah Blah\",\n      config: {\n        showOnList: true,\n        allowJoinFromSearch: true,\n        allowJoinWithURL: false\n        requireApprovalBeforeJoin: true\n      }\n    }\n  ) {\n    id\n    groupName\n    description\n    config\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "id"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "groupName"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "description"
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "config"
+                }
+            ],
+            "docs": "# Update Group [그룹 대시보드]\n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n  + c.f. 422: Duplicate Group Name",
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "1a62bc1b-fbff-4f01-bbb8-bbf08974ea80",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "4a434dd3-41c8-410f-b6f1-e899d8c5001d",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "2e6dd7d6-4110-4bd0-9138-660931d2a26d",
+            "name": "422: Duplicate Name",
+            "url": "",
+            "method": "POST",
+            "sortNum": 5000,
+            "created": "2023-07-01T09:38:13.195Z",
+            "modified": "2023-07-01T09:44:51.817Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  updateGroup(\n    groupId: 2\n    input: {\n      groupName: \"Example Group\",\n      description: \"Blah Blah\",\n      config: {\n        showOnList: true,\n        allowJoinFromSearch: true,\n        allowJoinWithURL: false\n        requireApprovalBeforeJoin: true\n      }\n    }\n  ) {\n    id\n    groupName\n    description\n    config\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].extensions.status",
+                    "action": "equal",
+                    "value": "422"
+                },
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].message",
+                    "action": "equal",
+                    "value": "Group name already exists"
+                }
+            ],
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "1a62bc1b-fbff-4f01-bbb8-bbf08974ea80",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "9b958c6b-8809-462c-b451-88177295c25f",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "5cbf039a-6e9c-4321-93c2-e297a12b480e",
+            "name": "Succeed",
+            "url": "",
+            "method": "POST",
+            "sortNum": 30000,
+            "created": "2023-07-01T09:47:35.203Z",
+            "modified": "2023-07-01T13:32:37.976Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  deleteGroup(groupId: 4) {\n    count\n  }\n}"
+                }
+            },
+            "tests": [],
+            "docs": "# Delete Group [그룹 대시보드]\n\n**⚠️ 최초 1번만 동작할 리퀘스트입니다. 다시 성공 응답을 받으려면 `npx prisma migrate reset`을 실행해주세요.**  \n\n그룹을 삭제합니다.\n\n### Constraints\n- 그룹은 그룹의 생성자 혹은 Admin/SuperAdmin만 삭제할 수 있습니다.\n- 그룹의 관리자이더라도 그룹을 생성한 유저가 아니라면 삭제가 불가능합니다.\n- Open Space는 어떤 유저도 삭제할 수 없습니다.\n",
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "86d2ae24-54f0-4567-9a3c-a993ac915ad4",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "53cc571f-a6d1-4c8d-8659-d261b337933d",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "5cbf039a-6e9c-4321-93c2-e297a12b480e",
+            "name": "403: Not Creator",
+            "url": "",
+            "method": "POST",
+            "sortNum": 40000,
+            "created": "2023-07-01T09:48:00.827Z",
+            "modified": "2023-07-01T13:31:40.071Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  deleteGroup(groupId: 2) {\n    count\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].extensions.originalError.statusCode",
+                    "action": "equal",
+                    "value": "403"
+                },
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].message",
+                    "action": "equal",
+                    "value": "If not admin, only creator can delete a group"
+                }
+            ],
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "de1639a5-d9da-4397-8a13-ae1fc61b849b",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "d62f2e3e-7a5c-4543-8eff-bb146cabde99",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "5cbf039a-6e9c-4321-93c2-e297a12b480e",
+            "name": "422: Protected Open Space",
+            "url": "",
+            "method": "POST",
+            "sortNum": 50000,
+            "created": "2023-07-01T13:27:34.416Z",
+            "modified": "2023-07-01T13:32:03.254Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  deleteGroup(groupId: 1) {\n    count\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].extensions.originalError.statusCode",
+                    "action": "equal",
+                    "value": "422"
+                },
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].message",
+                    "action": "equal",
+                    "value": "Open space cannot be deleted"
+                }
+            ],
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "1a62bc1b-fbff-4f01-bbb8-bbf08974ea80",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        }
+    ]
 }

--- a/thunder-tests/collections/tc_col_codedang-admin-api.json
+++ b/thunder-tests/collections/tc_col_codedang-admin-api.json
@@ -66,7 +66,7 @@
             "method": "POST",
             "sortNum": 10000,
             "created": "2023-07-01T08:39:22.506Z",
-            "modified": "2023-07-01T09:27:13.761Z",
+            "modified": "2023-07-01T15:12:37.712Z",
             "headers": [],
             "params": [],
             "body": {
@@ -74,7 +74,7 @@
                 "raw": "",
                 "form": [],
                 "graphql": {
-                    "query": "query Group {\n  getGroups {\n    id\n    groupName\n    description\n    config\n    memberNum\n  }\n}"
+                    "query": "query Group {\n  getGroups(cursor: 0, take: 3) {\n    id\n    groupName\n    description\n    config\n    memberNum\n  }\n}"
                 }
             },
             "tests": [
@@ -107,6 +107,12 @@
                     "custom": "",
                     "action": "contains",
                     "value": "memberNum"
+                },
+                {
+                    "type": "json-query",
+                    "custom": "json.data.getGroups.id | length",
+                    "action": "<=",
+                    "value": "3"
                 }
             ],
             "docs": "# Get Groups [어드민 대시보드]\n\n모든 그룹의 목록을 가져옵니다.",
@@ -291,7 +297,7 @@
             "method": "POST",
             "sortNum": 2500,
             "created": "2023-07-01T09:38:06.086Z",
-            "modified": "2023-07-01T10:04:35.760Z",
+            "modified": "2023-07-01T15:09:58.752Z",
             "headers": [],
             "params": [],
             "body": {
@@ -328,7 +334,7 @@
                     "value": "config"
                 }
             ],
-            "docs": "# Update Group [그룹 대시보드]\n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n  + c.f. 422: Duplicate Group Name",
+            "docs": "# Update Group [그룹 대시보드]\n\n새로운 그룹을 생성합니다.\n\n### Constraints\n- 그룹의 이름은 다른 그룹의 이름과 같을 수 없습니다.\n  + c.f. 422: Duplicate Group Name\n- Open Space의 정보는 업데이트할 수 없습니다.",
             "preReq": {
                 "runRequests": [
                     {
@@ -467,12 +473,12 @@
             "_id": "d62f2e3e-7a5c-4543-8eff-bb146cabde99",
             "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
             "containerId": "5cbf039a-6e9c-4321-93c2-e297a12b480e",
-            "name": "422: Protected Open Space",
+            "name": "403: Protected Open Space",
             "url": "",
             "method": "POST",
-            "sortNum": 50000,
+            "sortNum": 35000,
             "created": "2023-07-01T13:27:34.416Z",
-            "modified": "2023-07-01T13:32:03.254Z",
+            "modified": "2023-07-01T15:08:53.783Z",
             "headers": [],
             "params": [],
             "body": {
@@ -488,13 +494,58 @@
                     "type": "json-query",
                     "custom": "json.errors[0].extensions.originalError.statusCode",
                     "action": "equal",
-                    "value": "422"
+                    "value": "403"
                 },
                 {
                     "type": "json-query",
                     "custom": "json.errors[0].message",
                     "action": "equal",
                     "value": "Open space cannot be deleted"
+                }
+            ],
+            "preReq": {
+                "runRequests": [
+                    {
+                        "reqId": "1a62bc1b-fbff-4f01-bbb8-bbf08974ea80",
+                        "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+                        "triggerCondition": "run-always",
+                        "triggerValue": ""
+                    }
+                ]
+            }
+        },
+        {
+            "_id": "9631bc1c-c071-4512-9dc6-43267b8f9c78",
+            "colId": "089b01d8-96da-497e-8921-f5df86e4d23c",
+            "containerId": "2e6dd7d6-4110-4bd0-9138-660931d2a26d",
+            "name": "403: Protected Open Space",
+            "url": "",
+            "method": "POST",
+            "sortNum": 3750,
+            "created": "2023-07-01T15:05:20.179Z",
+            "modified": "2023-07-01T15:09:04.804Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "graphql",
+                "raw": "",
+                "form": [],
+                "graphql": {
+                    "query": "mutation Group {\n  updateGroup(\n    groupId: 1\n    input: {\n      groupName: \"Revised Group\",\n      description: \"Blah Blah\",\n      config: {\n        showOnList: true,\n        allowJoinFromSearch: true,\n        allowJoinWithURL: false\n        requireApprovalBeforeJoin: true\n      }\n    }\n  ) {\n    id\n    groupName\n    description\n    config\n  }\n}"
+                }
+            },
+            "tests": [
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].extensions.originalError.statusCode",
+                    "action": "equal",
+                    "value": "403"
+                },
+                {
+                    "type": "json-query",
+                    "custom": "json.errors[0].message",
+                    "action": "equal",
+                    "value": "Open space cannot be updated"
                 }
             ],
             "preReq": {

--- a/thunder-tests/collections/tc_col_codedang-admin-api.json
+++ b/thunder-tests/collections/tc_col_codedang-admin-api.json
@@ -23,7 +23,7 @@
             "name": "Get Groups (Admin)",
             "containerId": "fe52bede-3550-4899-9738-50719d9b04ef",
             "created": "2023-07-01T08:38:28.308Z",
-            "sortNum": 50000
+            "sortNum": 22500
         },
         {
             "_id": "771ab14a-f583-4a94-a34e-4f8e8b569d8b",

--- a/thunder-tests/collections/tc_col_codedang-admin-api.json
+++ b/thunder-tests/collections/tc_col_codedang-admin-api.json
@@ -66,7 +66,7 @@
             "method": "POST",
             "sortNum": 10000,
             "created": "2023-07-01T08:39:22.506Z",
-            "modified": "2023-07-01T15:12:37.712Z",
+            "modified": "2023-07-01T15:35:06.098Z",
             "headers": [],
             "params": [],
             "body": {
@@ -74,7 +74,7 @@
                 "raw": "",
                 "form": [],
                 "graphql": {
-                    "query": "query Group {\n  getGroups(cursor: 0, take: 3) {\n    id\n    groupName\n    description\n    config\n    memberNum\n  }\n}"
+                    "query": "query Group {\n  getGroups(take: 3) {\n    id\n    groupName\n    description\n    config\n    memberNum\n  }\n}"
                 }
             },
             "tests": [
@@ -115,7 +115,7 @@
                     "value": "3"
                 }
             ],
-            "docs": "# Get Groups [어드민 대시보드]\n\n모든 그룹의 목록을 가져옵니다.",
+            "docs": "# Get Groups [어드민 대시보드]\n\n모든 그룹의 목록을 가져옵니다.\n\n## Query\n\n- `cursor`: (optional) 가져올 아이템의 기준점으로, take 값에 따라 기준점의 앞뒤에 있는 아이템을 가져오게 됩니다. cursor 값은 항상 양수여야 하며, 값을 넘겨주지 않으면 자동으로 첫번째 아이템부터 반환됩니다.\n- `take`: 가져올 아이템의 개수를 지정합니다.",
             "preReq": {
                 "runRequests": [
                     {

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -5107,6 +5107,38 @@
                 }
             ],
             "docs": "# Get Clarifications by Contest\n\n파라미터로 주어진 group contest의 problem에 등록된 clarification의 목록을 불러옵니다.  "
+        },
+        {
+            "_id": "86d2ae24-54f0-4567-9a3c-a993ac915ad4",
+            "colId": "07dc2986-f7a6-4827-8ec2-cb288e3de5e7",
+            "containerId": "dcc8290a-fa46-4ad9-b9a1-f2f422fe2006",
+            "name": "Log In as Manager",
+            "url": "/auth/login",
+            "method": "POST",
+            "sortNum": 70000,
+            "created": "2023-07-01T01:32:45.988Z",
+            "modified": "2023-07-01T01:36:06.576Z",
+            "headers": [],
+            "params": [],
+            "body": {
+                "type": "json",
+                "raw": "{\n  \"username\": \"manager\",\n  \"password\": \"Managermanager\"\n}",
+                "form": []
+            },
+            "tests": [
+                {
+                    "type": "set-env-var",
+                    "custom": "header.authorization",
+                    "action": "setto",
+                    "value": "{{bearer_token}}"
+                },
+                {
+                    "type": "set-env-var",
+                    "custom": "cookie.refresh_token",
+                    "action": "setto",
+                    "value": "{{refresh_token}}"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
> Closes #170

### Description

admin 앱에서 사용될 Group CRUD API를 개발합니다.

### Additional context

- `RolesGuard`와 `GroupLeaderGuard`, `GroupMemberGuard` 사이에 존재하던 dependency를 제거하였습니다.
- admin 앱의 글로벌 가드로 `JwtAuthGuard` 및 `GroupLeaderGuard`를 설정해두었습니다.
- `RolesGuard`를 적용해야 할 경우, `@UseRolesGuard(role?)` 데코레이터를 사용합니다.
  + (데코레이터에 인자를 주지 않았을 때) 디폴트 role은 `Role.Admin`입니다.
  + 해당 데코레이터 **사용 시 `GroupLeaderGuard`의 적용은 해제**됩니다.
  + `RolesGuard`와 `GroupLeaderGuard`가 동시 사용되는 use case가 없고, 오히려 `RolesGuard` 적용 시 `GroupLeaderGuard`가 해제되어야만 동작하는 use case만 존재하기 때문에 이와 같이 구현하였습니다.
  + (또 하나로 뭉치지 않으면 핸들러 하나에 데코레이터만 네 개가 붙게 되니까요😱!)
  + TODO: 이에 따라 `@Roles(role)` 데코레이터가 필요하지 않아졌는데, client 앱의 admin controller에서 해당 데코레이터를 사용하고 있는 코드가 있어서, 해당 부분들이 admin 앱으로 모두 옮겨지면 삭제하겠습니다.  

*❗Added on 23.07.02.*
- Admin이 모든 그룹을 조회할 수 있는 `getGroups` 핸들러는 **Open Space를 포함한 모든 그룹의 목록**을 가져옵니다.
  + Open Space를 목록에서 제거하면, 프론트엔드에서 Admin 대시보드를 위해 너무 많은 페이지를 구현해야 할 것 같아 포함해두었습니다.
  + 추후 Open Space용(Admin 대시보드)과 Group용 페이지가 완전히 분리된다면 전체 그룹 목록에서 Open Space를 제외하도록 코드 수정이 필요합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
