### PR TITLE
fix(fe): use internal base url for graphql

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -31,10 +31,7 @@ axiosRetry(axios, {
     await useAuthStore().reissue()
   }
 })
-// const apolloClient = new ApolloClient({
-//   // You should use an absolute URL here
-//   uri: 'https://dev.codedang.com/graphql'
-// })
+
 const link = from([
   new ApolloLink((operation, forward) => {
     operation.setContext(({ headers }: { headers: object }) => ({
@@ -43,12 +40,13 @@ const link = from([
         authorization: axios.defaults.headers.common.authorization
       }
     }))
-    return forward(operation) // Go to the next link in the chain. Similar to `next` in Express.js middleware.
+    return forward(operation)
   }),
-  new HttpLink({ uri: 'https://dev.codedang.com/graphql' })
+  new HttpLink({ uri: '/graphql' })
 ])
 const cache = new InMemoryCache()
 const apolloClient = new ApolloClient({ link, cache })
+
 const app = createApp({
   setup() {
     provide(ApolloClients, {


### PR DESCRIPTION
### Description

Admin GraphQL API에서 auth 처리가 안되는 문제를 해결합니다.
GraphQL base url로 도메인을 명시하지 않도록 수정합니다!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/704"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

