### PR TITLE
feat(be): implement problem title search api

### DIFF
--- a/backend/apps/client/src/problem/problem.controller.ts
+++ b/backend/apps/client/src/problem/problem.controller.ts
@@ -23,6 +23,16 @@ export class ProblemController {
   constructor(private readonly problemService: ProblemService) {}
 
   @Get()
+  async searchProblems(@Query('search') search: string) {
+    try {
+      return await this.problemService.searchProblems(search)
+    } catch (error) {
+      this.logger.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
+  @Get()
   async getProblems(
     @Query('cursor', CursorValidationPipe) cursor: number,
     @Query('take', ParseIntPipe) take: number

--- a/backend/apps/client/src/problem/problem.controller.ts
+++ b/backend/apps/client/src/problem/problem.controller.ts
@@ -23,9 +23,9 @@ export class ProblemController {
   constructor(private readonly problemService: ProblemService) {}
 
   @Get()
-  async searchProblems(@Query('search') search: string) {
+  async searchProblemTitle(@Query('search') search: string) {
     try {
-      return await this.problemService.searchProblems(search)
+      return await this.problemService.searchProblemTitle(search)
     } catch (error) {
       this.logger.error(error)
       throw new InternalServerErrorException()

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -73,6 +73,17 @@ export class ProblemRepository {
     })
   }
 
+  async searchProblems(search: string): Promise<Partial<Problem>[]> {
+    return await this.prisma.problem.findMany({
+      where: {
+        title: {
+          search: search
+        }
+      },
+      select: this.problemsSelectOption
+    })
+  }
+
   async getProblemTags(problemId: number): Promise<Partial<Tag>[]> {
     return (
       await this.prisma.problemTag.findMany({

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -73,11 +73,11 @@ export class ProblemRepository {
     })
   }
 
-  async searchProblems(search: string): Promise<Partial<Problem>[]> {
+  async searchProblemTitle(search: string): Promise<Partial<Problem>[]> {
     return await this.prisma.problem.findMany({
       where: {
         title: {
-          search: search
+          contains: search
         }
       },
       select: this.problemsSelectOption

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -73,6 +73,12 @@ export class ProblemRepository {
     })
   }
 
+  // TODO/FIXME: postgreSQL의 full text search를 사용하여 검색하려 했으나
+  // 그럴 경우 띄어쓰기를 기준으로 나눠진 단어 단위로만 검색이 가능하다
+  // ex) "hello world"를 검색하면 "hello"와 "world"로 검색이 된다.
+  // 글자 단위로 검색하기 위해서, 성능을 희생하더라도 contains를 사용하여 구현했다.
+  // 추후에 검색 성능을 개선할 수 있는 방법을 찾아보자
+  // 아니면 텍스트가 많은 field에서는 full-text search를 사용하고, 텍스트가 적은 field에서는 contains를 사용하는 방법도 고려해보자.
   async searchProblemTitle(search: string): Promise<Partial<Problem>[]> {
     return await this.prisma.problem.findMany({
       where: {

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -52,6 +52,10 @@ export class ProblemService {
 
     return plainToInstance(ProblemsResponseDto, await Promise.all(problems))
   }
+  async searchProblems(search: string) {
+    const data = await this.problemRepository.searchProblems(search)
+    return plainToInstance(ProblemsResponseDto, data)
+  }
 
   async getProblem(problemId: number, groupId = OPEN_SPACE_ID) {
     const data = await this.problemRepository.getProblem(problemId, groupId)

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -52,8 +52,8 @@ export class ProblemService {
 
     return plainToInstance(ProblemsResponseDto, await Promise.all(problems))
   }
-  async searchProblems(search: string) {
-    const data = await this.problemRepository.searchProblems(search)
+  async searchProblemTitle(search: string) {
+    const data = await this.problemRepository.searchProblemTitle(search)
     return plainToInstance(ProblemsResponseDto, data)
   }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2,7 +2,9 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  // PostgreSQL full-text search feature를 사요하기 위해 previewFeatures를 추가합니다.
+  previewFeatures = ["fullTextSearch"]
 }
 
 generator graphql {

--- a/collection/client/Problem/Search Problem Title/Succeed.bru
+++ b/collection/client/Problem/Search Problem Title/Succeed.bru
@@ -5,11 +5,11 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/problem?search=정수
+  url: {{baseUrl}}/problem?search=사
   body: none
   auth: none
 }
 
 query {
-  search: 정수
+  search: 사
 }

--- a/collection/client/Problem/Search Problem Title/Succeed.bru
+++ b/collection/client/Problem/Search Problem Title/Succeed.bru
@@ -13,3 +13,11 @@ get {
 query {
   search: 사
 }
+
+docs {
+  # Search Problem Title
+  - `{{baseUrl}}/problem?search`
+  - query params
+    - `search`: 검색어
+  - 검색어를 이용하여, `Problem`의 `title`을 검색합니다.
+}

--- a/collection/client/Problem/Search Problem Title/Succeed.bru
+++ b/collection/client/Problem/Search Problem Title/Succeed.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Succeed
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/problem?search=정수
+  body: none
+  auth: none
+}
+
+query {
+  search: 정수
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`Problem`의 `title` field를 검색하는 api를 구현했습니다.  
본래는 [postgreSQL의 full-text search](https://www.prisma.io/docs/orm/prisma-client/queries/full-text-search)를 사용하여 구현하려 했으나, 띄어쓰기로 나눠진 단어 단위로만 검색이 됐습니다.  
그래서 Prisma의 `contains`를 사용하여 글자 단위 검색을 구현했습니다.  
텍스트량이 많은 필드는 full-text search를 이용하여 구현해 보는 것도 방법이라고 생각이 됩니다.

![image](https://github.com/skkuding/codedang/assets/48322716/a649ed77-dc68-4195-9fae-19576fe7ae12)

상기 이미지의 검색 결과를 보면, `사`라는 텍스트가 포함만 되어도, `Problem`들이 검색이 됩니다.  
하지만, full-text search를 쓸 경우, `사이클` 혹은 `경사`라는 단어를 검색해야 비로소 검색이 됩니다.  

closes #1117 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
