### PR TITLE
chore: add eslint rules for vue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     ],
     '@typescript-eslint/consistent-type-imports': 'warn',
     '@typescript-eslint/no-import-type-side-effects': 'error',
-    '@typescript-eslint/no-inferrable-types': 'warn'
+    '@typescript-eslint/no-inferrable-types': 'warn',
+    'func-style': ['error', 'expression']
   }
 }

--- a/backend/apps/admin/src/main.ts
+++ b/backend/apps/admin/src/main.ts
@@ -1,8 +1,9 @@
 import { NestFactory } from '@nestjs/core'
 import { AdminModule } from './admin.module'
 
-async function bootstrap() {
+const bootstrap = async () => {
   const app = await NestFactory.create(AdminModule)
   await app.listen(3000)
 }
+
 bootstrap()

--- a/backend/apps/client/src/main.ts
+++ b/backend/apps/client/src/main.ts
@@ -4,7 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import * as cookieParser from 'cookie-parser'
 import { AppModule } from './app.module'
 
-async function bootstrap() {
+const bootstrap = async () => {
   const app = await NestFactory.create(AppModule)
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }))
   app.use(cookieParser())
@@ -25,4 +25,5 @@ async function bootstrap() {
 
   await app.listen(4000)
 }
+
 bootstrap()

--- a/backend/mocha-fixture.ts
+++ b/backend/mocha-fixture.ts
@@ -1,6 +1,6 @@
 import { use } from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 
-export async function mochaGlobalSetup() {
+export const mochaGlobalSetup = async () => {
   use(chaiAsPromised)
 }

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
       }
     ],
     'vue/padding-line-between-blocks': 'warn',
+    'vue/prefer-true-attribute-shorthand': 'warn',
     'vue/multi-word-component-names': 'off'
   }
 }

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -13,6 +13,22 @@ module.exports = {
   extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
   rules: {
     'vue/no-empty-component-block': 'error',
+    'vue/no-undef-components': [
+      'error',
+      {
+        ignorePatterns: [
+          'Transition',
+          'TransitionGroup',
+          'KeepAlive',
+          'Teleport',
+          'Suspense',
+          'Story',
+          'Variant',
+          'RouterView',
+          'RouterLink'
+        ]
+      }
+    ],
     'vue/multi-word-component-names': 'off'
   }
 }

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
         ]
       }
     ],
+    'vue/padding-line-between-blocks': 'warn',
     'vue/multi-word-component-names': 'off'
   }
 }

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
       { ignores: ['/^n-/'] }
     ],
     'vue/define-props-declaration': 'error',
