### PR TITLE
feat(be): modify getGroup and getGroups API

### DIFF
--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -107,7 +107,7 @@ describe('GroupService', () => {
         id: mockGroup.id,
         groupName: mockGroup.groupName,
         description: mockGroup.description,
-        config: mockGroup.config['allowJoinFromSearch'],
+        allowJoinFromSearch: mockGroup.config['allowJoinFromSearch'],
         isGroupLeader: true,
         isJoined: true
       })

--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -79,7 +79,6 @@ describe('GroupService', () => {
       //then
       expect(result).to.deep.equal({
         ...publicGroupDatas[1],
-        config: mockGroupData.config,
         leaders: ['manager']
       })
     })
@@ -93,8 +92,7 @@ describe('GroupService', () => {
         group: {
           id: mockGroup.id,
           groupName: mockGroup.groupName,
-          description: mockGroup.description,
-          config: mockGroup.config
+          description: mockGroup.description
         },
         isGroupLeader: true
       })
@@ -107,7 +105,6 @@ describe('GroupService', () => {
         id: mockGroup.id,
         groupName: mockGroup.groupName,
         description: mockGroup.description,
-        config: mockGroup.config,
         isGroupLeader: true
       })
     })
@@ -139,7 +136,9 @@ describe('GroupService', () => {
       const result = await service.getGroups(cursor, take)
 
       //then
-      expect(result).to.deep.equal([publicGroupDatas[1]])
+      expect(result).to.deep.equal([
+        { ...publicGroupDatas[1], allowJoinFromSearch: true }
+      ])
     })
   })
 

--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -79,6 +79,7 @@ describe('GroupService', () => {
       //then
       expect(result).to.deep.equal({
         ...publicGroupDatas[1],
+        allowJoinFromSearch: true,
         leaders: ['manager'],
         isJoined: false
       })
@@ -93,8 +94,7 @@ describe('GroupService', () => {
         group: {
           id: mockGroup.id,
           groupName: mockGroup.groupName,
-          description: mockGroup.description,
-          config: mockGroup.config
+          description: mockGroup.description
         },
         isGroupLeader: true
       })
@@ -107,7 +107,6 @@ describe('GroupService', () => {
         id: mockGroup.id,
         groupName: mockGroup.groupName,
         description: mockGroup.description,
-        allowJoinFromSearch: mockGroup.config['allowJoinFromSearch'],
         isGroupLeader: true,
         isJoined: true
       })

--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -79,7 +79,8 @@ describe('GroupService', () => {
       //then
       expect(result).to.deep.equal({
         ...publicGroupDatas[1],
-        leaders: ['manager']
+        leaders: ['manager'],
+        isJoined: false
       })
     })
 
@@ -92,7 +93,8 @@ describe('GroupService', () => {
         group: {
           id: mockGroup.id,
           groupName: mockGroup.groupName,
-          description: mockGroup.description
+          description: mockGroup.description,
+          config: mockGroup.config
         },
         isGroupLeader: true
       })
@@ -105,7 +107,9 @@ describe('GroupService', () => {
         id: mockGroup.id,
         groupName: mockGroup.groupName,
         description: mockGroup.description,
-        isGroupLeader: true
+        config: mockGroup.config['allowJoinFromSearch'],
+        isGroupLeader: true,
+        isJoined: true
       })
     })
 
