### PR TITLE
chore(fe): navbar order changed

### DIFF
--- a/frontend/src/common/components/Organism/Header.vue
+++ b/frontend/src/common/components/Organism/Header.vue
@@ -50,8 +50,8 @@ const handleLinkClick = (name: string) => {
               v-for="{ to, name } in [
                 { to: '/notice', name: 'notice' },
                 { to: '/problem', name: 'problem' },
-                { to: '/', name: 'group' },
-                { to: '/', name: 'contest' }
+                { to: '/', name: 'contest' },
+                { to: '/', name: 'group' }
                 //hide: replace / with /contest, /group each
               ]"
               :key="name"


### PR DESCRIPTION
### Description
Close #1002 
- notice - contest - problem - group
    → notice - problem - contest - group로 순서 변경

### Additional context

노션에는 기존 순서가 "notice - contest - problem - group"로 되어 있었으나 실제로는 "notice - problem - group - contest" 였음. "notice - problem - contest - group"로 순서 변경함
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
