### PR TITLE
fix(cd): bruno cli is not installed in cd pipeline

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -130,7 +130,7 @@ jobs:
           node-version: 20
 
       - name: Install Bruno CLI
-        run: pnpm install -g @usebruno/cli
+        run: npm install -g @usebruno/cli
 
       - name: Run Bruno Collection (Client)
         working-directory: collection/client


### PR DESCRIPTION
### Description

CD - Development 파이프라인에서 Bruno CLI가 설치되지 않아 실패하는 문제를 해결합니다.
pnpm이 설치되지 않은 채로 pnpm 명령어를 사용해, npm 명령어로 수정하였습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