+    'vue/html-self-closing': ['error', { html: { void: 'always' } }], // compatibility with prettier
     'vue/no-empty-component-block': 'error',
     'vue/no-undef-components': [
       'error',

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -13,6 +13,11 @@ module.exports = {
   extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
   rules: {
     'vue/component-api-style': ['error', ['script-setup']],
+    'vue/component-name-in-template-casing': [
+      'error',
+      'PascalCase',
+      { ignores: ['/^n-/'] }
+    ],
     'vue/no-empty-component-block': 'error',
     'vue/no-undef-components': [
       'error',

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
   rules: {
+    'vue/component-api-style': ['error', ['script-setup']],
     'vue/no-empty-component-block': 'error',
     'vue/no-undef-components': [
       'error',

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
       'PascalCase',
       { ignores: ['/^n-/'] }
     ],
+    'vue/define-props-declaration': 'error',
     'vue/no-empty-component-block': 'error',
     'vue/no-undef-components': [
       'error',

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     ],
     'vue/padding-line-between-blocks': 'warn',
     'vue/prefer-true-attribute-shorthand': 'warn',
+    'vue/require-emit-validator': 'error',
     'vue/multi-word-component-names': 'off'
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,7 +27,7 @@ useAuthStore().reissue()
 
 <template>
   <n-config-provider :theme-overrides="themeOverrides">
-    <router-view />
+    <RouterView />
     <Toast />
   </n-config-provider>
 </template>

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/CreatePorblemModal.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/CreatePorblemModal.vue
@@ -96,14 +96,14 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
           <textarea
             v-model="data.inputDesc"
             class="border-gray focus:border-green focus:ring-green mt-3 h-[120px] w-full resize-none rounded-lg outline-none focus:ring-1"
-          ></textarea>
+          />
         </div>
         <div>
           <label class="text-lg font-bold">Output Description</label>
           <textarea
             v-model="data.outputDesc"
             class="border-gray focus:border-green focus:ring-green mt-3 h-[120px] w-full resize-none rounded-lg outline-none focus:ring-1"
-          ></textarea>
+          />
         </div>
       </div>
       <div class="grid grid-cols-2 gap-5">
@@ -149,7 +149,7 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
               }
             "
           >
-            <IconTrash></IconTrash>
+            <IconTrash />
             Delete
           </Button>
         </div>
@@ -162,7 +162,7 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
               <textarea
                 v-model="item.input"
                 class="border-gray focus:border-green focus:ring-green mt-3 h-[180px] w-full resize-none rounded-lg outline-none focus:ring-1"
-              ></textarea>
+              />
             </div>
             <div>
               <label class="text-gray-dark text-lg font-bold">
@@ -171,7 +171,7 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
               <textarea
                 v-model="item.output"
                 class="border-gray focus:border-green focus:ring-green mt-3 h-[180px] w-full resize-none rounded-lg outline-none focus:ring-1"
-              ></textarea>
+              />
             </div>
           </div>
         </div>
@@ -208,7 +208,7 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
               }
             "
           >
-            <IconTrash></IconTrash>
+            <IconTrash />
             Delete
           </Button>
         </div>
@@ -221,7 +221,7 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
               <textarea
                 v-model="item.input"
                 class="border-gray focus:border-green focus:ring-green mt-3 h-[180px] w-full resize-none rounded-lg outline-none focus:ring-1"
-              ></textarea>
+              />
             </div>
             <div>
               <label class="text-gray-dark text-lg font-bold">
@@ -230,7 +230,7 @@ const languageItems = ['C', 'C++', 'Python3', 'Java']
               <textarea
                 v-model="item.output"
                 class="border-gray focus:border-green focus:ring-green mt-3 h-[180px] w-full resize-none rounded-lg outline-none focus:ring-1"
-              ></textarea>
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
@@ -220,7 +220,7 @@ const tags = [
         :items="problem.filter((item) => item.selected)"
         placeholder="keywords"
         :number-of-pages="3"
-        :no-search-bar="true"
+        no-search-bar
       >
         <template #level="{ row }: { row: Row }">
           <div class="flex items-center gap-2">
@@ -343,7 +343,7 @@ const tags = [
       ]"
       placeholder="keywords"
       :number-of-pages="3"
-      :no-search-bar="true"
+      no-search-bar
     >
       <template #_delete="{}">
         <div class="flex items-center gap-2">
@@ -406,7 +406,7 @@ const tags = [
       ]"
       placeholder="keywords"
       :number-of-pages="3"
-      :no-search-bar="true"
+      no-search-bar
     >
       <template #_delete="{}">
         <div class="flex items-center gap-2">

--- a/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/contest/[id]/index.vue
@@ -245,7 +245,7 @@ const tags = [
                 }
               "
             >
-              <IconTrash></IconTrash>
+              <IconTrash />
             </Button>
           </div>
         </template>
@@ -348,7 +348,7 @@ const tags = [
       <template #_delete="{}">
         <div class="flex items-center gap-2">
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconTrash></IconTrash>
+            <IconTrash />
           </Button>
         </div>
       </template>
@@ -411,7 +411,7 @@ const tags = [
       <template #_delete="{}">
         <div class="flex items-center gap-2">
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconTrash></IconTrash>
+            <IconTrash />
           </Button>
         </div>
       </template>

--- a/frontend/src/admin/pages/[groupId]/member/index.vue
+++ b/frontend/src/admin/pages/[groupId]/member/index.vue
@@ -56,8 +56,8 @@ import IconTrash from '~icons/fa/trash-o'
       ]"
       placeholder="keywords"
       :number-of-pages="3"
-      :no-search-bar="true"
-      :no-pagination="true"
+      no-search-bar
+      no-pagination
     >
       <template #_option="{}">
         <div class="flex items-center gap-2">

--- a/frontend/src/admin/pages/[groupId]/member/index.vue
+++ b/frontend/src/admin/pages/[groupId]/member/index.vue
@@ -11,7 +11,7 @@ import IconTrash from '~icons/fa/trash-o'
 <template>
   <div class="flex flex-col">
     <div class="text-right text-lg font-semibold">SKKUDING</div>
-    <div class="bg-gray h-[1px]"></div>
+    <div class="bg-gray h-[1px]" />
     <div class="mt-10">
       <h1 class="text-gray-dark mr-6 inline text-2xl font-semibold">Member</h1>
       <Button>+ Register</Button>
@@ -62,10 +62,10 @@ import IconTrash from '~icons/fa/trash-o'
       <template #_option="{}">
         <div class="flex items-center gap-2">
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconDown></IconDown>
+            <IconDown />
           </Button>
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconTrash></IconTrash>
+            <IconTrash />
           </Button>
         </div>
       </template>
@@ -114,10 +114,10 @@ import IconTrash from '~icons/fa/trash-o'
       <template #_option="{}">
         <div class="flex items-center gap-2">
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconUp></IconUp>
+            <IconUp />
           </Button>
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconTrash></IconTrash>
+            <IconTrash />
           </Button>
         </div>
       </template>
@@ -166,10 +166,10 @@ import IconTrash from '~icons/fa/trash-o'
       <template #_option="{}">
         <div class="flex items-center gap-2">
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconCheck></IconCheck>
+            <IconCheck />
           </Button>
           <Button class="flex h-[32px] w-[32px] items-center justify-center">
-            <IconClose></IconClose>
+            <IconClose />
           </Button>
         </div>
       </template>

--- a/frontend/src/admin/pages/[groupId]/notice/index.vue
+++ b/frontend/src/admin/pages/[groupId]/notice/index.vue
@@ -24,7 +24,7 @@ const noticeFixedStat = ref(false)
 <template>
   <div class="flex flex-col">
     <div class="text-right text-lg font-semibold">SKKUDING</div>
-    <div class="bg-gray h-[1px]"></div>
+    <div class="bg-gray h-[1px]" />
     <div class="mt-10">
       <h1 class="text-gray-dark mr-6 inline text-2xl font-semibold">Notice</h1>
       <Button @click="show = true">+ Create</Button>
@@ -102,7 +102,7 @@ const noticeFixedStat = ref(false)
             Create Notice
           </h1>
         </div>
-        <div class="bg-gray mt-2 h-[1px]"></div>
+        <div class="bg-gray mt-2 h-[1px]" />
         <div class="mt-10 flex">
           <div class="w-20 text-lg font-bold">Group</div>
           <div class="flex items-center">NPC 중급반</div>
@@ -124,7 +124,7 @@ const noticeFixedStat = ref(false)
           <Switch v-model="noticeVisibleStat" class="mr-8" label="Visible" />
           <Switch v-model="noticeFixedStat" label="Fixed" />
         </div>
-        <div class="bg-gray mt-10 h-[1px]"></div>
+        <div class="bg-gray mt-10 h-[1px]" />
         <div class="mt-8 flex justify-end">
           <div class="flex">
             <Button

--- a/frontend/src/admin/pages/[groupId]/submission/SubmissionDetailModal.vue
+++ b/frontend/src/admin/pages/[groupId]/submission/SubmissionDetailModal.vue
@@ -22,7 +22,7 @@ int main() {
   <Modal
     class="bg-default w-full max-w-[70%]"
     :model-value="toggle"
-    :dark="true"
+    dark
     @update:model-value="
       () => {
         setToggle(toggle)
@@ -58,7 +58,7 @@ int main() {
           <h3 class="text-lg font-bold">Source Code</h3>
           <p class="text-gray">(612 Bytes)</p>
         </div>
-        <CodeEditor :model-value="code" lang="cpp" :lock="true" />
+        <CodeEditor :model-value="code" lang="cpp" lock />
         <PaginationTable
           :fields="[
             {
@@ -98,8 +98,8 @@ int main() {
           ]"
           mode="dark"
           :number-of-pages="3"
-          :no-search-bar="true"
-          :no-pagination="true"
+          no-search-bar
+          no-pagination
           class="pointer-events-none"
         >
           <template #result="{ row }">

--- a/frontend/src/admin/pages/[groupId]/workbook/[id]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/workbook/[id]/index.vue
@@ -7,7 +7,7 @@ import IconTrash from '~icons/fa/trash-o'
 <template>
   <div class="flex flex-col">
     <div class="text-right text-lg font-semibold">SKKUDING</div>
-    <div class="bg-gray h-[1px]"></div>
+    <div class="bg-gray h-[1px]" />
     <div class="mt-10">
       <h1 class="text-gray-dark mr-6 inline text-2xl font-semibold">
         1주차 과제

--- a/frontend/src/admin/pages/[groupId]/workbook/[id]/index.vue
+++ b/frontend/src/admin/pages/[groupId]/workbook/[id]/index.vue
@@ -74,8 +74,8 @@ import IconTrash from '~icons/fa/trash-o'
       ]"
       placeholder="keywords"
       :number-of-pages="3"
-      :no-search-bar="true"
-      :no-pagination="true"
+      no-search-bar
+      no-pagination
     >
       <template #delete="{}">
         <Button class="flex h-[32px] w-[32px] items-center justify-center">

--- a/frontend/src/admin/pages/[groupId]/workbook/index.vue
+++ b/frontend/src/admin/pages/[groupId]/workbook/index.vue
@@ -24,7 +24,7 @@ const difficultyVisibleStat = ref(false)
 <template>
   <div class="flex flex-col">
     <div class="text-right text-lg font-semibold">SKKUDING</div>
-    <div class="bg-gray h-[1px]"></div>
+    <div class="bg-gray h-[1px]" />
     <div class="mt-10">
       <h1 class="text-gray-dark mr-6 inline text-2xl font-semibold">
         Workbook List
@@ -101,7 +101,7 @@ const difficultyVisibleStat = ref(false)
             Create Workbook
           </h1>
         </div>
-        <div class="bg-gray mt-2 h-[1px]"></div>
+        <div class="bg-gray mt-2 h-[1px]" />
         <div class="mt-10 flex">
           <div class="w-20 text-lg font-bold">Group</div>
           <div class="flex items-center">NPC 중급반</div>
@@ -127,7 +127,7 @@ const difficultyVisibleStat = ref(false)
             label="Problem Difficulty Visible"
           />
         </div>
-        <div class="bg-gray mt-10 h-[1px]"></div>
+        <div class="bg-gray mt-10 h-[1px]" />
         <div class="mt-8 flex justify-end">
           <div class="flex">
             <Button

--- a/frontend/src/admin/pages/contest.vue
+++ b/frontend/src/admin/pages/contest.vue
@@ -119,6 +119,7 @@ const data = ref(
     />
   </div>
 </template>
+
 <route lang="yaml">
 meta:
   layout: admin

--- a/frontend/src/admin/pages/index.vue
+++ b/frontend/src/admin/pages/index.vue
@@ -211,7 +211,7 @@ const changeWorkBook = (page: number) => {
     :number-of-pages="pageNumContest"
     @row-clicked="(data: WorkBookItem) => $router.push('/contest/' + data.id)"
     @change-page="changeContest"
-  ></PaginationTable>
+  />
   <PageTitle text="Ongoing Workbook" class="mb-4 mt-10" />
   <PaginationTable
     class="mb-4"
@@ -221,7 +221,7 @@ const changeWorkBook = (page: number) => {
     :number-of-pages="pageNumWorkBook"
     @row-clicked="(data: WorkBookItem) => $router.push('workbook/' + data.id)"
     @change-page="changeWorkBook"
-  ></PaginationTable>
+  />
 </template>
 
 <route lang="yaml">

--- a/frontend/src/admin/pages/index.vue
+++ b/frontend/src/admin/pages/index.vue
@@ -223,6 +223,7 @@ const changeWorkBook = (page: number) => {
     @change-page="changeWorkBook"
   ></PaginationTable>
 </template>
+
 <route lang="yaml">
 meta:
   layout: admin

--- a/frontend/src/admin/pages/notice.vue
+++ b/frontend/src/admin/pages/notice.vue
@@ -112,6 +112,7 @@ const data = ref(
     />
   </div>
 </template>
+
 <route lang="yaml">
 meta:
   layout: admin

--- a/frontend/src/admin/pages/pool.vue
+++ b/frontend/src/admin/pages/pool.vue
@@ -157,6 +157,7 @@ const data = ref(
     />
   </div>
 </template>
+
 <route lang="yaml">
 meta:
   layout: admin

--- a/frontend/src/admin/pages/problem.vue
+++ b/frontend/src/admin/pages/problem.vue
@@ -136,6 +136,7 @@ const data = ref(
     />
   </div>
 </template>
+
 <route lang="yaml">
 meta:
   layout: admin

--- a/frontend/src/admin/pages/workbook.vue
+++ b/frontend/src/admin/pages/workbook.vue
@@ -112,6 +112,7 @@ const data = ref(
     />
   </div>
 </template>
+
 <route lang="yaml">
 meta:
   layout: admin

--- a/frontend/src/common/components/Atom/BoxTitle.story.vue
+++ b/frontend/src/common/components/Atom/BoxTitle.story.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BoxTitle from './BoxTitle.vue'
 </script>
+
 <template>
   <Story :layout="{ type: 'grid', width: '100%' }">
     <Variant title="default">

--- a/frontend/src/common/components/Atom/BoxTitle.vue
+++ b/frontend/src/common/components/Atom/BoxTitle.vue
@@ -3,10 +3,10 @@
     class="bg-gradient-to-r from-[#1A3E51] via-[#112835] to-[#1A3E51] py-12 text-center"
   >
     <div class="text-3xl text-white">
-      <slot name="title"></slot>
+      <slot name="title" />
     </div>
     <div class="mt-4 text-xl text-white">
-      <slot name="subtitle"></slot>
+      <slot name="subtitle" />
     </div>
   </div>
 </template>

--- a/frontend/src/common/components/Molecule/ButtonGroup.vue
+++ b/frontend/src/common/components/Molecule/ButtonGroup.vue
@@ -3,6 +3,7 @@
     <slot />
   </div>
 </template>
+
 <style>
 .btn-group > button:not(:last-child) {
   border-top-right-radius: 0;

--- a/frontend/src/common/components/Molecule/Card.vue
+++ b/frontend/src/common/components/Molecule/Card.vue
@@ -12,15 +12,15 @@ defineProps<{
 
 <template>
   <section class="border-gray/25 w-full rounded-lg border-2 p-5 shadow-xl">
-    <router-link :to="href" class="mb-4 flex justify-between text-xl font-bold">
+    <RouterLink :to="href" class="mb-4 flex justify-between text-xl font-bold">
       <span class="flex items-center">
         <slot name="title" />
       </span>
       <slot name="titleIcon" />
-    </router-link>
+    </RouterLink>
     <div class="flex flex-col gap-1">
       <template v-for="(item, index) in items">
-        <router-link
+        <RouterLink
           v-if="item.href"
           :key="item.title"
           :to="item.href"
@@ -29,7 +29,7 @@ defineProps<{
           <span><slot name="icon" :item="item.state" /></span>
           <span class="ml-2 mr-auto">{{ item.title }}</span>
           <span class="text-right">{{ item.date }}</span>
-        </router-link>
+        </RouterLink>
         <div v-else :key="index" class="flex items-center rounded p-1">
           <span><slot name="icon" :item="item.state" /></span>
           <span class="ml-2 mr-auto">{{ item.title }}</span>

--- a/frontend/src/common/components/Organism/Header.vue
+++ b/frontend/src/common/components/Organism/Header.vue
@@ -24,13 +24,13 @@ const modalContent = ref<'login' | 'signup' | 'password' | 'close'>('close')
   <OnClickOutside @trigger="isMenuOpen = false">
     <header class="border-b-gray grid h-14 place-items-center border-b px-8">
       <div class="flex w-full max-w-7xl items-center justify-between">
-        <router-link to="/">
+        <RouterLink to="/">
           <SignatureLogo
             class="w-40 cursor-pointer active:opacity-40 md:hover:opacity-60"
           />
-        </router-link>
+        </RouterLink>
         <nav class="text-text-title hidden gap-4 md:flex">
-          <router-link
+          <RouterLink
             v-for="{ to, name } in [
               { to: '/notice', name: 'Notice' },
               { to: '/contest', name: 'Contest' },
@@ -46,7 +46,7 @@ const modalContent = ref<'login' | 'signup' | 'password' | 'close'>('close')
             }"
           >
             {{ name }}
-          </router-link>
+          </RouterLink>
         </nav>
         <transition
           enter-active-class="transition-opacity duration-300"
@@ -103,7 +103,7 @@ const modalContent = ref<'login' | 'signup' | 'password' | 'close'>('close')
           class="absolute inset-x-0 top-14 z-30 flex w-full flex-col items-center justify-center gap-6 overflow-hidden bg-white/75 py-8 shadow-lg backdrop-blur md:hidden"
         >
           <nav class="text-text-title flex flex-col items-center gap-2">
-            <router-link
+            <RouterLink
               v-for="{ to, name } in [
                 { to: '/notice', name: 'Notice' },
                 { to: '/contest', name: 'Contest' },
@@ -116,7 +116,7 @@ const modalContent = ref<'login' | 'signup' | 'password' | 'close'>('close')
               :to="to"
             >
               {{ name }}
-            </router-link>
+            </RouterLink>
           </nav>
           <transition
             enter-active-class="transition-opacity duration-300"

--- a/frontend/src/common/components/Organism/PaginationTable.vue
+++ b/frontend/src/common/components/Organism/PaginationTable.vue
@@ -82,14 +82,14 @@ watch(currentPage, (value) => {
 <template>
   <div>
     <div class="mb-5 flex justify-end">
-      <slot name="option"></slot>
+      <slot name="option" />
       <SearchBar
         v-if="!noSearchBar"
         :placeholder="placeholder"
         class="ml-5"
         :class="!mode || mode === 'light' ? '' : 'text-white'"
         @search="search"
-      ></SearchBar>
+      />
     </div>
     <div class="min-w-full overflow-x-scroll md:overflow-x-auto">
       <table

--- a/frontend/src/common/components/Organism/Sidebar.vue
+++ b/frontend/src/common/components/Organism/Sidebar.vue
@@ -58,20 +58,20 @@ const items = computed(() =>
 
 <template>
   <div class="bg-gray-light text-gray-dark h-screen w-48 overflow-auto">
-    <router-link to="/admin" class="align-center flex justify-center">
+    <RouterLink to="/admin" class="align-center flex justify-center">
       <CodingPlatformLogo class="my-8 w-32" />
-    </router-link>
+    </RouterLink>
 
     <hr class="bg-gray h-0.5 border-none opacity-25" />
     <div v-for="{ to, name, icon } in items" :key="name">
-      <router-link
+      <RouterLink
         class="flex items-center p-2 pl-10 font-medium hover:shadow"
         :active-class="colorMapper[color] + ' border-l-8 !pl-8'"
         :to="to"
       >
         <component :is="icon" class="mr-2 h-4" />
         {{ name }}
-      </router-link>
+      </RouterLink>
       <hr class="bg-gray h-0.5 border-none opacity-25" />
     </div>
   </div>

--- a/frontend/src/common/components/Organism/TextEditor.vue
+++ b/frontend/src/common/components/Organism/TextEditor.vue
@@ -172,5 +172,5 @@ const editor = useEditor({
       </Button>
     </ButtonGroup>
   </div>
-  <editor-content :editor="editor" class="p-0.5" />
+  <EditorContent :editor="editor" class="p-0.5" />
 </template>

--- a/frontend/src/common/layouts/admin.vue
+++ b/frontend/src/common/layouts/admin.vue
@@ -6,7 +6,7 @@ import Sidebar from '../components/Organism/Sidebar.vue'
   <div class="flex w-full">
     <Sidebar class="fixed bottom-0 left-0 top-0 flex-none" />
     <main class="ml-48 w-[calc(100%-12rem)] flex-1 px-20 py-10">
-      <router-view />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/frontend/src/common/layouts/default.vue
+++ b/frontend/src/common/layouts/default.vue
@@ -39,7 +39,7 @@ const BoxTitle = defineAsyncComponent(
     </template>
   </BoxTitle>
   <main class="mx-auto mb-20 w-4/5 max-w-7xl">
-    <router-view />
+    <RouterView />
   </main>
   <Footer />
 </template>

--- a/frontend/src/common/layouts/empty.vue
+++ b/frontend/src/common/layouts/empty.vue
@@ -1,1 +1,1 @@
-<template><router-view /></template>
+<template><RouterView /></template>

--- a/frontend/src/user/contest/components/Top.vue
+++ b/frontend/src/user/contest/components/Top.vue
@@ -5,5 +5,5 @@ defineProps<{
 </script>
 
 <template>
-  <div v-dompurify-html="text" class="prose lg:prose-xl mt-10"></div>
+  <div v-dompurify-html="text" class="prose lg:prose-xl mt-10" />
 </template>

--- a/frontend/src/user/group/components/Member.vue
+++ b/frontend/src/user/group/components/Member.vue
@@ -10,9 +10,9 @@ defineProps<{
 }>()
 
 const isModalVisible = ref(false)
-function close() {
-  isModalVisible.value = false
-}
+
+const close = () => (isModalVisible.value = false)
+
 // TODO : Yes 눌렀을때 API 호출하도록 변경 필요
 
 // dummy data

--- a/frontend/src/user/group/components/Notice.vue
+++ b/frontend/src/user/group/components/Notice.vue
@@ -83,6 +83,6 @@ const clickRow = (row: Item) => {
       @search="filter"
       @change-page="changeItems"
       @row-clicked="clickRow"
-    ></PaginationTable>
+    />
   </div>
 </template>

--- a/frontend/src/user/group/components/Problem.vue
+++ b/frontend/src/user/group/components/Problem.vue
@@ -47,6 +47,6 @@ const [totalPages, changePage] = [
       @search="filter"
       @change-page="changePage"
       @row-clicked="({ id }) => $router.push('/problem/' + id)"
-    ></PaginationTable>
+    />
   </div>
 </template>

--- a/frontend/src/user/group/pages/index.vue
+++ b/frontend/src/user/group/pages/index.vue
@@ -24,7 +24,7 @@ const groupDescription = ref('')
       <InputItem v-model="invitationCode" placeholder="Invitation Code" />
       <Button class="py-2"><IconPaperPlane /></Button>
     </div>
-    <GroupListSection title="My Group" :is-my-group="true" />
+    <GroupListSection title="My Group" is-my-group />
     <div class="flex justify-end">
       <Button class="py-2" @click="createModal = true">+ Create Group</Button>
     </div>

--- a/frontend/src/user/group/pages/index.vue
+++ b/frontend/src/user/group/pages/index.vue
@@ -33,7 +33,7 @@ const groupDescription = ref('')
   <Modal v-model="createModal" class="shadow-md">
     <div class="flex flex-col px-8 py-12">
       <h1 class="text-gray-dark mb-2 text-2xl font-bold">Create Group</h1>
-      <div class="bg-gray-light mb-6 h-[1px] w-full"></div>
+      <div class="bg-gray-light mb-6 h-[1px] w-full" />
       <div class="mb-6">
         <div class="mb-2 flex">
           <h2 class="mr-60 text-lg font-semibold">Group Name</h2>

--- a/frontend/src/user/home/components/Carousel.story.vue
+++ b/frontend/src/user/home/components/Carousel.story.vue
@@ -12,6 +12,6 @@ const slides = [
 
 <template>
   <Story>
-    <Carousel :slides="slides"></Carousel>
+    <Carousel :slides="slides" />
   </Story>
 </template>

--- a/frontend/src/user/home/pages/index.vue
+++ b/frontend/src/user/home/pages/index.vue
@@ -74,12 +74,12 @@ axios.get('api/contest').then((res) => {
         <h2 class="ml-2">Current/Upcoming Contests</h2>
       </template>
       <template #titleIcon>
-        <router-link
+        <RouterLink
           to="/"
           class="cursor-pointer hover:opacity-50 active:opacity-30"
         >
           <IconBars />
-        </router-link>
+        </RouterLink>
       </template>
       <template #icon="item">
         <IconEllipsis v-if="item.item === 'ongoing'" />

--- a/frontend/src/user/notice/composables/notice.ts
+++ b/frontend/src/user/notice/composables/notice.ts
@@ -23,7 +23,7 @@ export interface NoticeItem {
 
 export const useNotice = () => {
   const notices = ref<NoticeItem[]>([])
-  async function getNoticeList(numberOfPages: number) {
+  const getNoticeList = async (numberOfPages: number) => {
     const res = await axios.get('/api/notice', {
       params:
         numberOfPages == 1
@@ -51,7 +51,7 @@ export const useNotice = () => {
     })
   }
 
-  async function getNotice(id: number) {
+  const getNotice = async (id: number) => {
     const res = await axios.get('/api/notice/' + id)
 
     res.data.current.createTime = useDateFormat(

--- a/frontend/src/user/notice/pages/[id].vue
+++ b/frontend/src/user/notice/pages/[id].vue
@@ -41,10 +41,10 @@ const field: Field[] = [
 <template>
   <div class="mt-10">
     <div class="mb-4 flex justify-end">
-      <router-link to="/notice" class="flex items-center">
+      <RouterLink to="/notice" class="flex items-center">
         <IconBars />
         <div class="ml-2 hidden sm:block">List</div>
-      </router-link>
+      </RouterLink>
     </div>
     <div
       class="bg-gray-light border-gray flex w-full justify-between border-y p-4"

--- a/frontend/src/user/notice/pages/[id].vue
+++ b/frontend/src/user/notice/pages/[id].vue
@@ -63,7 +63,7 @@ const field: Field[] = [
     <div
       v-dompurify-html="currentNotice?.content"
       class="prose min-h-[400px] w-full max-w-full break-all p-4"
-    ></div>
+    />
     <PaginationTable
       no-header
       no-pagination

--- a/frontend/src/user/problem/pages/[id]/index.vue
+++ b/frontend/src/user/problem/pages/[id]/index.vue
@@ -90,20 +90,17 @@ onMounted(async () => {
       :style="{ width: x + 'px' }"
     >
       <h1 class="text-xl font-bold">{{ problem?.title }}</h1>
-      <div
-        v-dompurify-html="problem?.description"
-        class="prose text-white"
-      ></div>
+      <div v-dompurify-html="problem?.description" class="prose text-white" />
       <h2 class="mt-4 text-lg font-bold">Input</h2>
       <div
         v-dompurify-html="problem?.inputDescription"
         class="prose text-white"
-      ></div>
+      />
       <h2 class="mt-4 text-lg font-bold">Output</h2>
       <div
         v-dompurify-html="problem?.outputDescription"
         class="prose text-white"
-      ></div>
+      />
       <div v-for="(sample, index) in samples" :key="index">
         <div class="flex items-end justify-between">
           <h2 class="mt-4 text-lg font-bold">Sample Input {{ index + 1 }}</h2>

--- a/frontend/src/user/workbook/composables/workbook.ts
+++ b/frontend/src/user/workbook/composables/workbook.ts
@@ -14,7 +14,7 @@ export interface Workbook {
   }[]
 }
 
-export function useWorkbook() {
+export const useWorkbook = async () => {
   // TODO: workbookList에서 마지막 item 있는지 판별하기
   const containLastItem = ref(false)
   const workbookList = ref<Workbook[]>([])

--- a/frontend/src/user/workbook/composables/workbook.ts
+++ b/frontend/src/user/workbook/composables/workbook.ts
@@ -14,7 +14,7 @@ export interface Workbook {
   }[]
 }
 
-export const useWorkbook = async () => {
+export const useWorkbook = () => {
   // TODO: workbookList에서 마지막 item 있는지 판별하기
   const containLastItem = ref(false)
   const workbookList = ref<Workbook[]>([])


### PR DESCRIPTION
### Description

Close #654
ESLint rule을 몇 가지 추가합니다.

- vue/no-undef-components: 정의된 component만 template에 사용할 수 있습니다.
- vue/component-api-style: `script setup`만 script style로 가능합니다.
- vue/component-name-in-template-casing: template 내 component을 PascalCase로 통일합니다.
- vue/define-props-declaration: prop 정의 시 defineProps를 type-based로 사용합니다.
- vue/padding-line-between-blocks: `<script>`, `<template>` 등 block 사이에 한 줄을 띄우도록 합니다.
- vue/prefer-true-attribute-shorthand: boolean props의 경우 `:foo="true"` 대신 `foo` 형식으로 shorthand를 사용합니다.
- vue/require-emit-validator: defineEmit을 type-based로 사용합니다.
- vue/html-self-closing: html tag를 self close로 통일합니다.
- func-style: 화살표 함수만 사용합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/657"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

