### PR TITLE
fix(be): remove validation pipe from admin-global pipe

### DIFF
--- a/backend/apps/admin/src/main.ts
+++ b/backend/apps/admin/src/main.ts
@@ -1,11 +1,9 @@
-import { ValidationPipe } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import { graphqlUploadExpress } from 'graphql-upload'
 import { AdminModule } from './admin.module'
 
 const bootstrap = async () => {
   const app = await NestFactory.create(AdminModule)
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
   app.use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 2 }))
   app.enableCors({
     allowedHeaders: ['*'],

--- a/backend/apps/admin/src/problem/problem.resolver.ts
+++ b/backend/apps/admin/src/problem/problem.resolver.ts
@@ -3,7 +3,9 @@ import {
   Logger,
   NotFoundException,
   ParseIntPipe,
-  UnprocessableEntityException
+  UnprocessableEntityException,
+  UsePipes,
+  ValidationPipe
 } from '@nestjs/common'
 import { Args, Context, Query, Int, Mutation, Resolver } from '@nestjs/graphql'
 import { Prisma } from '@prisma/client'
@@ -54,6 +56,7 @@ export class ProblemResolver {
   }
 
   @Mutation(() => [Problem])
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async uploadProblems(
     @Context('req') req: AuthenticatedRequest,
     @Args('groupId', { defaultValue: OPEN_SPACE_ID }, ParseIntPipe)


### PR DESCRIPTION
### Description

ValidationPipe가 admin 앱에 전역으로 걸려 있어, 오브젝트 타입 input에서 class-validator의 validation 데코레이터가 달려있지 않은 모든 필드가 지워지고 있었습니다(...) 필요한 핸들러에만 파이프를 달아 문제를 해결합니다.

### Additional context

GraphQL에서 MIME Type을 validation할 수 있는 타입을 제공한다면 나중에 GraphQL Input Type을 활용하도록 바꾸는 것도 괜찮을 것 같습니다!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/726"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

