### PR TITLE
fix(infra): use proper ec2 ami 

### DIFF
--- a/infra/modules/codedang-infra/ecs-api-asg.tf
+++ b/infra/modules/codedang-infra/ecs-api-asg.tf
@@ -61,8 +61,8 @@ resource "aws_autoscaling_policy" "asp_api" {
 ###################### Launch Template ######################
 resource "aws_launch_template" "ec2_template_api" {
   name          = "Codedang-LaunchTemplate-Api"
-  image_id      = "ami-056fad42304856ccf" # 한국
-  instance_type = "t3.small"              # 2vCPU, 2GiB Mem
+  image_id      = "ami-05db432abf706dc01" # 한국
+  instance_type = "t3a.small"             # 2vCPU, 2GiB Mem
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecs_container_instance_role.name

--- a/infra/modules/codedang-infra/ecs-iris-asg.tf
+++ b/infra/modules/codedang-infra/ecs-iris-asg.tf
@@ -58,8 +58,8 @@ resource "aws_autoscaling_policy" "asp_iris" {
 ###################### Launch Template ######################
 resource "aws_launch_template" "ec2_template_iris" {
   name          = "Codedang-LaunchTemplate-Iris"
-  image_id      = "ami-056fad42304856ccf"
-  instance_type = "t3.small" # 2vCPU, 2GiB Mem
+  image_id      = "ami-05db432abf706dc01"
+  instance_type = "t3a.small" # 2vCPU, 2GiB Mem
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecs_container_instance_role.name

--- a/infra/modules/codedang-infra/security-group.tf
+++ b/infra/modules/codedang-infra/security-group.tf
@@ -109,6 +109,14 @@ resource "aws_security_group" "iris" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     description = "Iris"
     from_port   = var.rabbitmq_port
     to_port     = var.rabbitmq_port


### PR DESCRIPTION
Close #869 
### Description
1. 이미지 AMI를 수정했습니다.
- 기존 AMI : ami-056fad42304856ccf 
![image](https://github.com/skkuding/codedang/assets/100272259/9e6c1fb8-bbbc-4f42-8b87-49d6914e9d96)
![image](https://github.com/skkuding/codedang/assets/100272259/8ec4d0ea-e8e4-4524-8a7e-1edbf45ae850)
Graviton-based instance에 최적화되어있어서, 오류가 나지 않았을까 예상해봅니다.

- 변경 AMI : ami-05db432abf706dc01
![image](https://github.com/skkuding/codedang/assets/100272259/cd82b1b3-f6df-4733-8797-216ceb75b510)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
iris ec2 instance의 SSH 접속 Security Group 추가했습니다.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/887"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

