### PR TITLE
feat(fe): create contest notice modal

### DIFF
--- a/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
@@ -53,7 +53,7 @@ const problemId = ref('')
       <TextEditor class="h-[360px] w-full" />
     </div>
     <div class="border-gray mt-10 flex justify-end gap-3 border-t py-5">
-      <Button class="text-sm font-normal capitalize" color="indigo">
+      <Button class="text-sm font-normal capitalize" color="gray-dark">
         cancel
       </Button>
       <Button class="text-sm font-normal capitalize">save</Button>

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
@@ -5,7 +5,7 @@ import Modal from '@/common/components/Molecule/Modal.vue'
 import TextEditor from '@/common/components/Organism/TextEditor.vue'
 import { ref } from 'vue'
 
-const props = defineProps<{
+defineProps<{
   toggle: boolean
   setToggle: (a: boolean) => void
 }>()
@@ -15,7 +15,7 @@ const problemId = ref('')
 
 <template>
   <Modal
-    :model-value="props.toggle"
+    :model-value="toggle"
     @update:model-value="
       () => {
         setToggle(toggle)

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
@@ -53,8 +53,10 @@ const problemId = ref('')
       <TextEditor class="h-[360px] w-full" />
     </div>
     <div class="border-gray mt-10 flex justify-end gap-3 border-t py-5">
-      <Button class="text-sm font-normal" color="indigo">cancel</Button>
-      <Button class="text-sm font-normal">save</Button>
+      <Button class="text-sm font-normal capitalize" color="indigo">
+        cancel
+      </Button>
+      <Button class="text-sm font-normal capitalize">save</Button>
     </div>
   </Modal>
 </template>

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/CreateNoticeModal.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import Button from '@/common/components/Atom/Button.vue'
+import InputItem from '@/common/components/Atom/InputItem.vue'
+import Modal from '@/common/components/Molecule/Modal.vue'
+import TextEditor from '@/common/components/Organism/TextEditor.vue'
+import { ref } from 'vue'
+
+const props = defineProps<{
+  toggle: boolean
+  setToggle: (a: boolean) => void
+}>()
+const title = ref('')
+const problemId = ref('')
+</script>
+
+<template>
+  <Modal
+    :model-value="props.toggle"
+    @update:model-value="
+      () => {
+        setToggle(toggle)
+      }
+    "
+  >
+    <div class="flex flex-col">
+      <h1 class="text-gray-dark text-2xl font-semibold">
+        Create Contest Notice
+      </h1>
+      <h2 class="text-gray-dark border-gray border-b py-5 font-semibold">
+        SKKU 프로그래밍 대회 - SKKUDING
+      </h2>
+      <div class="grid grid-cols-2 gap-5">
+        <div class="mt-6 flex-col">
+          <label class="w-20 text-lg font-bold">Title</label>
+          <InputItem
+            v-model="title"
+            required
+            placeholder="Title"
+            class="w-full"
+          />
+        </div>
+        <div class="mt-6 flex-col">
+          <label class="w-20 text-lg font-bold">Problem ID</label>
+          <InputItem
+            v-model="problemId"
+            class="w-full"
+            required
+            placeholder="Problem ID"
+          />
+        </div>
+      </div>
+      <h2 class="mt-8 text-lg font-bold">Content</h2>
+      <TextEditor class="h-[360px] w-full" />
+    </div>
+    <div class="border-gray mt-10 flex justify-end gap-3 border-t py-5">
+      <Button class="text-sm font-normal" color="indigo">cancel</Button>
+      <Button class="text-sm font-normal">save</Button>
+    </div>
+  </Modal>
+</template>

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
@@ -5,6 +5,7 @@ import PaginationTable from '@/common/components/Organism/PaginationTable.vue'
 import { ref, type Ref } from 'vue'
 import IconPlus from '~icons/fa/plus'
 import IconTrash from '~icons/fa/trash-o'
+import CreateNoticeModal from './CreateNoticeModal.vue'
 
 interface Row {
   id: string
@@ -16,6 +17,7 @@ interface Row {
 }
 
 const toggle = ref(false)
+const toggleNotice = ref(false)
 const problem: Ref<Row[]> = ref([
   {
     id: '1',
@@ -247,6 +249,14 @@ const tags = [
         </template>
       </PaginationTable>
     </Modal>
+    <CreateNoticeModal
+      :toggle="toggleNotice"
+      :set-toggle="
+        (a) => {
+          toggleNotice = !a
+        }
+      "
+    />
     <div class="border-gray border-b text-right text-lg font-semibold">
       SKKUDING
     </div>
@@ -328,7 +338,15 @@ const tags = [
     <div class="mt-16 flex justify-between">
       <h2 class="text-lg font-semibold">Notice List</h2>
       <div class="flex gap-3 text-sm">
-        <Button>+ Create</Button>
+        <Button
+          @click="
+            () => {
+              toggleNotice = true
+            }
+          "
+        >
+          + Create
+        </Button>
       </div>
     </div>
     <PaginationTable

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
@@ -16,8 +16,8 @@ interface Row {
   selected: boolean
 }
 
-const toggle = ref(false)
-const toggleNotice = ref(false)
+const showImportModal = ref(false)
+const showNoticeModal = ref(false)
 const problem: Ref<Row[]> = ref([
   {
     id: '1',
@@ -55,11 +55,11 @@ const tags = [
 <template>
   <div class="flex flex-col">
     <Modal
-      :model-value="toggle"
+      :model-value="showImportModal"
       class="max-w-3xl"
       @update:model-value="
         () => {
-          toggle = !toggle
+          showImportModal = !showImportModal
         }
       "
     >
@@ -250,10 +250,10 @@ const tags = [
       </PaginationTable>
     </Modal>
     <CreateNoticeModal
-      :toggle="toggleNotice"
+      :toggle="showNoticeModal"
       :set-toggle="
         (a) => {
-          toggleNotice = !a
+          showNoticeModal = !a
         }
       "
     />
@@ -272,7 +272,7 @@ const tags = [
         <Button
           @click="
             () => {
-              toggle = !toggle
+              showImportModal = !showImportModal
             }
           "
         >
@@ -341,7 +341,7 @@ const tags = [
         <Button
           @click="
             () => {
-              toggleNotice = true
+              showNoticeModal = true
             }
           "
         >

--- a/frontend/src/admin/pages/[groupId]/workbook/index.vue
+++ b/frontend/src/admin/pages/[groupId]/workbook/index.vue
@@ -93,7 +93,7 @@ const difficultyVisibleStat = ref(false)
       </template>
     </PaginationTable>
   </div>
-  <Modal v-model="show" class="mx-8 h-[96%] w-full">
+  <Modal v-model="show" class="mx-8 w-full">
     <div class="overflow-auto px-40">
       <div class="flex flex-col">
         <div class="mt-10">


### PR DESCRIPTION
### Description

![Screenshot 2023-07-11 at 7 44 42 PM](https://github.com/skkuding/codedang/assets/50468628/c83bfc39-b5d3-469d-a7d7-4d0e0c87ffbf)

group admin contest page의 contest 섹션에서 create 버튼을 누르면 뜨는 modal 구현

close #542 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/610"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

