### PR TITLE
fix(be): modify leaveGroup api

### DIFF
--- a/backend/apps/client/src/group/group.controller.ts
+++ b/backend/apps/client/src/group/group.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   InternalServerErrorException,
   Logger,
@@ -102,6 +103,10 @@ export class GroupController {
     try {
       return await this.groupService.leaveGroup(req.user.id, groupId)
     } catch (error) {
+      if (error instanceof ActionNotAllowedException) {
+        throw new ForbiddenException(error.message)
+      }
+
       this.logger.error(error.message, error.stack)
       throw new InternalServerErrorException()
     }

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -240,6 +240,26 @@ export class GroupService {
   }
 
   async leaveGroup(userId: number, groupId: number): Promise<UserGroup> {
+    const currentUserGroup = await this.prisma.userGroup.findFirst({
+      where: {
+        userId: userId,
+        isGroupLeader: true
+      }
+    })
+
+    if (currentUserGroup) {
+      const groupLeaders = await this.prisma.userGroup.findMany({
+        where: {
+          isGroupLeader: true,
+          groupId: groupId
+        }
+      })
+
+      if (groupLeaders.length < 2) {
+        throw new ActionNotAllowedException('last group leader leave', 'group')
+      }
+    }
+
     const deletedUserGroup = await this.prisma.userGroup.delete({
       where: {
         // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
### Description

Closes #747 

GroupLeader가 Group에서 탈퇴하고자 할 때, 유일하게 남아있는 GroupLeader라면 탈퇴할 수 없도록 합니다.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
