### PR TITLE
fix(infra): replace dir to docker context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,9 +84,9 @@ jobs:
 
       - name: Build and push image (iris)
         uses: docker/build-push-action@v5
-        working-directory: ./iris
         with:
           push: true
+          context: ./iris
           tags: ${{ steps.login-ecr.outputs.registry }}/codedang-iris:latest
 
   deploy:

--- a/.github/workflows/devserver.yml
+++ b/.github/workflows/devserver.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: Build and push iris image
         uses: docker/build-push-action@v5
-        working-directory: ./iris
         with:
           push: true
+          context: ./iris
           tags: ghcr.io/${{ github.repository_owner }}/codedang-iris:latest
 
   run-server:


### PR DESCRIPTION
### Description

GitHub Action job의 `working-directory` 옵션은 `run`이 있을 때만 쓸 수 있다고 하네요...
Docker context로 대체하였습니다.
참고: https://github.com/docker/build-push-action/issues/169#issuecomment-705392716

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/880"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

