### PR TITLE
feat(infra): allow api docs to use dev server

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,30 +1,39 @@
 (cors) {
-  @cors_preflight method OPTIONS
-  @cors header Origin {args[0]}
+  @cors_preflight{args[0]} {        # cors_preflight{args[0]} matcher 생성
+    header Origin {args[0]}         # header와 method를 조건으로 설정
+    method OPTIONS
+  }
+  @cors{args[0]} header Origin {args[0]}    # cors{args[0]} matcher 생성
 
-  handle @cors_preflight {
-	  header Access-Control-Allow-Credentials true
+  handle @cors_preflight{args[0]} {         # cors_preflight{args[0]}를 처리할 handler
+    header Access-Control-Allow-Credentials true
     header Access-Control-Allow-Origin "{args[0]}"
     header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE"
     header Access-Control-Allow-Headers "Content-Type, Authorization"
     respond "" 204
   }
 
-  handle @cors {
+  handle @cors{args[0]} {        # cors{args[0]}를 처리할 handler
     header Access-Control-Allow-Origin "{args[0]}"
   }
 }
 
 dev.codedang.com {
   handle /api/* {
-	  import cors http://localhost:5173
     reverse_proxy 127.0.0.1:4000 {
       header_down -Access-Control-Allow-Origin *
 	  }
-	  header {
+
+    # 캐시 설정
+    header {
       Set-Cookie (.*) "$1; SameSite=None; Secure"
       defer
     }
+
+    # import <pattenr> [<args...>]
+    # cors 허용할 도메인 설정
+    import cors http://localhost:5173     # frontend server
+    import cors http://localhost:5555     # api docs server
   }
 
   handle /graphql {


### PR DESCRIPTION
Close #892 
### Description
로컬에서 API 문서 작업할 때 사용하는 vitepress 서버(localhost 5555)에서 
dev server로  Request를 보낼 수 있도록 dev server를 설정합니다 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
CORS는 해결해서 통신은 가능하도록 열어놨습니다! 

![image](https://github.com/skkuding/codedang/assets/100272259/8093386b-7c6e-4cf2-bfad-2f611142e504)




다만 `log in` API를 거치고 나서 다른 API를 테스트하는 경우 
직접 token을 복붙해서 사용해야하는 불편함이 있더군요... 
혹시 이 부분은 해결이 안되나요??

![image](https://github.com/skkuding/codedang/assets/100272259/01f85402-2cf1-47d4-be0f-4ca633ec266f)

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/893"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

