### PR TITLE
fix(iris): use older go version in go.mod

### DIFF
--- a/iris/go.mod
+++ b/iris/go.mod
@@ -1,6 +1,6 @@
 module github.com/skkuding/codedang/iris
 
-go 1.21.4
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.23.5


### PR DESCRIPTION
### Description

Gitpod 실행 시 `setup.sh` 실행 과정에서 아래와 같은 에러가 출력됩니다.

```
go: errors parsing go.mod:
/workspace/codedang/iris/go.mod:3: invalid go version '1.21.4': must match format 1.23
```

`go.mod` 파일에서도 아래처럼 에러가 나와 VSCode에서 Go language server가 정상적으로 동작되지 않습니다.

<img width="522" alt="image" src="https://github.com/skkuding/codedang/assets/19747913/008067aa-baca-4dcb-bbb2-72e0d9bc684f">

관련 이슈: https://github.com/golang/go/issues/61888

`go.mod`에 명시된 최소 버전을 낮춰 에러를 없앱니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
