### PR TITLE
feat(fe): change card design in a home page

### DIFF
--- a/frontend/src/common/components/Molecule/NewCard.vue
+++ b/frontend/src/common/components/Molecule/NewCard.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+}>()
+</script>
+
+<template>
+  <div class="w-full rounded-lg border border-slate-50 p-5 text-slate-600">
+    <h2 class="border-b border-slate-50 pb-3 text-xl font-bold capitalize">
+      {{ title }}
+    </h2>
+    <div>
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/user/home/components/ContestItem.vue
+++ b/frontend/src/user/home/components/ContestItem.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { useTimeAgo, useIntervalFn } from '@vueuse/core'
+import { NProgress } from 'naive-ui'
+import { ref } from 'vue'
+
+const props = defineProps<{
+  title: string
+  startTime: string
+  endTime: string
+  state: string
+}>()
+
+const percentage = ref(0)
+
+useIntervalFn(() => {
+  const now = Date.now()
+  const start = new Date(props.startTime).getTime()
+  const end = new Date(props.endTime).getTime()
+  if (now < start) {
+    percentage.value = 0
+  } else if (now > end) {
+    percentage.value = 100
+  } else {
+    percentage.value = ((now - start) / (end - start)) * 100
+  }
+}, 1000)
+
+const timeAgo = useTimeAgo(
+  props.state === 'ongoing' ? props.endTime : props.startTime
+)
+</script>
+
+<template>
+  <div
+    class="flex flex-wrap justify-between gap-2 border-b border-slate-50 py-5 last:border-none last:pb-0"
+  >
+    <div class="flex items-center gap-2">
+      <p>
+        {{ title }}
+      </p>
+      <div
+        :class="`${
+          state === 'ongoing' ? 'bg-green' : 'bg-yellow'
+        } h-3 w-3 shrink-0 rounded-full`"
+      />
+    </div>
+    <p class="shrink-0 text-right text-sm text-slate-300">
+      {{ `${state === 'ongoing' ? 'Ends in ' : 'Start in'} ${timeAgo}` }}
+    </p>
+    <div class="flex w-full gap-5">
+      <NProgress
+        v-if="state === 'ongoing'"
+        :percentage="percentage"
+        color="#8DC63F"
+        type="line"
+        :height="10"
+        :show-indicator="false"
+        class="mt-2"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/src/user/home/components/ContestItem.vue
+++ b/frontend/src/user/home/components/ContestItem.vue
@@ -8,21 +8,26 @@ const props = defineProps<{
   startTime: string
   endTime: string
   state: string
+  href: string
 }>()
 
-const percentage = ref(0)
-
-useIntervalFn(() => {
+const getPercentage = () => {
   const now = Date.now()
   const start = new Date(props.startTime).getTime()
   const end = new Date(props.endTime).getTime()
   if (now < start) {
-    percentage.value = 0
+    return 0
   } else if (now > end) {
-    percentage.value = 100
+    return 100
   } else {
-    percentage.value = ((now - start) / (end - start)) * 100
+    return ((now - start) / (end - start)) * 100
   }
+}
+
+const percentage = ref(getPercentage())
+
+useIntervalFn(() => {
+  percentage.value = getPercentage()
 }, 1000)
 
 const timeAgo = useTimeAgo(
@@ -35,9 +40,9 @@ const timeAgo = useTimeAgo(
     class="flex flex-wrap justify-between gap-2 border-b border-slate-50 py-5 last:border-none last:pb-0"
   >
     <div class="flex items-center gap-2">
-      <p>
+      <RouterLink :to="href">
         {{ title }}
-      </p>
+      </RouterLink>
       <div
         :class="`${
           state === 'ongoing' ? 'bg-green' : 'bg-yellow'
@@ -47,16 +52,14 @@ const timeAgo = useTimeAgo(
     <p class="shrink-0 text-right text-sm text-slate-300">
       {{ `${state === 'ongoing' ? 'Ends in ' : 'Start in'} ${timeAgo}` }}
     </p>
-    <div class="flex w-full gap-5">
-      <NProgress
-        v-if="state === 'ongoing'"
-        :percentage="percentage"
-        color="#8DC63F"
-        type="line"
-        :height="10"
-        :show-indicator="false"
-        class="mt-2"
-      />
-    </div>
+    <NProgress
+      v-if="state === 'ongoing'"
+      :percentage="percentage"
+      color="#8DC63F"
+      type="line"
+      :height="10"
+      :show-indicator="false"
+      class="mt-2"
+    />
   </div>
 </template>

--- a/frontend/src/user/home/pages/index.vue
+++ b/frontend/src/user/home/pages/index.vue
@@ -104,7 +104,9 @@ axios.get('api/contest').then((res) => {
         :key="index"
         class="g border-b border-slate-50 py-5 last:border-none last:pb-0"
       >
-        <p>{{ item.title }}</p>
+        <RouterLink :to="item.href">
+          {{ item.title }}
+        </RouterLink>
         <p class="text-gray mt-1 text-sm">
           {{ item.date }}
         </p>
@@ -118,6 +120,7 @@ axios.get('api/contest').then((res) => {
         :start-time="item.startTime"
         :end-time="item.endTime"
         :state="item.state"
+        :href="item.href"
       />
     </NewCard>
   </div>

--- a/frontend/src/user/home/pages/index.vue
+++ b/frontend/src/user/home/pages/index.vue
@@ -2,29 +2,31 @@
 import dummyImg from '@/common/assets/dummy.png'
 import GithubLogo from '@/common/assets/github.svg'
 import SkkudingLogo from '@/common/assets/skkudingLogo.png'
-import Card from '@/common/components/Molecule/Card.vue'
+import NewCard from '@/common/components/Molecule/NewCard.vue'
 import type { Contest } from '@/user/contest/pages/index.vue'
 import Carousel from '@/user/home/components/Carousel.vue'
 import type { NoticeItem } from '@/user/notice/composables/notice'
 import { useDateFormat } from '@vueuse/core'
 import axios from 'axios'
 import { ref } from 'vue'
-import IconAngleRight from '~icons/fa6-solid/angle-right'
-import IconBars from '~icons/fa6-solid/bars'
-import IconCalendar from '~icons/fa6-solid/calendar'
-import IconInfo from '~icons/fa6-solid/circle-info'
-import IconEllipsis from '~icons/fa6-solid/ellipsis'
-import IconMedal from '~icons/fa6-solid/medal'
+import ContestItem from '../components/ContestItem.vue'
 
 interface Post {
   title: string
-  date: string
   href: string
-  state?: string
+  date: string
+}
+
+interface ContestPost {
+  title: string
+  href: string
+  state: string
+  startTime: string
+  endTime: string
 }
 
 const notices = ref<Post[]>([])
-const contest = ref<Post[]>([])
+const contest = ref<ContestPost[]>([])
 
 axios
   .get('/api/notice', {
@@ -42,7 +44,8 @@ axios.get('api/contest').then((res) => {
   res.data.ongoing.map((element: Contest) => {
     contest.value.push({
       title: element.title,
-      date: useDateFormat(element.startTime, 'YYYY-MM-DD').value,
+      startTime: element.startTime,
+      endTime: element.endTime,
       href: `/contest/${element.id}`,
       state: 'ongoing'
     })
@@ -50,7 +53,8 @@ axios.get('api/contest').then((res) => {
   res.data.upcoming.map((element: Contest) => {
     contest.value.push({
       title: element.title,
-      date: useDateFormat(element.startTime, 'YYYY-MM-DD').value,
+      startTime: element.startTime,
+      endTime: element.endTime,
       href: `/contest/${element.id}`,
       state: 'upcoming'
     })
@@ -92,36 +96,30 @@ axios.get('api/contest').then((res) => {
     ]"
   />
   <div
-    class="mt-20 flex flex-col items-center justify-center gap-12 lg:flex-row lg:items-start"
+    class="mt-8 flex flex-wrap items-start justify-between gap-5 md:flex-nowrap"
   >
-    <Card href="/notice" :items="notices" class="w-[36rem] max-w-full">
-      <template #title>
-        <IconInfo />
-        <h2 class="ml-2">Notice</h2>
-      </template>
-
-      <template #icon>
-        <IconAngleRight />
-      </template>
-    </Card>
-    <Card href="/contest" :items="contest" class="w-[36rem] max-w-full">
-      <template #title>
-        <IconMedal />
-        <h2 class="ml-2">Current/Upcoming Contests</h2>
-      </template>
-      <template #titleIcon>
-        <RouterLink
-          to="/"
-          class="cursor-pointer hover:opacity-50 active:opacity-30"
-        >
-          <IconBars />
-        </RouterLink>
-      </template>
-      <template #icon="item">
-        <IconEllipsis v-if="item.item === 'ongoing'" />
-        <IconCalendar v-else />
-      </template>
-    </Card>
+    <NewCard title="notices">
+      <div
+        v-for="(item, index) in notices"
+        :key="index"
+        class="g border-b border-slate-50 py-5 last:border-none last:pb-0"
+      >
+        <p>{{ item.title }}</p>
+        <p class="text-gray mt-1 text-sm">
+          {{ item.date }}
+        </p>
+      </div>
+    </NewCard>
+    <NewCard title="contests">
+      <ContestItem
+        v-for="(item, index) in contest"
+        :key="index"
+        :title="item.title"
+        :start-time="item.startTime"
+        :end-time="item.endTime"
+        :state="item.state"
+      />
+    </NewCard>
   </div>
 </template>
 


### PR DESCRIPTION
### Description

- PC 화면
  - <img width="1624" alt="Screenshot 2023-07-27 at 8 38 25 PM" src="https://github.com/skkuding/codedang/assets/50468628/67e7c0dd-a945-4072-a625-85205361b970">
- 모바일 화면
  - <img width="726" alt="Screenshot 2023-07-27 at 8 38 36 PM" src="https://github.com/skkuding/codedang/assets/50468628/65900592-85f0-405b-9936-1263f9cee4c2">
 
- vueuse 활용하여 date 표시
- contest가 pending 상태일 때에는 process 바 미표시

close #668 

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/674"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

