### PR TITLE
fix(fe): fix sidebar bug

### DIFF
--- a/frontend/src/admin/pages/[groupId]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/index.vue
@@ -25,8 +25,6 @@ const groupUpdateTimeFormat = useDateFormat(
   groupUpdateTime,
   'YYYY.MM.DD HH:mm:ss'
 )
-const emits = defineEmits(['toggleGroup'])
-emits('toggleGroup', true)
 </script>
 
 <template>

--- a/frontend/src/admin/pages/index.vue
+++ b/frontend/src/admin/pages/index.vue
@@ -7,11 +7,11 @@ import { ref, computed } from 'vue'
 import IconLock from '~icons/bi/lock'
 import IconUnlock from '~icons/bi/unlock'
 import IconAngleRight from '~icons/fa6-solid/angle-right'
-import IconPlus from '~icons/fa6-solid/plus'
 
 type WorkBookItem = Record<string, string>
 const groupItems = [
   {
+    id: 1,
     href: '/admin/1',
     title: '초급반',
     scope: 'private',
@@ -25,7 +25,8 @@ const groupItems = [
     ]
   },
   {
-    href: '/',
+    id: 2,
+    href: '/admin/2',
     title: '중급반',
     scope: 'public',
     items: [
@@ -38,7 +39,8 @@ const groupItems = [
     ]
   },
   {
-    href: '/',
+    id: 3,
+    href: '/admin/3',
     title: '고급반',
     scope: 'private',
     items: [
@@ -160,8 +162,6 @@ const changeContest = (page: number) => {
 const changeWorkBook = (page: number) => {
   currentWorkBookP.value = page
 }
-const emits = defineEmits(['toggleGroup'])
-emits('toggleGroup', false)
 </script>
 
 <template>
@@ -176,8 +176,7 @@ emits('toggleGroup', false)
         }
       "
     >
-      <IconPlus />
-      Create
+      + Create
     </Button>
   </div>
   <div class="grid grid-cols-1 gap-8 md:grid-cols-2">

--- a/frontend/src/common/components/Organism/Sidebar.story.vue
+++ b/frontend/src/common/components/Organism/Sidebar.story.vue
@@ -8,7 +8,7 @@ import Sidebar from './Sidebar.vue'
       <Sidebar />
     </Variant>
     <Variant title="Group">
-      <Sidebar group color="blue" />
+      <Sidebar color="blue" />
     </Variant>
   </Story>
 </template>

--- a/frontend/src/common/components/Organism/Sidebar.vue
+++ b/frontend/src/common/components/Organism/Sidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import CodingPlatformLogo from '@/common/components/Atom/CodingPlatformLogo.vue'
-import { watch, computed } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import IconBox from '~icons/bi/box'
 import IconCode from '~icons/bi/code-square'
@@ -12,9 +12,14 @@ import IconUser from '~icons/fa6-regular/user'
 import IconBrain from '~icons/fluent/brain-circuit-24-regular'
 
 // TODO: get group name and color
-const props = defineProps<{
-  color?: 'blue' | 'gray' | 'white'
-}>()
+const props = withDefaults(
+  defineProps<{
+    color?: 'blue' | 'gray' | 'white'
+  }>(),
+  {
+    color: 'white'
+  }
+)
 
 const route = useRoute()
 
@@ -46,17 +51,8 @@ const groupItems = (id: number) => [
 
 const items = computed(() =>
   route.params.groupId
-    ? groupItems(parseInt(route.params.groupId[0]))
+    ? groupItems(parseInt(route.params.groupId as string))
     : commonItems
-)
-
-watch(
-  () => route.params.groupId,
-  () => {
-    route.params.groupId
-      ? groupItems(parseInt(route.params.groupId[0]))
-      : commonItems
-  }
 )
 </script>
 
@@ -70,9 +66,7 @@ watch(
     <div v-for="{ to, name, icon } in items" :key="name">
       <router-link
         class="flex items-center p-2 pl-10 font-medium hover:shadow"
-        :active-class="
-          colorMapper[props.color || 'default'] + ' border-l-8 !pl-8'
-        "
+        :active-class="colorMapper[color || 'default'] + ' border-l-8 !pl-8'"
         :to="to"
       >
         <component :is="icon" class="mr-2 h-4" />

--- a/frontend/src/common/components/Organism/Sidebar.vue
+++ b/frontend/src/common/components/Organism/Sidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import CodingPlatformLogo from '@/common/components/Atom/CodingPlatformLogo.vue'
-import { computed } from 'vue'
+import { watch, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import IconBox from '~icons/bi/box'
 import IconCode from '~icons/bi/code-square'
 import IconFile from '~icons/bi/file-text'
@@ -12,9 +13,10 @@ import IconBrain from '~icons/fluent/brain-circuit-24-regular'
 
 // TODO: get group name and color
 const props = defineProps<{
-  group?: boolean
   color?: 'blue' | 'gray' | 'white'
 }>()
+
+const route = useRoute()
 
 const colorMapper = {
   blue: 'border-l-blue',
@@ -31,15 +33,30 @@ const commonItems = [
   { to: '/admin/pool', name: 'Problem Pool', icon: IconBox }
 ]
 
+const groupItems = (id: number) => [
+  { to: `/admin/${id}`, name: 'SKKUDING', icon: IconBiHouse },
+  { to: `/admin/${id}/notice`, name: 'Notice', icon: IconFile },
+  { to: `/admin/${id}/contest`, name: 'Contest', icon: IconTrophy },
+  { to: `/admin/${id}/workbook`, name: 'Workbook', icon: IconBook },
+  { to: `/admin/${id}/problem`, name: 'Problem', icon: IconBrain },
+  { to: `/admin/${id}/pool`, name: 'Problem Pool', icon: IconBox },
+  { to: `/admin/${id}/member`, name: 'Member', icon: IconUser },
+  { to: `/admin/${id}/submission`, name: 'Submission', icon: IconCode }
+]
+
 const items = computed(() =>
-  props.group
-    ? [
-        { to: '/admin', name: 'SKKUDING', icon: IconBiHouse },
-        ...commonItems,
-        { to: '/admin/member', name: 'Member', icon: IconUser },
-        { to: '/admin/submission', name: 'Submission', icon: IconCode }
-      ]
+  route.params.groupId
+    ? groupItems(parseInt(route.params.groupId[0]))
     : commonItems
+)
+
+watch(
+  () => route.params.groupId,
+  () => {
+    route.params.groupId
+      ? groupItems(parseInt(route.params.groupId[0]))
+      : commonItems
+  }
 )
 </script>
 
@@ -53,7 +70,9 @@ const items = computed(() =>
     <div v-for="{ to, name, icon } in items" :key="name">
       <router-link
         class="flex items-center p-2 pl-10 font-medium hover:shadow"
-        :active-class="colorMapper[color || 'default'] + ' border-l-8 !pl-8'"
+        :active-class="
+          colorMapper[props.color || 'default'] + ' border-l-8 !pl-8'
+        "
         :to="to"
       >
         <component :is="icon" class="mr-2 h-4" />

--- a/frontend/src/common/components/Organism/Sidebar.vue
+++ b/frontend/src/common/components/Organism/Sidebar.vue
@@ -12,7 +12,7 @@ import IconUser from '~icons/fa6-regular/user'
 import IconBrain from '~icons/fluent/brain-circuit-24-regular'
 
 // TODO: get group name and color
-const props = withDefaults(
+withDefaults(
   defineProps<{
     color?: 'blue' | 'gray' | 'white'
   }>(),
@@ -66,7 +66,7 @@ const items = computed(() =>
     <div v-for="{ to, name, icon } in items" :key="name">
       <router-link
         class="flex items-center p-2 pl-10 font-medium hover:shadow"
-        :active-class="colorMapper[color || 'default'] + ' border-l-8 !pl-8'"
+        :active-class="colorMapper[color] + ' border-l-8 !pl-8'"
         :to="to"
       >
         <component :is="icon" class="mr-2 h-4" />

--- a/frontend/src/common/layouts/admin.vue
+++ b/frontend/src/common/layouts/admin.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import Sidebar from '../components/Organism/Sidebar.vue'
-
-const group = ref(false)
 </script>
 
 <template>
   <div class="flex w-full">
-    <Sidebar :group="group" class="fixed bottom-0 left-0 top-0 flex-none" />
+    <Sidebar class="fixed bottom-0 left-0 top-0 flex-none" />
     <main class="ml-48 w-[calc(100%-12rem)] flex-1 px-20 py-10">
-      <router-view @toggle-group="(value: boolean) => (group = value)" />
+      <router-view />
     </main>
   </div>
 </template>


### PR DESCRIPTION
### Description
group admin에서 사이드바를 클릭했을 때 잘못된 경로로 이동해서 이 부분을 수정했다.
close #606 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
원래는 toggle-group을 사용해서 group id를 넘겨주는 방식으로 구현할 예정이었다. 
그런데 admin에서 group card를 눌러서 group admin 으로 이동했을 때, 다시 뒤로 가기 버튼을 눌러 admin으로 돌아가면 group admin의 sidebar가 유지된다. 그래서 현재 url을 보고 group admin인 경우 해당 sidebar가 나오도록 했다.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/614"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

