### PR TITLE
feat(be): modify get group api

### DIFF
--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -79,6 +79,7 @@ describe('GroupService', () => {
       //then
       expect(result).to.deep.equal({
         ...publicGroupDatas[1],
+        config: mockGroupData.config,
         leaders: ['manager']
       })
     })

--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -92,8 +92,10 @@ describe('GroupService', () => {
         group: {
           id: mockGroup.id,
           groupName: mockGroup.groupName,
-          description: mockGroup.description
-        }
+          description: mockGroup.description,
+          config: mockGroup.config
+        },
+        isGroupLeader: true
       })
 
       //when
@@ -103,7 +105,9 @@ describe('GroupService', () => {
       expect(result).to.deep.equal({
         id: mockGroup.id,
         groupName: mockGroup.groupName,
-        description: mockGroup.description
+        description: mockGroup.description,
+        config: mockGroup.config,
+        isGroupLeader: true
       })
     })
 

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -31,9 +31,11 @@ export class GroupService {
           select: {
             id: true,
             groupName: true,
-            description: true
+            description: true,
+            config: true
           }
-        }
+        },
+        isGroupLeader: true
       }
     })
 
@@ -51,6 +53,7 @@ export class GroupService {
           groupName: true,
           description: true,
           userGroup: true,
+          config: true,
           createdBy: {
             select: {
               username: true
@@ -64,12 +67,13 @@ export class GroupService {
         id: group.id,
         groupName: group.groupName,
         description: group.description,
+        config: group.config,
         createdBy: group.createdBy.username,
         memberNum: group.userGroup.length,
         leaders: await this.getGroupLeaders(groupId)
       }
     } else {
-      return isJoined.group
+      return { ...isJoined.group, isGroupLeader: isJoined.isGroupLeader }
     }
   }
 

--- a/backend/apps/client/src/group/interface/group-data.interface.ts
+++ b/backend/apps/client/src/group/interface/group-data.interface.ts
@@ -1,9 +1,12 @@
+import { Prisma } from '@prisma/client'
+
 export interface GroupData {
   id: number
   groupName: string
   description: string
   memberNum: number
   createdBy: string
+  config?: Prisma.JsonValue
   leaders?: string[]
   isGroupLeader?: boolean
 }

--- a/backend/apps/client/src/group/mock/group.mock.ts
+++ b/backend/apps/client/src/group/mock/group.mock.ts
@@ -176,6 +176,12 @@ export const mockGroupData = {
   id: 2,
   groupName: 'mock public group 2',
   description: 'mock public group with approval',
+  config: {
+    showOnList: true,
+    allowJoinFromSearch: true,
+    allowJoinWithURL: false,
+    requireApprovalBeforeJoin: false
+  },
   createdBy: {
     username: 'manager'
   },

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -4074,7 +4074,7 @@
             "method": "GET",
             "sortNum": 590000,
             "created": "2023-02-21T07:00:09.919Z",
-            "modified": "2023-04-28T12:59:36.577Z",
+            "modified": "2023-07-13T19:53:55.989Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4119,6 +4119,18 @@
                     "custom": "",
                     "action": "notcontains",
                     "value": "\"leaders\""
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "\"config\""
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "\"isGroupLeader\""
                 }
             ],
             "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
@@ -4365,7 +4377,7 @@
             "method": "GET",
             "sortNum": 592500,
             "created": "2023-02-21T17:23:38.437Z",
-            "modified": "2023-04-28T12:43:10.918Z",
+            "modified": "2023-07-13T19:53:53.475Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4410,6 +4422,12 @@
                     "custom": "",
                     "action": "contains",
                     "value": "\"leaders\""
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "\"config\""
                 }
             ],
             "docs": "# Get group\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n}\n\n```",

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -4074,7 +4074,7 @@
             "method": "GET",
             "sortNum": 590000,
             "created": "2023-02-21T07:00:09.919Z",
-            "modified": "2023-07-13T19:53:55.989Z",
+            "modified": "2023-07-13T20:10:37.344Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4133,7 +4133,7 @@
                     "value": "\"isGroupLeader\""
                 }
             ],
-            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
+            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  config: Json\n  isGroupLeader: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  config: Json\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
             "preReq": {
                 "runRequests": [
                     {
@@ -4377,7 +4377,7 @@
             "method": "GET",
             "sortNum": 592500,
             "created": "2023-02-21T17:23:38.437Z",
-            "modified": "2023-07-13T19:53:53.475Z",
+            "modified": "2023-07-13T20:10:33.795Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4430,7 +4430,7 @@
                     "value": "\"config\""
                 }
             ],
-            "docs": "# Get group\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n}\n\n```",
+            "docs": "# Get group\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  config: Json\n  isGroupLeader: boolean\n}\n\n```",
             "preReq": {
                 "runRequests": [
                     {


### PR DESCRIPTION
### Description

Closes #629 

`getGroup`에서 현재 그룹에 가입되어 있는 상태라면 `config` 와 `isGroupLeader`를,
그룹에 가입되어 있지 않은 상태라면 `config` 를 추가적으로 반환하도록 합니다.


### Additional context



---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/630"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

