### PR TITLE
fix(be): set cookie path option for refresh token

### DIFF
--- a/backend/libs/constants/src/time.constants.ts
+++ b/backend/libs/constants/src/time.constants.ts
@@ -8,7 +8,11 @@ export const REFRESH_TOKEN_EXPIRE_TIME = SECONDS_PER_DAY
 export const REFRESH_TOKEN_COOKIE_OPTIONS = {
   maxAge: 1000 * SECONDS_PER_DAY,
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production'
+  secure: process.env.NODE_ENV === 'production',
+  path:
+    process.env.NODE_ENV === 'production'
+      ? '/api/auth/reissue'
+      : '/auth/reissue'
 }
 export const EMAIL_AUTH_EXPIRE_TIME = 5 * SECONDS_PER_MINUTE
 

--- a/iris/go.mod
+++ b/iris/go.mod
@@ -1,6 +1,6 @@
 module github.com/skkuding/codedang/iris
 
-go 1.21.4
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.23.5


### PR DESCRIPTION
### Description

fixes #1025 

Refresh token cookie에 path 속성을 추가합니다.
production 일 땐 `/api/auth/reissue`, 아닐 땐 `/auth/reissue`로 설정됩니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
