### PR TITLE
fix: disable pnpm hard link

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=true
+package-import-method=clone-or-copy


### PR DESCRIPTION
### Description

Close #902

store-dir 옵션은 환경 변수 인식이 안되는 문제가 있어,
hard link를 해제하여 해결하였습니다. (`clone-or-copy`)
https://pnpm.io/npmrc#package-import-method

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<a href="https://gitpod.io/#https://github.com/skkuding/codedang/pull/904"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

