### PR TITLE
fix(fe): fixed light theme in sonner

### DIFF
--- a/frontend-client/components/ui/sonner.tsx
+++ b/frontend-client/components/ui/sonner.tsx
@@ -6,7 +6,7 @@ import { Toaster as Sonner } from 'sonner'
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  // const { theme = 'light' } = useTheme()
+  // const { theme = 'system' } = useTheme()
 
   return (
     <Sonner

--- a/frontend-client/components/ui/sonner.tsx
+++ b/frontend-client/components/ui/sonner.tsx
@@ -1,16 +1,17 @@
-'use client'
-
-import { useTheme } from 'next-themes'
+// TODO: Uncomment this when we have a dark theme
+// 'use client'
+// import { useTheme } from 'next-themes'
 import { Toaster as Sonner } from 'sonner'
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme()
+  // const { theme = 'light' } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      // theme={theme as ToasterProps['theme']}
+      theme="light"
       className="toaster group"
       toastOptions={{
         classNames: {


### PR DESCRIPTION
### Description

<img width="406" alt="Screenshot 2024-01-02 at 7 42 39 PM" src="https://github.com/skkuding/codedang/assets/50468628/78edc15e-a510-47bb-90db-237f154acb10">

기존에는 system의 theme를 가져와서 sooner의 theme를 설정하기 때문에 system이 dark mode 일 경우 sooner에 dark theme가 적용됨.
하지만 우리는 아직 dark mode를 고려하지 않기 때문에 해당 부분들은 일단 주석 처리하고 sooner의 theme를 light로 고정시킴

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
