### PR TITLE
fix: prevent modal closed on dragging

### DIFF
--- a/frontend/src/common/components/Molecule/Modal.vue
+++ b/frontend/src/common/components/Molecule/Modal.vue
@@ -24,7 +24,7 @@ defineOptions({ inheritAttrs: false })
     <div
       v-show="modelValue"
       class="fixed inset-0 z-40 flex h-full w-full items-center justify-center bg-black/25 p-5 backdrop-blur"
-      @click.self="$emit('update:modelValue', false)"
+      @mousedown.self="$emit('update:modelValue', false)"
     >
       <section
         class="relative max-h-[96%] overflow-y-auto rounded-lg bg-white p-10"

--- a/frontend/src/common/components/Organism/AuthModal.vue
+++ b/frontend/src/common/components/Organism/AuthModal.vue
@@ -40,18 +40,20 @@ const PasswordReset = defineAsyncComponent(() => import('./PasswordReset.vue'))
       leave-to-class="opacity-0"
       mode="out-in"
     >
-      <Login
-        v-if="modelValue === 'login'"
-        @to="(value) => $emit('update:modelValue', value)"
-      />
-      <Signup
-        v-else-if="modelValue === 'signup'"
-        @to="(value) => $emit('update:modelValue', value)"
-      />
-      <PasswordReset
-        v-else-if="modelValue === 'password'"
-        @to="(value) => $emit('update:modelValue', value)"
-      />
+      <KeepAlive>
+        <Login
+          v-if="modelValue === 'login'"
+          @to="(value) => $emit('update:modelValue', value)"
+        />
+        <Signup
+          v-else-if="modelValue === 'signup'"
+          @to="(value) => $emit('update:modelValue', value)"
+        />
+        <PasswordReset
+          v-else-if="modelValue === 'password'"
+          @to="(value) => $emit('update:modelValue', value)"
+        />
+      </KeepAlive>
     </transition>
   </Modal>
 </template>


### PR DESCRIPTION
### Description

Close #613

`@click` event 대신 `@mousedown` event를 이용해 클릭된 위치만 인식하도록 합니다.

### Additional Description

`KeepAlive` component로 입력 상태를 유지합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