@@ -136,9 +140,7 @@ describe('GroupService', () => {
       const result = await service.getGroups(cursor, take)
 
       //then
-      expect(result).to.deep.equal([
-        { ...publicGroupDatas[1], allowJoinFromSearch: true }
-      ])
+      expect(result).to.deep.equal([publicGroupDatas[1]])
     })
   })
 

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -43,7 +43,7 @@ export class GroupService {
         where: {
           id: groupId,
           config: {
-            path: ['allowJoinFromSearch'],
+            path: ['showOnList'],
             equals: true
           }
         },

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -52,6 +52,7 @@ export class GroupService {
           groupName: true,
           description: true,
           userGroup: true,
+          config: true,
           createdBy: {
             select: {
               username: true
@@ -65,12 +66,18 @@ export class GroupService {
         id: group.id,
         groupName: group.groupName,
         description: group.description,
+        allowJoinFromSearch: group.config['allowJoinFromSearch'],
         createdBy: group.createdBy.username,
         memberNum: group.userGroup.length,
-        leaders: await this.getGroupLeaders(groupId)
+        leaders: await this.getGroupLeaders(groupId),
+        isJoined: false
       }
     } else {
-      return { ...isJoined.group, isGroupLeader: isJoined.isGroupLeader }
+      return {
+        ...isJoined.group,
+        isGroupLeader: isJoined.isGroupLeader,
+        isJoined: true
+      }
     }
   }
 
@@ -138,8 +145,7 @@ export class GroupService {
           id: true,
           groupName: true,
           description: true,
-          userGroup: true,
-          config: true
+          userGroup: true
         }
       })
     ).map((group) => {
@@ -148,8 +154,7 @@ export class GroupService {
         groupName: group.groupName,
         description: group.description,
         createdBy: group.createdBy.username,
-        memberNum: group.userGroup.length,
-        allowJoinFromSearch: group.config['allowJoinFromSearch']
+        memberNum: group.userGroup.length
       }
     })
 

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -52,12 +52,7 @@ export class GroupService {
           groupName: true,
           description: true,
           userGroup: true,
-          config: true,
-          createdBy: {
-            select: {
-              username: true
-            }
-          }
+          config: true
         },
         rejectOnNotFound: () => new EntityNotExistException('group')
       })
@@ -67,7 +62,6 @@ export class GroupService {
         groupName: group.groupName,
         description: group.description,
         allowJoinFromSearch: group.config['allowJoinFromSearch'],
-        createdBy: group.createdBy.username,
         memberNum: group.userGroup.length,
         leaders: await this.getGroupLeaders(groupId),
         isJoined: false
@@ -137,11 +131,6 @@ export class GroupService {
           }
         },
         select: {
-          createdBy: {
-            select: {
-              username: true
-            }
-          },
           id: true,
           groupName: true,
           description: true,
@@ -153,7 +142,6 @@ export class GroupService {
         id: group.id,
         groupName: group.groupName,
         description: group.description,
-        createdBy: group.createdBy.username,
         memberNum: group.userGroup.length
       }
     })
