### PR TITLE
fix(infra): add required cloudfront methods

### DIFF
--- a/infra/modules/codedang-infra/cloudfront.tf
+++ b/infra/modules/codedang-infra/cloudfront.tf
@@ -68,7 +68,7 @@ resource "aws_cloudfront_distribution" "main" {
   ordered_cache_behavior {
     path_pattern             = "/api/*"
     allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods           = []
+    cached_methods           = ["GET", "HEAD", "OPTIONS"]
     target_origin_id         = aws_lb.client_api.id
     viewer_protocol_policy   = "redirect-to-https"
     cache_policy_id          = data.aws_cloudfront_cache_policy.disable.id
@@ -78,7 +78,7 @@ resource "aws_cloudfront_distribution" "main" {
   ordered_cache_behavior {
     path_pattern             = "/graphql"
     allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods           = []
+    cached_methods           = ["GET", "HEAD", "OPTIONS"]
     target_origin_id         = aws_lb.admin_api.id
     viewer_protocol_policy   = "redirect-to-https"
     cache_policy_id          = data.aws_cloudfront_cache_policy.disable.id


### PR DESCRIPTION
### Description

[Deploy #54](https://github.com/skkuding/codedang/actions/runs/6046678284)에서 누락된 cloudfront `cached_methods`를 추가합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/851"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

