### PR TITLE
feat(fe): combine signin signup modal

### DIFF
--- a/frontend-client/app/_components/Auth.tsx
+++ b/frontend-client/app/_components/Auth.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react'
+import SignIn from './SignIn'
+import SignUp from './SignUp'
+
+interface Props {
+  initialIndex: number
+}
+export default function Auth({ initialIndex }: Props) {
+  const [authIndex, setAuthIndex] = useState<number>(initialIndex)
+  const switchModal = () => {
+    setAuthIndex(1 - authIndex)
+  }
+  return authIndex === 0 ? (
+    <SignIn switchModal={switchModal} />
+  ) : (
+    <SignUp switchModal={switchModal} />
+  )
+}

--- a/frontend-client/app/_components/Auth.tsx
+++ b/frontend-client/app/_components/Auth.tsx
@@ -1,18 +1,8 @@
-import { useState } from 'react'
+import useAuthStore from '@/stores/auth'
 import SignIn from './SignIn'
 import SignUp from './SignUp'
 
-interface Props {
-  initialIndex: number
-}
-export default function Auth({ initialIndex }: Props) {
-  const [authIndex, setAuthIndex] = useState<number>(initialIndex)
-  const switchModal = () => {
-    setAuthIndex(1 - authIndex)
-  }
-  return authIndex === 0 ? (
-    <SignIn switchModal={switchModal} />
-  ) : (
-    <SignUp switchModal={switchModal} />
-  )
+export default function Auth() {
+  const { currentModal } = useAuthStore((state) => state)
+  return currentModal === 'signIn' ? <SignIn /> : <SignUp />
 }

--- a/frontend-client/app/_components/Auth.tsx
+++ b/frontend-client/app/_components/Auth.tsx
@@ -1,8 +1,34 @@
 import useAuthStore from '@/stores/auth'
+import { Transition } from '@headlessui/react'
 import SignIn from './SignIn'
 import SignUp from './SignUp'
 
 export default function Auth() {
   const { currentModal } = useAuthStore((state) => state)
-  return currentModal === 'signIn' ? <SignIn /> : <SignUp />
+  return (
+    <>
+      <Transition
+        show={currentModal === 'signIn'}
+        enter="transition-opacity duration-150"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-150"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <SignIn />
+      </Transition>
+      <Transition
+        show={currentModal === 'signUp'}
+        enter="transition-opacity duration-150"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-150"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <SignUp />
+      </Transition>
+    </>
+  )
 }

--- a/frontend-client/app/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/_components/HeaderAuthPanel.tsx
@@ -2,15 +2,18 @@
 
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
+import useAuthStore from '@/stores/auth'
 import { RxHamburgerMenu } from 'react-icons/rx'
 import Auth from './Auth'
 
 export default function HeaderAuthPanel() {
+  const { showSignIn, showSignUp } = useAuthStore((state) => state)
   return (
     <div className="ml-2 flex items-center gap-2">
       <Dialog>
         <DialogTrigger asChild>
           <Button
+            onClick={() => showSignIn()}
             variant={'outline'}
             className="hidden border-none px-3 py-1 text-base font-semibold md:block"
           >
@@ -18,12 +21,13 @@ export default function HeaderAuthPanel() {
           </Button>
         </DialogTrigger>
         <DialogContent className="max-w-[22rem]">
-          <Auth initialIndex={0} />
+          <Auth />
         </DialogContent>
       </Dialog>
       <Dialog>
         <DialogTrigger asChild>
           <Button
+            onClick={() => showSignUp()}
             variant={'outline'}
             className="hidden px-3 py-1 text-base font-bold md:block"
           >
@@ -31,7 +35,7 @@ export default function HeaderAuthPanel() {
           </Button>
         </DialogTrigger>
         <DialogContent className="max-w-[22rem]">
-          <Auth initialIndex={1} />
+          <Auth />
         </DialogContent>
       </Dialog>
       <RxHamburgerMenu size="30" className="md:hidden" />

--- a/frontend-client/app/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/_components/HeaderAuthPanel.tsx
@@ -29,7 +29,7 @@ export default function HeaderAuthPanel() {
             Sign Up
           </Button>
         </DialogTrigger>
-        <DialogContent className="max-w-[22rem]">
+        <DialogContent className="h-[500px] max-w-[22rem]">
           <Auth />
         </DialogContent>
       </Dialog>

--- a/frontend-client/app/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/_components/HeaderAuthPanel.tsx
@@ -20,11 +20,6 @@ export default function HeaderAuthPanel() {
             Sign In
           </Button>
         </DialogTrigger>
-        <DialogContent className="max-w-[22rem]">
-          <Auth />
-        </DialogContent>
-      </Dialog>
-      <Dialog>
         <DialogTrigger asChild>
           <Button
             onClick={() => showSignUp()}

--- a/frontend-client/app/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/_components/HeaderAuthPanel.tsx
@@ -29,7 +29,7 @@ export default function HeaderAuthPanel() {
             Sign Up
           </Button>
         </DialogTrigger>
-        <DialogContent className="h-[500px] max-w-[22rem]">
+        <DialogContent className="h-[520px] max-w-[22rem]">
           <Auth />
         </DialogContent>
       </Dialog>

--- a/frontend-client/app/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/_components/HeaderAuthPanel.tsx
@@ -3,8 +3,7 @@
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
 import { RxHamburgerMenu } from 'react-icons/rx'
-import SignIn from './SignIn'
-import SignUp from './SignUp'
+import Auth from './Auth'
 
 export default function HeaderAuthPanel() {
   return (
@@ -19,7 +18,7 @@ export default function HeaderAuthPanel() {
           </Button>
         </DialogTrigger>
         <DialogContent className="max-w-[22rem]">
-          <SignIn />
+          <Auth initialIndex={0} />
         </DialogContent>
       </Dialog>
       <Dialog>
@@ -32,7 +31,7 @@ export default function HeaderAuthPanel() {
           </Button>
         </DialogTrigger>
         <DialogContent className="max-w-[22rem]">
-          <SignUp />
+          <Auth initialIndex={1} />
         </DialogContent>
       </Dialog>
       <RxHamburgerMenu size="30" className="md:hidden" />

--- a/frontend-client/app/_components/SignIn.tsx
+++ b/frontend-client/app/_components/SignIn.tsx
@@ -5,11 +5,13 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import CodedangLogo from '@/public/codedang.svg'
 import KakaotalkLogo from '@/public/kakaotalk.svg'
+import useAuthStore from '@/stores/auth'
 import Image from 'next/image'
 import { FaGithub } from 'react-icons/fa'
 import { FcGoogle } from 'react-icons/fc'
 
-export default function SignIn({ switchModal }: { switchModal: () => void }) {
+export default function SignIn() {
+  const { showSignUp } = useAuthStore((state) => state)
   return (
     <div className="flex w-full flex-col gap-3">
       <div className="flex justify-center py-4">
@@ -47,7 +49,7 @@ export default function SignIn({ switchModal }: { switchModal: () => void }) {
       </div>
       <div className="mt-4 flex items-center justify-between">
         <Button
-          onClick={() => switchModal()}
+          onClick={() => showSignUp()}
           variant={'link'}
           className="h-5 w-fit p-0 py-2 text-xs text-gray-500"
         >

--- a/frontend-client/app/_components/SignIn.tsx
+++ b/frontend-client/app/_components/SignIn.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image'
 import { FaGithub } from 'react-icons/fa'
 import { FcGoogle } from 'react-icons/fc'
 
-export default function SignIn() {
+export default function SignIn({ switchModal }: { switchModal: () => void }) {
   return (
     <div className="flex w-full flex-col gap-3">
       <div className="flex justify-center py-4">
@@ -47,6 +47,7 @@ export default function SignIn() {
       </div>
       <div className="mt-4 flex items-center justify-between">
         <Button
+          onClick={() => switchModal()}
           variant={'link'}
           className="h-5 w-fit p-0 py-2 text-xs text-gray-500"
         >

--- a/frontend-client/app/_components/SignUp.tsx
+++ b/frontend-client/app/_components/SignUp.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import CodedangLogo from '@/public/codedang.svg'
+import useAuthStore from '@/stores/auth'
 import Image from 'next/image'
 import React, { useState } from 'react'
 import { IoMdArrowBack } from 'react-icons/io'
@@ -17,7 +18,8 @@ export interface FormData {
   }
 }
 
-export default function SignUp({ switchModal }: { switchModal: () => void }) {
+export default function SignUp() {
+  const { showSignIn } = useAuthStore((state) => state)
   const [modalPage, setModalPage] = useState(0)
   const [formData, setFormData] = useState({
     email: '',
@@ -62,7 +64,7 @@ export default function SignUp({ switchModal }: { switchModal: () => void }) {
           Already have account?
         </span>
         <Button
-          onClick={() => switchModal()}
+          onClick={() => showSignIn()}
           variant={'link'}
           className="h-5 w-fit text-xs text-gray-500"
         >

--- a/frontend-client/app/_components/SignUp.tsx
+++ b/frontend-client/app/_components/SignUp.tsx
@@ -38,7 +38,7 @@ export default function SignUp() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center">
+    <div className="flex flex-col items-center justify-center ">
       {!(modalPage === 0) && (
         <button
           onClick={backModal}

--- a/frontend-client/app/_components/SignUp.tsx
+++ b/frontend-client/app/_components/SignUp.tsx
@@ -59,7 +59,7 @@ export default function SignUp() {
         <SignUpEmailVerify nextModal={nextModal} setFormData={setFormData} />
       )}
       {modalPage === 2 && <SignUpRegister formData={formData} />}
-      <div className="mt-4 flex items-center justify-center">
+      <div className="absolute bottom-6 mt-4 flex items-center justify-center">
         <span className="h-5 w-fit text-xs leading-5 text-gray-500">
           Already have account?
         </span>

--- a/frontend-client/app/_components/SignUp.tsx
+++ b/frontend-client/app/_components/SignUp.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Button } from '@/components/ui/button'
 import CodedangLogo from '@/public/codedang.svg'
 import Image from 'next/image'
 import React, { useState } from 'react'
@@ -16,7 +17,7 @@ export interface FormData {
   }
 }
 
-export default function SignUp() {
+export default function SignUp({ switchModal }: { switchModal: () => void }) {
   const [modalPage, setModalPage] = useState(0)
   const [formData, setFormData] = useState({
     email: '',
@@ -56,11 +57,17 @@ export default function SignUp() {
         <SignUpEmailVerify nextModal={nextModal} setFormData={setFormData} />
       )}
       {modalPage === 2 && <SignUpRegister formData={formData} />}
-      <div className="flex items-center text-sm text-gray-500">
-        Already have an account?
-        <a className="ml-5 w-fit cursor-pointer text-sm underline hover:text-black active:text-black">
+      <div className="mt-4 flex items-center justify-center">
+        <span className="h-5 w-fit text-xs leading-5 text-gray-500">
+          Already have account?
+        </span>
+        <Button
+          onClick={() => switchModal()}
+          variant={'link'}
+          className="h-5 w-fit text-xs text-gray-500"
+        >
           Sign In
-        </a>
+        </Button>
       </div>
     </div>
   )

--- a/frontend-client/app/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/_components/SignUpEmailVerify.tsx
@@ -106,11 +106,9 @@ export default function SignUpEmailVerify({
   return (
     <div className="mb-24 mt-24">
       <form onSubmit={handleSubmit(onSubmit)}>
-        <div>
-          <p className="mb-5 text-left text-xl font-bold text-blue-500">
-            Sign Up
-          </p>
-        </div>
+        <p className="mb-5 mt-8 text-left text-xl font-bold text-blue-500">
+          Sign Up
+        </p>
         {!sentEmail && (
           <Input
             id="email"

--- a/frontend-client/app/_components/SignUpRegister.tsx
+++ b/frontend-client/app/_components/SignUpRegister.tsx
@@ -115,15 +115,12 @@ export default function SignUpRegister({ formData }: { formData: FormData }) {
   }
 
   return (
-    <div className="mb-5 mt-16 flex w-full flex-col p-4">
+    <div className="mb-5 mt-12 flex w-full flex-col p-4">
       <form
         className="flex w-full flex-col gap-4"
         onSubmit={handleSubmit(onSubmit)}
       >
-        <p className="mb-2 text-left text-xl font-bold text-blue-500">
-          Sign Up
-        </p>
-
+        <p className="text-left text-xl font-bold text-blue-500">Sign Up</p>
         <div>
           <Input
             placeholder="Your name"
@@ -173,7 +170,7 @@ export default function SignUpRegister({ formData }: { formData: FormData }) {
               <p>&#x2022; User ID used for log in</p>
               <p>
                 &#x2022; Your ID must be 3-10 characters of alphabet
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;letters, numbers
+                &nbsp;&nbsp;letters, numbers
               </p>
             </div>
           )}

--- a/frontend-client/app/_components/SignUpWelcome.tsx
+++ b/frontend-client/app/_components/SignUpWelcome.tsx
@@ -13,8 +13,8 @@ export default function SignUpWelcome({
   nextModal: () => void
 }) {
   return (
-    <div className="mb-20 mt-32">
-      <p className="mb-3 text-center text-xl font-bold text-blue-500">
+    <div className="mb-20 mt-36">
+      <p className="mb-3 text-center text-xl font-semibold text-blue-500">
         &quot;Welcome to CODEDANG&quot;
       </p>
 

--- a/frontend-client/package.json
+++ b/frontend-client/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.17",
     "@hookform/resolvers": "^3.3.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-separator": "^1.0.3",

--- a/frontend-client/package.json
+++ b/frontend-client/package.json
@@ -26,7 +26,8 @@
     "react-use": "^17.4.2",
     "sharp": "^0.33.1",
     "sonner": "^1.3.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",

--- a/frontend-client/stores/auth.ts
+++ b/frontend-client/stores/auth.ts
@@ -7,8 +7,18 @@ interface AuthStore {
 }
 const useAuthStore = create<AuthStore>((set) => ({
   currentModal: '',
-  showSignIn: () => set({ currentModal: 'signIn' }),
-  showSignUp: () => set({ currentModal: 'signUp' })
+  showSignIn: () => {
+    set({ currentModal: '' })
+    setTimeout(() => {
+      set({ currentModal: 'signIn' })
+    }, 150)
+  },
+  showSignUp: () => {
+    set({ currentModal: '' })
+    setTimeout(() => {
+      set({ currentModal: 'signUp' })
+    }, 150)
+  }
 }))
 
 export default useAuthStore

--- a/frontend-client/stores/auth.ts
+++ b/frontend-client/stores/auth.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand'
+
+interface AuthStore {
+  currentModal: string
+  showSignIn: () => void
+  showSignUp: () => void
+}
+const useAuthStore = create<AuthStore>((set) => ({
+  currentModal: '',
+  showSignIn: () => set({ currentModal: 'signIn' }),
+  showSignUp: () => set({ currentModal: 'signUp' })
+}))
+
+export default useAuthStore


### PR DESCRIPTION
### Description
1. SignIn과 SignUp 모달을 Auth 컴포넌트로 묶음
   - zustand로 상태 관리
   - 상태에 따라 각 모달을 보여줍니다.
2. Headless UI로 SignIn, SignUp 전환 시 트랜지션 추가
3. 트랜지션 사용을 위해 Dialog의 height를 520px로 고정
   - 고정된 height에 맞게 여백 조정
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
close #1120 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
