### PR TITLE
fix: use acm certificate only

### DIFF
--- a/infra/modules/codedang-infra/cloudfront.tf
+++ b/infra/modules/codedang-infra/cloudfront.tf
@@ -96,9 +96,8 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
-    acm_certificate_arn            = aws_acm_certificate_validation.main.certificate_arn # Certificate for codedang.com
-    ssl_support_method             = "sni-only"
+    acm_certificate_arn = aws_acm_certificate_validation.main.certificate_arn # Certificate for codedang.com
+    ssl_support_method  = "sni-only"
   }
 
   # Redirect non-root path to root path (need for SPA)


### PR DESCRIPTION
### Description

Cloudfront의 SSL certificate로 codedang.com 전용 certificate만 사용합니다.

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/672"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

