### PR TITLE
fix(fe): auth header is not added in local

### DIFF
--- a/frontend/src/common/store/auth.ts
+++ b/frontend/src/common/store/auth.ts
@@ -40,7 +40,8 @@ export const useAuthStore = defineStore('auth', {
     async reissue() {
       try {
         const res = await axios.get('/api/auth/reissue', {
-          withCredentials: true // for local development
+          // Send cross-site cookie in development mode
+          withCredentials: import.meta.env.DEV
         })
         axios.defaults.headers.common.authorization = res.headers.authorization
         this.isLoggedIn = true

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -41,11 +41,11 @@ export default defineConfig({
     host: true,
     proxy: {
       '/api': {
-        target: 'http://dev.codedang.com',
+        target: 'https://dev.codedang.com',
         changeOrigin: true
       },
       '/graphql': {
-        target: 'http://dev.codedang.com',
+        target: 'https://dev.codedang.com',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
### Description

로컬에서 dev.codedang.com으로 API를 호출할 때 `authorization` 헤더가 추가되지 않는 문제를 해결합니다.

### Additional Context

Vite proxy 설정을 했는데도 API 호출이 Vite에서 일어나는 게 아니라 브라우저 내에서 redirection되는 문제를 발견하였습니다.

<img width="743" alt="image" src="https://github.com/skkuding/codedang/assets/19747913/a373c0d3-86c6-4ea3-ab98-0c64434ffeb8">

(왜 되는지는 모르겠지만...) Vite proxy 설정에서 target URL을 `http://` => `https://`로 변경하니까 됐습니다.

<img width="724" alt="image" src="https://github.com/skkuding/codedang/assets/19747913/ad7e90a9-2448-4f23-9ce2-879e4467f770">


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
