### PR TITLE
fix: udpate Caddyfile to handle reload

### DIFF
--- a/.github/workflows/devserver.yml
+++ b/.github/workflows/devserver.yml
@@ -98,3 +98,7 @@ jobs:
       - name: Run docker compose up
         run: |
           docker compose up -d
+
+      - name: Remove unused docker storages
+        run: |
+          docker system prune -f

--- a/infra/dev/Caddyfile
+++ b/infra/dev/Caddyfile
@@ -1,12 +1,15 @@
 dev.codedang.com {
-    root * /var/www/html
-    file_server
-
-    handle /api* {
+    handle /api/* {
         reverse_proxy backend-client:4000
     }
 
-    handle /graphql* {
+    handle /graphql {
         reverse_proxy backend-admin:3000
+    }
+
+    handle {
+        root * /var/www/html
+        try_files {path} /index.html
+        file_server
     }
 }


### PR DESCRIPTION
Close #710 

### Description
Dev 서버 (dev.codedang.com)에서 index(/)를 제외한 나머지 경로에서 새로고침 시 404를 반환하는 에러가 발생하여 Caddyfile을 수정하였습니다. 

(추가) EC2 runner에서 용량 부족 문제가 발생하여 docker prune하는 코드를 추가하였습니다. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/711"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

