### PR TITLE
feat(fe): add main tab and change logo link

### DIFF
--- a/frontend/src/common/components/Organism/Sidebar.vue
+++ b/frontend/src/common/components/Organism/Sidebar.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import IconCode from '~icons/bi/code-square'
 import IconFile from '~icons/bi/file-text'
-import IconBiHouse from '~icons/bi/house'
+import IconHome from '~icons/bi/house'
 import IconBook from '~icons/bi/journals'
 import IconTrophy from '~icons/bi/trophy'
 import IconUser from '~icons/fa6-regular/user'
@@ -13,6 +13,7 @@ import IconBrain from '~icons/fluent/brain-circuit-24-regular'
 const route = useRoute()
 
 const commonItems = [
+  { to: '/admin', name: 'Main', icon: IconHome },
   { to: '/admin/notice', name: 'Notice', icon: IconFile },
   { to: '/admin/contest', name: 'Contest', icon: IconTrophy },
   { to: '/admin/workbook', name: 'Workbook', icon: IconBook },
@@ -20,7 +21,7 @@ const commonItems = [
 ]
 
 const groupItems = (id: number) => [
-  { to: `/admin/${id}`, name: 'Main', icon: IconBiHouse },
+  { to: `/admin/${id}`, name: 'Main', icon: IconHome },
   { to: `/admin/${id}/notice`, name: 'Notice', icon: IconFile },
   { to: `/admin/${id}/contest`, name: 'Contest', icon: IconTrophy },
   { to: `/admin/${id}/workbook`, name: 'Workbook', icon: IconBook },
@@ -38,7 +39,7 @@ const items = computed(() =>
 
 <template>
   <div class="bg-gray-light text-gray-dark h-screen w-48 overflow-auto">
-    <RouterLink to="/admin" class="align-center flex justify-center">
+    <RouterLink to="/" class="align-center flex justify-center">
       <img :src="Logo" class="my-8 w-32" />
     </RouterLink>
     <hr class="bg-gray h-0.5 border-none opacity-25" />


### PR DESCRIPTION
### Description

<img width="263" alt="Screenshot 2023-08-24 at 7 55 26 PM" src="https://github.com/skkuding/codedang/assets/50468628/a6703b53-d579-418d-b404-86d07e6da1b8">

admin 페이지에도 main tab을 추가하고 logo를 클릭하면 codedang main 페이지로 이동되게 만듬

close #821 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
