### PR TITLE
feat: attach testcase bucket policy

### DIFF
--- a/infra/modules/codedang-infra/testcase.tf
+++ b/infra/modules/codedang-infra/testcase.tf
@@ -6,6 +6,29 @@ resource "aws_s3_bucket" "testcase" {
   }
 }
 
+data "aws_iam_policy_document" "testcase_permissions" {
+  statement {
+    actions   = ["s3:ListBucket", "s3:GetObject"]
+    resources = [aws_s3_bucket.frontend.arn, "${aws_s3_bucket.frontend.arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "IpAddress"
+      variable = "AWS:SourceIp"
+      values   = [aws_eip.nat_eip.public_ip]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "testcase" {
+  bucket = aws_s3_bucket.testcase.id
+  policy = data.aws_iam_policy_document.testcase_permissions.json
+}
+
 # user
 # TODO: do not create IAM user, use EC2 instance profile instead
 resource "aws_iam_user" "testcase" {


### PR DESCRIPTION
Close #856 
### Description
Testcase bucket의 bucket policy를 설정합니다.
private subnet에서 NAT Gateway를 거쳐 S3에 접속하는 경우 
해당 IP를 통한 접속을 허용하는 policy가 필요합니다. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
