### PR TITLE
fix(infra): modify Caddyfile & docker-compose to solve 404 Error afte…

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -49,7 +49,7 @@ dev.codedang.com {
 	}
 
 	handle {
-		root * /var/www/html
+		root * /static
 		try_files {path} /index.html
 		file_server
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - '443:443'
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - ./dist:/var/www/html
+      - ./dist:/static
     network_mode: host
 
   backend-client:


### PR DESCRIPTION
Close #1026

### Description
Github Actions(cd-dev) 이후에 Docker mount된 변경된 파일들이 Caddy Container에 반영이 안되는 문제를 해결합니다. 

### Additional context
Caddy 컨테이너의 루트 경로, docker mount 경로를 수정하였습니다.

