### PR TITLE
fix(fe): contest item display a wrong date string

### DIFF
--- a/frontend/src/common/components/Organism/PaginationTable.vue
+++ b/frontend/src/common/components/Organism/PaginationTable.vue
@@ -189,7 +189,7 @@ useSortable(el, items, {
         :page-slot="pageSlot"
         :number-of-pages="numberOfPages"
         :mode="mode"
-        @change-page="(page) => emit('change-page', page)"
+        @change-page="(page: number) => emit('change-page', page)"
       />
     </div>
   </div>

--- a/frontend/src/user/home/components/ContestItem.vue
+++ b/frontend/src/user/home/components/ContestItem.vue
@@ -30,8 +30,10 @@ useIntervalFn(() => {
   percentage.value = getPercentage()
 }, 1000)
 
-const timeAgo = computed(() =>
-  useTimeAgo(props.state === 'ongoing' ? props.endTime : props.startTime)
+const timeAgo = computed(
+  () =>
+    useTimeAgo(props.state === 'ongoing' ? props.endTime : props.startTime)
+      .value
 )
 </script>
 


### PR DESCRIPTION
### Description

- contest 게시판에 date가 이상하게 표현되는 거 고침
- computed는 Ref로 반환해서 .value를 붙여야 했는데 안 붙여서 생겼던 오류
- 추가로 pagination table에 type error 떠서 수정함(issue에 관련 없지만 사소한 오류라서 같이 PR 올림)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/787"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

