### PR TITLE
feat: use single instance in redis

### DIFF
--- a/infra/modules/codedang-infra/ecs-admin.tf
+++ b/infra/modules/codedang-infra/ecs-admin.tf
@@ -102,7 +102,7 @@ resource "aws_ecs_task_definition" "admin_api" {
     ecr_uri              = data.aws_ecr_repository.admin_api.repository_url,
     container_port       = 3000
     cloudwatch_region    = var.region,
-    redis_host           = aws_elasticache_replication_group.db_cache.configuration_endpoint_address
+    redis_host           = aws_elasticache_cluster.db_cache.cache_nodes.0.address,
     redis_port           = var.redis_port,
     jwt_secret           = random_password.jwt_secret.result,
     nodemailer_from      = "Codedang <noreply@codedang.com>",

--- a/infra/modules/codedang-infra/ecs-client.tf
+++ b/infra/modules/codedang-infra/ecs-client.tf
@@ -102,7 +102,7 @@ resource "aws_ecs_task_definition" "client_api" {
     ecr_uri           = data.aws_ecr_repository.client_api.repository_url,
     container_port    = 4000
     cloudwatch_region = var.region,
-    redis_host        = aws_elasticache_replication_group.db_cache.configuration_endpoint_address
+    redis_host        = aws_elasticache_cluster.db_cache.cache_nodes.0.address,
     redis_port        = var.redis_port,
     jwt_secret        = random_password.jwt_secret.result,
     nodemailer_from   = "Codedang <noreply@codedang.com>"

--- a/infra/modules/codedang-infra/redis.tf
+++ b/infra/modules/codedang-infra/redis.tf
@@ -16,24 +16,19 @@ resource "aws_subnet" "private_redis2" {
     Name = "Codedang_Redis-Subnet2"
   }
 }
-
-resource "aws_elasticache_replication_group" "db_cache" {
-  automatic_failover_enabled = true
-  # preferred_cache_cluster_azs = [var.availability_zones[0], var.availability_zones[1]]
-  replication_group_id     = "elasticache-redis-codedang-1"
-  description              = "Redis for codedang"
-  node_type                = "cache.t3.micro"
+resource "aws_elasticache_cluster" "db_cache" {
+  cluster_id               = "elasticache-redis-codedang-1"
   engine                   = "redis"
-  parameter_group_name     = "default.redis7.cluster.on"
+  node_type                = "cache.t3.micro"
+  num_cache_nodes          = 1
+  parameter_group_name     = "default.redis7"
   engine_version           = "7.0"
   port                     = var.redis_port
   apply_immediately        = true
   snapshot_retention_limit = 0 # no backup
-  replicas_per_node_group  = 1 # replicas per shard
 
   security_group_ids = [aws_security_group.redis.id]
   subnet_group_name  = aws_elasticache_subnet_group.redis_subnet_group.name
-
 
   log_delivery_configuration {
     destination      = "/elasticache/redis"
@@ -42,79 +37,7 @@ resource "aws_elasticache_replication_group" "db_cache" {
     log_type         = "slow-log"
   }
 }
-
-# resource "aws_elasticache_replication_group" "db_cache" {
-#   automatic_failover_enabled = true
-#   # preferred_cache_cluster_azs = [var.availability_zones[0], var.availability_zones[1]]
-#   replication_group_id     = "elasticache-redis-codedang-1"
-#   description              = "Redis for codedang"
-#   node_type                = "cache.t3.micro"
-#   engine                   = "redis"
-#   parameter_group_name     = "default.redis7.cluster.on"
-#   engine_version           = "7.0"
-#   port                     = var.redis_port
-#   apply_immediately        = true
-#   snapshot_retention_limit = 0 # no backup
-
-#   num_node_groups         = 1 # number of shards
-#   replicas_per_node_group = 1 # replicas per shard
-
-#   security_group_ids = [aws_security_group.redis.id]
-#   subnet_group_name  = aws_elasticache_subnet_group.redis_subnet_group.name
-
-
-#   log_delivery_configuration {
-#     destination      = "/elasticache/redis"
-#     destination_type = "cloudwatch-logs"
-#     log_format       = "text"
-#     log_type         = "slow-log"
-#   }
-
-#   log_delivery_configuration {
-#     destination      = "/elasticache/redis"
-#     destination_type = "cloudwatch-logs"
-#     log_format       = "text"
-#     log_type         = "engine-log"
-#   }
-# }
-
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
   name       = "Redis-subnet-group"
   subnet_ids = [aws_subnet.private_redis1.id, aws_subnet.private_redis2.id]
 }
-
-# resource "aws_elasticache_cluster" "codedang" {
-#   cluster_id           = "cluster-codedang"
-#   engine               = "redis"
-#   node_type            = "cache.t3.micro"
-#   num_cache_nodes      = 1
-#   parameter_group_name = "default.redis7"
-#   engine_version       = "7.0"
-#   port                 = 6379
-
-#   security_group_ids = [aws_security_group.redis.id]
-#   availability_zone  = var.availability_zones[0]
-#   subnet_group_name  = aws_elasticache_subnet_group.private_db.name
-
-#   log_delivery_configuration {
-#     destination      = "ecs/Codedang-Api"
-#     destination_type = "cloudwatch-logs"
-#     log_format       = "text"
-#     log_type         = "slow-log"
-#   }
-# }
-
-# resource "aws_subnet" "redis" {
-#   vpc_id            = aws_vpc.main.id
-#   cidr_block        = "10.0.20.0/24"
-#   availability_zone = var.availability_zones[0]
-
-#   tags = {
-#     Name = "Codedang-REDIS-Subnet1"
-#   }
-# }
-# resource "aws_elasticache_subnet_group" "private_db" {
-#   name       = "elastiCache-subnet"
-#   subnet_ids = [aws_subnet.redis.id]
-
-# }


### PR DESCRIPTION
Close #808 
### Description
개발 환경과 동일하게 Redis를 single instance 형태로 생성합니다.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
추후 안정성 강화가 필요할 경우 Sentinel 모드로의 확장을 고려하면 되지 않을까 싶습니다!
* Redis 구성 (참고)
  * Single instance : 단일 node(write / read)
  * Sentinel : 다중 node (1 write node / 다중 read nodes) - Elasticache에서는 Multi-AZ로 설정하는 듯 보입니다. 
  * Cluster : 다중 node (다중 write nodes / 다중 read nodes)
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/809"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