@@ -173,11 +161,6 @@ export class GroupService {
         select: {
           group: {
             select: {
-              createdBy: {
-                select: {
-                  username: true
-                }
-              },
               id: true,
               groupName: true,
               description: true,
@@ -193,7 +176,6 @@ export class GroupService {
         groupName: userGroup.group.groupName,
         description: userGroup.group.description,
         memberNum: userGroup.group.userGroup.length,
-        createdBy: userGroup.group.createdBy.username,
         isGroupLeader: userGroup.isGroupLeader
       }
     })

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -31,8 +31,7 @@ export class GroupService {
           select: {
             id: true,
             groupName: true,
-            description: true,
-            config: true
+            description: true
           }
         },
         isGroupLeader: true
@@ -53,7 +52,6 @@ export class GroupService {
           groupName: true,
           description: true,
           userGroup: true,
-          config: true,
           createdBy: {
             select: {
               username: true
@@ -67,7 +65,6 @@ export class GroupService {
         id: group.id,
         groupName: group.groupName,
         description: group.description,
-        config: group.config,
         createdBy: group.createdBy.username,
         memberNum: group.userGroup.length,
         leaders: await this.getGroupLeaders(groupId)

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -138,7 +138,8 @@ export class GroupService {
           id: true,
           groupName: true,
           description: true,
-          userGroup: true
+          userGroup: true,
+          config: true
         }
       })
     ).map((group) => {
@@ -147,7 +148,8 @@ export class GroupService {
         groupName: group.groupName,
         description: group.description,
         createdBy: group.createdBy.username,
-        memberNum: group.userGroup.length
+        memberNum: group.userGroup.length,
+        allowJoinFromSearch: group.config['allowJoinFromSearch']
       }
     })
 

--- a/backend/apps/client/src/group/interface/group-data.interface.ts
+++ b/backend/apps/client/src/group/interface/group-data.interface.ts
@@ -3,7 +3,6 @@ export interface GroupData {
   groupName: string
   description: string
   memberNum: number
-  createdBy: string
   allowJoinFromSearch?: boolean
   leaders?: string[]
   isGroupLeader?: boolean

--- a/backend/apps/client/src/group/interface/group-data.interface.ts
+++ b/backend/apps/client/src/group/interface/group-data.interface.ts
@@ -1,12 +1,10 @@
-import type { Prisma } from '@prisma/client'
-
 export interface GroupData {
   id: number
   groupName: string
   description: string
   memberNum: number
   createdBy: string
-  config?: Prisma.JsonValue
+  allowJoinFromSearch?: boolean
   leaders?: string[]
   isGroupLeader?: boolean
 }

--- a/backend/apps/client/src/group/interface/group-data.interface.ts
+++ b/backend/apps/client/src/group/interface/group-data.interface.ts
@@ -7,4 +7,5 @@ export interface GroupData {
   allowJoinFromSearch?: boolean
   leaders?: string[]
   isGroupLeader?: boolean
+  isJoined?: boolean
 }

--- a/backend/apps/client/src/group/mock/group.mock.ts
+++ b/backend/apps/client/src/group/mock/group.mock.ts
@@ -160,14 +160,12 @@ export const publicGroupDatas: GroupData[] = [
     id: 1,
     groupName: 'mock public group',
     description: 'mock public group with no approval',
-    createdBy: 'manager',
     memberNum: 2
   },
   {
     id: 2,
     groupName: 'mock public group 2',
     description: 'mock public group with approval',
-    createdBy: 'manager',
     memberNum: 2
   }
 ]

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -4439,7 +4439,7 @@
             "method": "GET",
             "sortNum": 575000,
             "created": "2023-02-28T03:58:46.391Z",
-            "modified": "2023-04-28T12:22:22.515Z",
+            "modified": "2023-07-20T12:42:25.857Z",
             "headers": [],
             "params": [
                 {
@@ -4473,7 +4473,7 @@
                     "value": "4"
                 }
             ],
-            "docs": "# Get groups\n\n### URL\nGET /group <br><br>\n\n### Query String\n|#|name|type|description|\n|-|--|--|--|\n|1|cursor|number?|전달하지 않을경우 처음부터 {take} 만큼 불러옵니다.|\n|2|take|number|한 번에 불러올 group의 개수|\n\n<br>\n\n### Description\n공개로 설정된 그룹 들의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   createdBy: String\n   memberNum: Number\n} []\n```",
+            "docs": "# Get groups\n\n### URL\nGET /group <br><br>\n\n### Query String\n|#|name|type|description|\n|-|--|--|--|\n|1|cursor|number?|전달하지 않을경우 처음부터 {take} 만큼 불러옵니다.|\n|2|take|number|한 번에 불러올 group의 개수|\n\n<br>\n\n### Description\n공개로 설정된 그룹 들의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   createdBy: String\n   memberNum: Number\n   allowJoinFromSearch: Boolean\n} []\n```",
             "preReq": {
                 "runRequests": [
                     {

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -4074,7 +4074,7 @@
             "method": "GET",
             "sortNum": 590000,
             "created": "2023-02-21T07:00:09.919Z",
-            "modified": "2023-07-13T20:10:37.344Z",
+            "modified": "2023-07-20T12:07:42.122Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4124,16 +4124,10 @@
                     "type": "res-body",
                     "custom": "",
                     "action": "contains",
-                    "value": "\"config\""
-                },
-                {
-                    "type": "res-body",
-                    "custom": "",
-                    "action": "contains",
                     "value": "\"isGroupLeader\""
                 }
             ],
-            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  config: Json\n  isGroupLeader: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  config: Json\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
+            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
             "preReq": {
                 "runRequests": [
                     {
@@ -4377,7 +4371,7 @@
             "method": "GET",
             "sortNum": 592500,
             "created": "2023-02-21T17:23:38.437Z",
-            "modified": "2023-07-13T20:10:33.795Z",
+            "modified": "2023-07-20T12:08:01.070Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4422,15 +4416,9 @@
                     "custom": "",
                     "action": "contains",
                     "value": "\"leaders\""
-                },
-                {
-                    "type": "res-body",
-                    "custom": "",
-                    "action": "contains",
-                    "value": "\"config\""
                 }
             ],
-            "docs": "# Get group\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  config: Json\n  isGroupLeader: boolean\n}\n\n```",
+            "docs": "# Get group\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n}\n\n```",
             "preReq": {
                 "runRequests": [
                     {

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -4006,7 +4006,7 @@
             "method": "GET",
             "sortNum": 580000,
             "created": "2023-02-21T06:36:54.399Z",
-            "modified": "2023-06-24T09:02:30.579Z",
+            "modified": "2023-07-25T12:44:50.484Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4038,12 +4038,6 @@
                     "type": "res-body",
                     "custom": "",
                     "action": "contains",
-                    "value": "createdBy"
-                },
-                {
-                    "type": "res-body",
-                    "custom": "",
-                    "action": "contains",
                     "value": "memberNum"
                 },
                 {
@@ -4053,7 +4047,7 @@
                     "value": "isGroupLeader"
                 }
             ],
-            "docs": "# Get joined groups\n\n### URL\nGET /group/joined <br><br>\n\n### Description\n가입한 그룹의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   memberNum: Number\n   createdBy: String\n   isGroupLeader: Boolean\n} []\n```",
+            "docs": "# Get joined groups\n\n### URL\nGET /group/joined <br><br>\n\n### Description\n가입한 그룹의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   memberNum: Number\n   isGroupLeader: Boolean\n} []\n```",
             "preReq": {
                 "runRequests": [
                     {
@@ -4074,7 +4068,7 @@
             "method": "GET",
             "sortNum": 590000,
             "created": "2023-02-21T07:00:09.919Z",
-            "modified": "2023-07-24T14:38:43.122Z",
+            "modified": "2023-07-25T12:38:07.558Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4125,9 +4119,15 @@
                     "custom": "",
                     "action": "contains",
                     "value": "\"isGroupLeader\""
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "\"isJoined\""
                 }
             ],
-            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
+            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  memberNum: Number\n  leaders: String[]\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
             "preReq": {
                 "runRequests": [
                     {
@@ -4371,7 +4371,7 @@
             "method": "GET",
             "sortNum": 592500,
             "created": "2023-02-21T17:23:38.437Z",
-            "modified": "2023-07-24T14:41:23.885Z",
+            "modified": "2023-07-25T12:38:16.391Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4416,9 +4416,15 @@
                     "custom": "",
                     "action": "contains",
                     "value": "\"leaders\""
+                },
+                {
+                    "type": "res-body",
+                    "custom": "",
+                    "action": "contains",
+                    "value": "\"isJoined\""
                 }
             ],
-            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
+            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  memberNum: Number\n  leaders: String[]\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
             "preReq": {
                 "runRequests": [
                     {
@@ -4439,7 +4445,7 @@
             "method": "GET",
             "sortNum": 575000,
             "created": "2023-02-28T03:58:46.391Z",
-            "modified": "2023-07-24T14:37:39.087Z",
+            "modified": "2023-07-25T12:44:18.961Z",
             "headers": [],
             "params": [
                 {
@@ -4473,7 +4479,7 @@
                     "value": "4"
                 }
             ],
-            "docs": "# Get groups\n\n### URL\nGET /group <br><br>\n\n### Query String\n|#|name|type|description|\n|-|--|--|--|\n|1|cursor|number?|전달하지 않을경우 처음부터 {take} 만큼 불러옵니다.|\n|2|take|number|한 번에 불러올 group의 개수|\n\n<br>\n\n### Description\n공개로 설정된 그룹 들의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   createdBy: String\n   memberNum: Number\n} []\n```",
+            "docs": "# Get groups\n\n### URL\nGET /group <br><br>\n\n### Query String\n|#|name|type|description|\n|-|--|--|--|\n|1|cursor|number?|전달하지 않을경우 처음부터 {take} 만큼 불러옵니다.|\n|2|take|number|한 번에 불러올 group의 개수|\n\n<br>\n\n### Description\n공개로 설정된 그룹 들의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   memberNum: Number\n} []\n```",
             "preReq": {
                 "runRequests": [
                     {

--- a/thunder-tests/collections/tc_col_codedang-client-api.json
+++ b/thunder-tests/collections/tc_col_codedang-client-api.json
@@ -4074,7 +4074,7 @@
             "method": "GET",
             "sortNum": 590000,
             "created": "2023-02-21T07:00:09.919Z",
-            "modified": "2023-07-20T12:07:42.122Z",
+            "modified": "2023-07-24T14:38:43.122Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4127,7 +4127,7 @@
                     "value": "\"isGroupLeader\""
                 }
             ],
-            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
+            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
             "preReq": {
                 "runRequests": [
                     {
@@ -4371,7 +4371,7 @@
             "method": "GET",
             "sortNum": 592500,
             "created": "2023-02-21T17:23:38.437Z",
-            "modified": "2023-07-20T12:08:01.070Z",
+            "modified": "2023-07-24T14:41:23.885Z",
             "headers": [],
             "params": [],
             "tests": [
@@ -4418,7 +4418,7 @@
                     "value": "\"leaders\""
                 }
             ],
-            "docs": "# Get group\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n}\n\n```",
+            "docs": "# Get group\n\n### Notice\n이 메서드에는 유저의 그룹 가입 여부에 따른 2개의 Success Cases 및 Response Types들이 존재합니다.<br><br>\n\n### URL\nGET /group/{groupId}<br><br>\n\n### Description\n그룹의 id가 {groupId}인 그룹의 정보를 불러옵니다.<br><br>\n\n### Response Type (Joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  isGroupLeader: boolean\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Response Type (Not joined group)\n```typscript\n{\n  id: Number\n  groupName: String\n  description: String\n  createdBy: String\n  memberNum: Number\n  leaders: String[]\n  isJoined: boolean\n}\n\n```\n<br>\n\n### Success Cases\n**Joined group**: `가입한` 그룹의 정보를 요청하는 경우<br>\n**Not Joined group**: `가입하지 않은` 그룹의 정보를 요청하는 경우\n<br><br>",
             "preReq": {
                 "runRequests": [
                     {
@@ -4439,7 +4439,7 @@
             "method": "GET",
             "sortNum": 575000,
             "created": "2023-02-28T03:58:46.391Z",
-            "modified": "2023-07-20T12:42:25.857Z",
+            "modified": "2023-07-24T14:37:39.087Z",
             "headers": [],
             "params": [
                 {
@@ -4473,7 +4473,7 @@
                     "value": "4"
                 }
             ],
-            "docs": "# Get groups\n\n### URL\nGET /group <br><br>\n\n### Query String\n|#|name|type|description|\n|-|--|--|--|\n|1|cursor|number?|전달하지 않을경우 처음부터 {take} 만큼 불러옵니다.|\n|2|take|number|한 번에 불러올 group의 개수|\n\n<br>\n\n### Description\n공개로 설정된 그룹 들의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   createdBy: String\n   memberNum: Number\n   allowJoinFromSearch: Boolean\n} []\n```",
+            "docs": "# Get groups\n\n### URL\nGET /group <br><br>\n\n### Query String\n|#|name|type|description|\n|-|--|--|--|\n|1|cursor|number?|전달하지 않을경우 처음부터 {take} 만큼 불러옵니다.|\n|2|take|number|한 번에 불러올 group의 개수|\n\n<br>\n\n### Description\n공개로 설정된 그룹 들의 목록을 불러옵니다.<br><br>\n\n### Response Type\n```typscript\n{\n   id: Number\n   groupName: String\n   description: String\n   createdBy: String\n   memberNum: Number\n} []\n```",
             "preReq": {
                 "runRequests": [
                     {


### PR DESCRIPTION
> Closes #658 
### Description

기존에 `GetGroup`에서 유저가 가입되지 않은 그룹에 대해서`config`를 반환하였지만,
`config` 전체가 아닌, 그 중에서 `allowJoinFromSearch` 여부를 반환해 groupJoinModal에서 join button을 띄울 수 있도록 합니다.
또한, `GetGroup` 에서 유저가 가입되지 않은 그룹에 대해 반환할때, `showOnList`가 `true` 인 그룹에 대해서만 정보를 Return할 수 있도록 했습니다. (기존에는 `allowFromSearch`가 `true` 인 그룹에 대해서 반환하였으나, `allowFromSearch`가 `false`인 그룹도 모달창을 띄울 수 있도록 수정하였습니다.)

또한, `GetGroup` api 에서 `isJoined` 필드를 추가했습니다. (그룹에 가입되어 있다면 `isJoined:true`, 가입되어 있지 않다면 `isJoined:false`를 반환합니다.)

++) `getGroup`, `getGroups`, `getJoinedGroups` 에서 `createdBy` field를 제거하였습니다.

### Additional context

config 에서는 4개의 옵션이 있습니다.
그중 `showOnList`, `requireApprovalBeforeJoin` 은 backend단에서 처리하기때문에 보여줄 필요가 없어서 제외하였습니다.
마찬가지로 `allowJoinWithURL` 또한 지금단계에서는 필요없는 정보라고 판단해 `allowJoinFromSearch` 만을 반환하도록 수정하였습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/659"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

