### PR TITLE
fix(be): validate judger response without error

### DIFF
--- a/backend/apps/client/src/submission/dto/judger-response.dto.ts
+++ b/backend/apps/client/src/submission/dto/judger-response.dto.ts
@@ -45,7 +45,6 @@ export class JudgerResponse {
   submissionId: string
 
   @IsString()
-  @IsNotEmpty()
   error: string
 
   @Type(() => JudgeData)

--- a/backend/apps/client/src/submission/submission.service.spec.ts
+++ b/backend/apps/client/src/submission/submission.service.spec.ts
@@ -453,6 +453,34 @@ describe('SubmissionService', () => {
     })
   })
 
+  it('should handle message without error', async () => {
+    const target = {
+      resultCode: 1,
+      submissionId: 'ea953b',
+      error: '',
+      data: {
+        acceptedNum: 0,
+        totalTestcase: 1,
+        judgeResult: [
+          {
+            testcaseId: '18:30',
+            resultCode: 1,
+            cpuTime: 0,
+            realTime: 0,
+            memory: 1417216,
+            signal: 0,
+            exitCode: 0,
+            errorCode: 0
+          }
+        ]
+      }
+    }
+
+    const result = await service.judgerResponseTypeValidation(target)
+
+    expect(result).to.be.deep.equal(target)
+  })
+
   describe('getContestSubmisssion', () => {
     it('should return submission', async () => {
       db.contestRecord.findUniqueOrThrow.resolves({


### PR DESCRIPTION
### Description

#776 에서 추가한 type validation 중 error가 비어있는 경우도 올바르게 처리하도록 수정합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/816"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

