### PR TITLE
fix(fe): changed logo, color of login modal

### DIFF
--- a/frontend/src/common/components/Organism/Login.vue
+++ b/frontend/src/common/components/Organism/Login.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
+import Logo from '@/common/assets/codedang.svg'
 import { useAuthStore } from '@/common/store/auth'
 import { ref } from 'vue'
 import RegularEye from '~icons/fa6-regular/eye'
 import EyeSlash from '~icons/fa6-regular/eye-slash'
 import Button from '../Atom/Button.vue'
 import InputItem from '../Atom/InputItem.vue'
-import SymbolLogo from '../Atom/SymbolLogo.vue'
 
 const emit = defineEmits<{
   (e: 'to', value: 'login' | 'signup' | 'password' | 'close'): void
@@ -25,8 +25,8 @@ const login = async () => {
 
 <template>
   <div class="flex flex-col items-center justify-center">
-    <SymbolLogo class="fill-green h-28" />
-    <h1 class="text-green my-6 w-40 text-center text-xl font-bold">
+    <img :src="Logo" class="mb-8 h-20" />
+    <h1 class="text-blue my-6 w-40 text-center text-xl font-bold">
       SKKU
       <br />
       Coding Platform
@@ -45,7 +45,7 @@ const login = async () => {
           @click.stop="passwordVisible = !passwordVisible"
         />
       </div>
-      <Button type="submit" class="rounded-md">Log In</Button>
+      <Button color="blue" type="submit" class="rounded-md">Log In</Button>
     </form>
     <div class="absolute inset-x-0 bottom-0 flex w-full justify-between p-3">
       <a


### PR DESCRIPTION
### Description
Close #1008 
로그인 모달의 로고를 코드당 로고로 변경
로그인 모달의 색을 파란색으로 변경(회원가입 모달과 통일)

### Additional context


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
