### PR TITLE
fix(cd): add etag to s3 object

### DIFF
--- a/infra/modules/codedang-infra/s3.tf
+++ b/infra/modules/codedang-infra/s3.tf
@@ -13,6 +13,8 @@ resource "aws_s3_object" "frontend" {
   key          = each.value
   source       = "../../frontend/dist/${each.value}"
   content_type = lookup(jsondecode(file("${path.module}/mime.json")), regex("\\.[^.]+$", each.key), null)
+
+  etag = filemd5("../../frontend/dist/${each.value}") # Trigger updating s3 object if the file content changes
 }
 
 resource "aws_s3_bucket_website_configuration" "frontend" {


### PR DESCRIPTION
### Description

Close #678 

파일 내용으로 MD5 hash를 만들어, S3의 기존 파일 내용과 비교합니다.
두 hash 값이 다르면 object를 다시 생성합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/680"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

