### PR TITLE
feat(be): reduce db access in getproblems

### DIFF
--- a/backend/apps/client/src/problem/mock/problem.mock.ts
+++ b/backend/apps/client/src/problem/mock/problem.mock.ts
@@ -95,3 +95,8 @@ export const problemTag = {
     name: 'Tag'
   }
 }
+
+export const tag = {
+  id: 1,
+  name: 'Tag'
+}

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common'
-import type { Problem, Submission, Tag, WorkbookProblem } from '@prisma/client'
+import type {
+  Problem,
+  ProblemTag,
+  Submission,
+  Tag,
+  WorkbookProblem
+} from '@prisma/client'
 import { PrismaService } from '@libs/prisma'
 
 /**
@@ -53,7 +59,11 @@ export class ProblemRepository {
     cursor: number,
     take: number,
     groupId: number
-  ): Promise<(Partial<Problem> & { submission: Partial<Submission>[] })[]> {
+  ): Promise<
+    (Partial<Problem> & { submission: Partial<Submission>[] } & {
+      problemTag: Partial<ProblemTag>[]
+    })[]
+  > {
     let skip = 1
     if (cursor === 0) {
       cursor = 1
@@ -73,6 +83,11 @@ export class ProblemRepository {
         submission: {
           select: {
             result: true
+          }
+        },
+        problemTag: {
+          select: {
+            tagId: true
           }
         }
       }
@@ -107,6 +122,20 @@ export class ProblemRepository {
         groupId: groupId
       },
       select: this.problemSelectOption
+    })
+  }
+
+  async getProblemsTags(tagIds: number[]): Promise<Partial<Tag>[]> {
+    return await this.prisma.tag.findMany({
+      where: {
+        id: {
+          in: tagIds
+        }
+      },
+      select: {
+        id: true,
+        name: true
+      }
     })
   }
 

--- a/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/backend/apps/client/src/problem/problem.service.spec.ts
@@ -21,7 +21,8 @@ import {
   contestProblems,
   problemTag,
   problems,
-  workbookProblems
+  workbookProblems,
+  tag
 } from './mock/problem.mock'
 import { ProblemRepository } from './problem.repository'
 import {
@@ -46,6 +47,9 @@ const db = {
     findUnique: stub(),
     findUniqueOrThrow: stub()
   },
+  tag: {
+    findMany: stub()
+  },
   problemTag: {
     findMany: stub()
   }
@@ -65,7 +69,8 @@ const mockProblems = problems.map((problem) => {
       submission: [
         { id: 1, result: ResultStatus.Accepted },
         { id: 2, result: ResultStatus.WrongAnswer }
-      ]
+      ],
+      problemTag: [{ tagId: 1 }]
     }
   )
 })
@@ -89,6 +94,7 @@ const mockWorkbookProblems = workbookProblems.map((workbookProblem) => {
 })
 
 const mockProblemTag = Object.assign({}, problemTag)
+const mockTag = Object.assign({}, tag)
 
 describe('ProblemService', () => {
   let service: ProblemService
@@ -119,7 +125,7 @@ describe('ProblemService', () => {
     it('should return public problems', async () => {
       // given
       db.problem.findMany.resolves(mockProblems)
-      db.problemTag.findMany.resolves([mockProblemTag])
+      db.tag.findMany.resolves([mockTag])
 
       // when
       const result = await service.getProblems(1, 2)

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -26,9 +26,7 @@ export class ProblemService {
     )
     const uniqueTagIds = new Set(
       problem.flatMap((item) => {
-        return item.problemTag.flatMap((item2) => {
-          return item2.tagId
-        })
+        return item.problemTag.map((item2) => item2.tagId)
       })
     )
     const tagIds = [...uniqueTagIds]
@@ -41,9 +39,8 @@ export class ProblemService {
         submission.filter(
           (submission) => submission.result === ResultStatus.Accepted
         ).length / submissionCount
-      const tags = tagList.filter((tagItem) =>
-        problemTag.flatMap((tag) => tag.tagId).includes(tagItem.id)
-      )
+      const problemTags = problemTag.map((tag) => tag.tagId)
+      const tags = tagList.filter((tagItem) => problemTags.includes(tagItem.id))
       return {
         ...data,
         submissionCount,


### PR DESCRIPTION
### Description

Closes #866 

problem에 딸린 problemTag에서 id만 뽑아와서 list로 놓고, tag에서 해당 row만 한번에 뽑아온 후 해당되는 id 매칭해서 보내주는 방식으로 변경했습니다!

실제로 속도가 빨라지는지, test코드는 따로 신경쓰지 못했습니다...

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
