### PR TITLE
fix(fe): fixed nav bar items order

### DIFF
--- a/frontend/src/common/components/Organism/Header.vue
+++ b/frontend/src/common/components/Organism/Header.vue
@@ -49,9 +49,9 @@ const handleLinkClick = (name: string) => {
             <RouterLink
               v-for="{ to, name } in [
                 { to: '/notice', name: 'notice' },
-                { to: '/', name: 'contest' },
                 { to: '/problem', name: 'problem' },
-                { to: '/', name: 'group' }
+                { to: '/', name: 'group' },
+                { to: '/', name: 'contest' }
                 //hide: replace / with /contest, /group each
               ]"
               :key="name"


### PR DESCRIPTION
### Description

Close #976 
헤더의 네비바 중 기능이 숨겨진 두 가지(Group, Contest)를 뒤로 보내고 Notice, Problem을 앞 순서로 변경했습니다.
변경된 순서 : Notice Problem Group Contest

### Additional context

간단한 변경이지만 이슈가 존재하여 hotfix 대신 새로운 브랜치를 만들었습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
