### PR TITLE
feat(infra): add service auto scaling for iris

### DIFF
--- a/infra/modules/codedang-infra/ecs-api-asg.tf
+++ b/infra/modules/codedang-infra/ecs-api-asg.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_cluster_capacity_providers" "ecs_api" {
 resource "aws_autoscaling_group" "asg_api" {
   name                  = "Codedang-AutoScalingGroup-Api"
   vpc_zone_identifier   = [aws_subnet.private_client_api1.id, aws_subnet.private_client_api2.id]
-  protect_from_scale_in = true
+  protect_from_scale_in = false
 
   # target_group_arns = [aws_lb_target_group.client_api.id]
   health_check_type = "ELB"

--- a/infra/modules/codedang-infra/ecs-iris-asg.tf
+++ b/infra/modules/codedang-infra/ecs-iris-asg.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_cluster_capacity_providers" "ecs_iris" {
 resource "aws_autoscaling_group" "asg_iris" {
   name                  = "Codedang-AutoScalingGroup-Iris"
   vpc_zone_identifier   = [aws_subnet.private_iris1.id, aws_subnet.private_iris2.id]
-  protect_from_scale_in = true
+  protect_from_scale_in = false
 
   # Desired number of instances in the Autoscaling Group
   desired_capacity = 1

--- a/infra/modules/codedang-infra/ecs-iris-service-asg.tf
+++ b/infra/modules/codedang-infra/ecs-iris-service-asg.tf
@@ -1,3 +1,42 @@
+###################### cloudwatch alert ######################
+resource "aws_cloudwatch_metric_alarm" "ecs_iris_scale-down" {
+  alarm_name          = "Codedang-Iris-Service-Scale-Down-Alert"
+  comparison_operator = "LessThanThreshold"
+  datapoints_to_alarm = 15
+  evaluation_periods  = 15
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 45
+  alarm_description   = "This metric monitors ec2 cpu utilization and scale down ecs service"
+  alarm_actions       = [aws_appautoscaling_policy.service_asp_iris_scale_down.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.iris.name
+    ServiceName = aws_ecs_service.iris.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_iris_scale-up" {
+  alarm_name          = "Codedang-Iris-Service-Scale-Up-Alert"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = 1
+  evaluation_periods  = 1
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 60
+  alarm_description   = "This metric monitors ec2 cpu utilization and scale up ecs service"
+  alarm_actions       = [aws_appautoscaling_policy.service_asp_iris_scale_up.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.iris.name
+    ServiceName = aws_ecs_service.iris.name
+  }
+}
+
 ###################### Service Auto Scaling #####################
 resource "aws_appautoscaling_target" "service_asg_iris" {
   max_capacity       = 8
@@ -6,8 +45,6 @@ resource "aws_appautoscaling_target" "service_asg_iris" {
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }
-
-
 
 resource "aws_appautoscaling_policy" "service_asp_iris_scale_up" {
   name               = "scale-up"

--- a/infra/modules/codedang-infra/ecs-iris-service-asg.tf
+++ b/infra/modules/codedang-infra/ecs-iris-service-asg.tf
@@ -1,0 +1,50 @@
+###################### Service Auto Scaling #####################
+resource "aws_appautoscaling_target" "service_asg_iris" {
+  max_capacity       = 8
+  min_capacity       = 2
+  resource_id        = "service/${aws_ecs_cluster.iris.name}/${aws_ecs_service.iris.name}}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+
+
+resource "aws_appautoscaling_policy" "service_asp_iris_scale_up" {
+  name               = "scale-up"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.service_asg_iris.resource_id
+  scalable_dimension = aws_appautoscaling_target.service_asg_iris.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.service_asg_iris.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type          = "ChangeInCapacity"
+    cooldown                 = 60
+    metric_aggregation_type  = "Average"
+    min_adjustment_magnitude = 0
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "service_asp_iris_scale_down" {
+  name               = "scale-down"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.service_asg_iris.resource_id
+  scalable_dimension = aws_appautoscaling_target.service_asg_iris.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.service_asg_iris.service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type          = "ChangeInCapacity"
+    cooldown                 = 60
+    metric_aggregation_type  = "Average"
+    min_adjustment_magnitude = 0
+
+    step_adjustment {
+      metric_interval_upper_bound = -30
+      scaling_adjustment          = -1
+    }
+  }
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
closes #1012 
IRIS ECS service에 autocaling 기능을 추가했습니다. 
Cloudwatch에 Alert 설정을 해 놓고, 
특정 alert가 trigger되는 경우에 scale-in/out 되도록 설정했습니다.


### Additional context
API ECS Cluster 에 AutoScaling이 필요한가? 에 대해서 이야기해보는 것이 좋을 것 같아요! 
물론 본격적으로 Load Test를 해봐야 알겠지만, 예전에 했던 LoadTest 결과를 보니깐 Client API 서버에는 CPUUtilization이 10%를 넘기질 않더라구요. 

<img src="https://github.com/skkuding/codedang/assets/100272259/6d53732f-6438-4dfd-aed2-b689a3647714"  width="300"/>


- 현재 상황: API ECS cluster는 Service Autoscaling 안됨 (지금 작업은 Iris ECS에만 Service Auto Scaling 해 놓은 상태)
=> EC2 Auto Scaling은 설정이 되어있지만 Service Auto Scaling이 적용되지 않아서 정상적으로 작동되는 상태는 아니긴 합니다.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
