### PR TITLE
fix(infra): set github token for oauth as sensitive in tfvars

### DIFF
--- a/infra/modules/codedang-infra/variables.tf
+++ b/infra/modules/codedang-infra/variables.tf
@@ -77,11 +77,13 @@ variable "rabbitmq_submission_routing_key" {
 }
 
 variable "github_client_id" {
-  type    = string
-  default = "github_client_id"
+  type      = string
+  default   = "github_client_id"
+  sensitive = true
 }
 
 variable "github_client_secret" {
-  type    = string
-  default = "github_client_secret"
+  type      = string
+  default   = "github_client_secret"
+  sensitive = true
 }


### PR DESCRIPTION
### Description
Tfvars에서 사용하는 GITHUB_CLIENT_ID 및 GITHUB_CLIENT_SECRET 값을 `sensitive`로 설정합니다 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
