### PR TITLE
feat(infra): change ecs cpu to x64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,6 @@ jobs:
 
   build-backend:
     name: Build backend Docker image
-    # Using QEMU to build Docker image in x64 is too slow.
-    # Let's use self-hosted ARM machine instead.
-    runs-on: [self-hosted, linux, ARM64]
     steps:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -72,9 +69,6 @@ jobs:
     name: Build iris Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -93,7 +87,6 @@ jobs:
           file: ./infra/builder/iris/Dockerfile
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/codedang-iris:latest
-          platforms: linux/arm64
 
   deploy:
     name: Deploy

--- a/infra/modules/codedang-infra/backend/client-task-definition.tftpl
+++ b/infra/modules/codedang-infra/backend/client-task-definition.tftpl
@@ -2,7 +2,7 @@
   {
     "name": "${task_name}",
     "image": "${ecr_uri}",
-    "cpu": 512,
+    "cpu": 1024,
     "memory": 512,
     "essential": true,
     "portMappings": [

--- a/infra/modules/codedang-infra/ecs-api-admin.tf
+++ b/infra/modules/codedang-infra/ecs-api-admin.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_service" "admin_api" {
   name                              = "Codedang-Admin-Api-Service"
   cluster                           = aws_ecs_cluster.api.id
   task_definition                   = aws_ecs_task_definition.admin_api.arn
-  desired_count                     = 2
+  desired_count                     = 1
   launch_type                       = "EC2"
   health_check_grace_period_seconds = 300
 

--- a/infra/modules/codedang-infra/ecs-api-asg.tf
+++ b/infra/modules/codedang-infra/ecs-api-asg.tf
@@ -22,9 +22,9 @@ resource "aws_autoscaling_group" "asg_api" {
   health_check_type = "ELB"
 
   # Desired number of instances in the Autoscaling Group
-  desired_capacity = 2
+  desired_capacity = 1
   # Minimum and maximum number of instances in the Autoscaling Group
-  min_size = 2
+  min_size = 1
   max_size = 10
 
   lifecycle {

--- a/infra/modules/codedang-infra/ecs-api-asg.tf
+++ b/infra/modules/codedang-infra/ecs-api-asg.tf
@@ -61,8 +61,8 @@ resource "aws_autoscaling_policy" "asp_api" {
 ###################### Launch Template ######################
 resource "aws_launch_template" "ec2_template_api" {
   name          = "Codedang-LaunchTemplate-Api"
-  image_id      = "ami-01287572b99f45fc2" # 한국
-  instance_type = "t4g.small"             # 2vCPU, 2GiB Mem
+  image_id      = "ami-056fad42304856ccf" # 한국
+  instance_type = "t3.small"              # 2vCPU, 2GiB Mem
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecs_container_instance_role.name

--- a/infra/modules/codedang-infra/ecs-api-client.tf
+++ b/infra/modules/codedang-infra/ecs-api-client.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_service" "client_api" {
   name                              = "Codedang-Client-Api-Service"
   cluster                           = aws_ecs_cluster.api.id
   task_definition                   = aws_ecs_task_definition.client_api.arn
-  desired_count                     = 2
+  desired_count                     = 1
   launch_type                       = "EC2"
   health_check_grace_period_seconds = 300
 

--- a/infra/modules/codedang-infra/ecs-iris-asg.tf
+++ b/infra/modules/codedang-infra/ecs-iris-asg.tf
@@ -58,15 +58,15 @@ resource "aws_autoscaling_policy" "asp_iris" {
 ###################### Launch Template ######################
 resource "aws_launch_template" "ec2_template_iris" {
   name          = "Codedang-LaunchTemplate-Iris"
-  image_id      = "ami-01287572b99f45fc2"
-  instance_type = "t4g.small" # 2vCPU, 2GiB Mem
+  image_id      = "ami-056fad42304856ccf"
+  instance_type = "t3.small" # 2vCPU, 2GiB Mem
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecs_container_instance_role.name
   }
 
   # 미리 만들어 놓아야 합니다.
-  key_name  = "codedang-ecs-iris-instance"
+  key_name = "codedang-ecs-iris-instance"
   user_data = base64encode(templatefile("${path.module}/user-data.sh", {
     cluster_name = aws_ecs_cluster.iris.name
   }))


### PR DESCRIPTION
Close #865 
### Description
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
ECS instance를 ARM 기반에서 x86 64bit으로 다시 전환합니다.

### Additional context
ECS-API 에서 사용하는 instance 개수를 1개(default)로 줄이고, 
ECS Admin과 Client task의 사양을 조정했습니다.
* ECS API Admin task ( 0.5vCPU, 0.5Mem) - 1개
* ECS API Client task ( 1vCPU, 0.5Mem) - 1개
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/867"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

