### PR TITLE
fix(infra): allow cors for email-auth

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -11,7 +11,7 @@
 		header Access-Control-Allow-Credentials true
 		header Access-Control-Allow-Origin "{args[0]}"
 		header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE"
-		header Access-Control-Allow-Headers "Content-Type, Authorization"
+		header Access-Control-Allow-Headers "Content-Type, Authorization, Email-Auth"
 		respond "" 204
 	}
 


### PR DESCRIPTION
### Description
email 인증할 때 frontend에서 header를 못 읽어오는 문제를 해결했습니다.
Caddyfile의 cors header에 email-auth를 추가하였습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
