### PR TITLE
fix(infra): wrong docker dist directory

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,7 @@ ARG target
 ENV NODE_ENV=production
 ENV TARGET=${target}
 
-COPY --from=builder /build/out /app
+COPY --from=builder /build/out/dist /app
 COPY ./backend/entrypoint.sh /app
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
### Description

Docker container 실행 시 `pnpm deploy out` 이후 `npm run build` 결과값인 dist 폴더 안의 파일을 실행하도록 경로를 수정합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
