### PR TITLE
feat(be): change submission id type

### DIFF
--- a/backend/apps/client/src/submission/dto/judger-response.dto.ts
+++ b/backend/apps/client/src/submission/dto/judger-response.dto.ts
@@ -40,9 +40,9 @@ export class JudgerResponse {
   @IsNotEmpty()
   resultCode: number
 
-  @IsString()
+  @IsNumber()
   @IsNotEmpty()
-  submissionId: string
+  submissionId: number
 
   @IsString()
   error: string

--- a/backend/apps/client/src/submission/mock/submission.mock.ts
+++ b/backend/apps/client/src/submission/mock/submission.mock.ts
@@ -4,7 +4,7 @@ import { type CreateSubmissionDto, Snippet } from '../dto/create-submission.dto'
 
 export const submissions = [
   {
-    id: 'test01',
+    id: 1,
     code: [
       { id: 1, text: 'code', locked: false },
       { id: 2, text: 'unchanged', locked: true }
@@ -19,7 +19,7 @@ export const submissions = [
     workbookId: null
   },
   {
-    id: 'test02',
+    id: 2,
     code: [
       { id: 1, text: 'code', locked: false },
       { id: 2, text: 'changed', locked: true }

--- a/backend/apps/client/src/submission/mock/submissionResult.mock.ts
+++ b/backend/apps/client/src/submission/mock/submissionResult.mock.ts
@@ -7,7 +7,7 @@ export const submissionResults: SubmissionResult[] = [
     createTime: new Date('2023-01-01'),
     problemTestcaseId: 1,
     result: ResultStatus.Accepted,
-    submissionId: 'test01',
+    submissionId: 1,
     updateTime: new Date('2023-01-01'),
     cpuTime: BigInt(12345),
     memoryUsage: 12345
@@ -17,7 +17,7 @@ export const submissionResults: SubmissionResult[] = [
     createTime: new Date('2023-01-01'),
     problemTestcaseId: 2,
     result: ResultStatus.Accepted,
-    submissionId: 'test01',
+    submissionId: 2,
     updateTime: new Date('2023-01-01'),
     cpuTime: BigInt(12345),
     memoryUsage: 12345
@@ -27,7 +27,7 @@ export const submissionResults: SubmissionResult[] = [
     createTime: new Date('2023-01-01'),
     problemTestcaseId: 3,
     result: ResultStatus.WrongAnswer,
-    submissionId: 'test01',
+    submissionId: 1,
     updateTime: new Date('2023-01-01'),
     cpuTime: BigInt(12345),
     memoryUsage: 12345
@@ -37,7 +37,7 @@ export const submissionResults: SubmissionResult[] = [
     createTime: new Date('2023-01-01'),
     problemTestcaseId: 4,
     result: ResultStatus.CompileError,
-    submissionId: 'test01',
+    submissionId: 1,
     updateTime: new Date('2023-01-01'),
     cpuTime: BigInt(12345),
     memoryUsage: 12345
@@ -46,7 +46,7 @@ export const submissionResults: SubmissionResult[] = [
 
 export const judgerResponse: JudgerResponse = {
   resultCode: 6,
-  submissionId: 'test01',
+  submissionId: 1,
   error: '',
   data: {
     acceptedNum: 2,

--- a/backend/apps/client/src/submission/submission.controller.ts
+++ b/backend/apps/client/src/submission/submission.controller.ts
@@ -65,7 +65,7 @@ export class ProblemSubmissionController {
   async getSubmission(
     @Req() req: AuthenticatedRequest,
     @Param('problemId', ParseIntPipe) problemId: number,
-    @Param('id') id: string
+    @Param('id') id: number
   ) {
     try {
       return await this.submissionService.getSubmission(
@@ -131,7 +131,7 @@ export class GroupProblemSubmissionController {
     @Req() req: AuthenticatedRequest,
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('problemId', ParseIntPipe) problemId: number,
-    @Param('id') id: string
+    @Param('id') id: number
   ) {
     try {
       return await this.submissionService.getSubmission(
@@ -208,7 +208,7 @@ export class ContestSubmissionController {
     @Req() req: AuthenticatedRequest,
     @Param('contestId', ParseIntPipe) contestId: number,
     @Param('problemId', ParseIntPipe) problemId: number,
-    @Param('id') id: string
+    @Param('id') id: number
   ) {
     try {
       return await this.submissionService.getContestSubmission(
@@ -291,7 +291,7 @@ export class GroupContestSubmissionController {
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('contestId', ParseIntPipe) contestId: number,
     @Param('problemId', ParseIntPipe) problemId: number,
-    @Param('id') id: string
+    @Param('id') id: number
   ) {
     try {
       return await this.submissionService.getContestSubmission(
@@ -356,7 +356,7 @@ export class WorkbookSubmissionController {
   async getSubmission(
     @Req() req: AuthenticatedRequest,
     @Param('problemId', ParseIntPipe) problemId: number,
-    @Param('id') id: string
+    @Param('id') id: number
   ) {
     try {
       return await this.submissionService.getSubmission(
@@ -426,7 +426,7 @@ export class GroupWorkbookSubmissionController {
     @Req() req: AuthenticatedRequest,
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('problemId', ParseIntPipe) problemId: number,
-    @Param('id') id: string
+    @Param('id') id: number
   ) {
     try {
       return await this.submissionService.getSubmission(

--- a/backend/apps/client/src/submission/submission.service.spec.ts
+++ b/backend/apps/client/src/submission/submission.service.spec.ts
@@ -250,7 +250,7 @@ describe('SubmissionService', () => {
       const target: JudgerResponse = {
         resultCode: 7,
         error: 'succeed',
-        submissionId: 'abc123',
+        submissionId: 1,
         data: {
           acceptedNum: 1,
           totalTestcase: 1,
@@ -440,7 +440,7 @@ describe('SubmissionService', () => {
         resultCode: -1,
         data: 'Test Error',
         error: 'Test Error',
-        submissionId: 'abc123'
+        submissionId: 1
       }
 
       await expect(service.validateJudgerResponse(target)).to.be.rejected
@@ -450,7 +450,7 @@ describe('SubmissionService', () => {
       const target: JudgerResponse = {
         resultCode: 5,
         error: 'succeed',
-        submissionId: 'abc123',
+        submissionId: 1,
         data: {
           acceptedNum: 1,
           totalTestcase: 1,
@@ -478,7 +478,7 @@ describe('SubmissionService', () => {
   it('should handle message without error', async () => {
     const target = {
       resultCode: 0,
-      submissionId: 'a84f8d',
+      submissionId: 1,
       error: '',
       data: {
         acceptedNum: 1,
@@ -596,7 +596,7 @@ describe('SubmissionService', () => {
 
   // describe('getSubmissionResults', () => {
   //   it('should return judgeFinished=true when judge finished', async () => {
-  //     const submissionId = 'test01'
+  //     const submissionId = 1
   //     const results = submissionResults.filter(
   //       (submissionResult) => submissionResult.submissionId === submissionId
   //     )
@@ -613,7 +613,7 @@ describe('SubmissionService', () => {
   //   })
 
   //   it('shoud return judgeFinished=false when judge not finished', async () => {
-  //     const submissionId = 'test02'
+  //     const submissionId = 2
   //     db.submissionResult.findMany.resolves
   //     const results = submissionResults.filter(
   //       (submissionResult) => submissionResult.submissionId === submissionId
@@ -631,7 +631,7 @@ describe('SubmissionService', () => {
   //   })
 
   //   it('shoud return passed=false when at least one of judge failed', async () => {
-  //     const submissionId = 'test03'
+  //     const submissionId = 3
   //     db.submissionResult.findMany.resolves
   //     const results = submissionResults.filter(
   //       (submissionResult) => submissionResult.submissionId === submissionId

--- a/backend/apps/client/src/submission/submission.service.ts
+++ b/backend/apps/client/src/submission/submission.service.ts
@@ -193,7 +193,6 @@ export class SubmissionService implements OnModuleInit {
 
     const submission = await this.prisma.submission.create({
       data: {
-        id: this.hash(),
         code: code.map((snippet) => ({ ...snippet })), // convert to plain object
         result: ResultStatus.Judging,
         userId,
@@ -293,7 +292,7 @@ export class SubmissionService implements OnModuleInit {
   }
 
   async updateSubmissionResult(
-    id: string,
+    id: number,
     resultStatus: ResultStatus,
     results: Partial<SubmissionResult>[]
   ) {
@@ -393,7 +392,7 @@ export class SubmissionService implements OnModuleInit {
   }
 
   async getSubmission(
-    id: string,
+    id: number,
     problemId: number,
     userId: number,
     groupId = OPEN_SPACE_ID
@@ -516,7 +515,7 @@ export class SubmissionService implements OnModuleInit {
   }
 
   async getContestSubmission(
-    id: string,
+    id: number,
     problemId: number,
     contestId: number,
     userId: number,

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -13,6 +13,7 @@ UPDATE submssion_result T SET submission_id = (SELECT id FROM submission WHERE h
 -- AlterTable
 ALTER TABLE "submission" DROP COLUMN "hex_code";
 ALTER TABLE "submssion_result" DROP COLUMN "hex_code_id";
+ALTER TABLE "submission_result" ALTER COLUMN "submission_id" SET NOT NULL;
 
 -- AddForeignKey
 ALTER TABLE "submssion_result" ADD CONSTRAINT "submssion_result_submission_id_fkey" FOREIGN KEY ("submission_id") REFERENCES "submission"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -13,7 +13,7 @@ UPDATE submssion_result T SET submission_id = (SELECT id FROM submission WHERE h
 -- AlterTable
 ALTER TABLE "submission" DROP COLUMN "hex_code";
 ALTER TABLE "submssion_result" DROP COLUMN "hex_code_id";
-ALTER TABLE "submission_result" ALTER COLUMN "submission_id" SET NOT NULL;
+ALTER TABLE "submssion_result" ALTER COLUMN "submission_id" SET NOT NULL;
 
 -- AddForeignKey
 ALTER TABLE "submssion_result" ADD CONSTRAINT "submssion_result_submission_id_fkey" FOREIGN KEY ("submission_id") REFERENCES "submission"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -1,24 +1,18 @@
 -- DropForeignKey
 ALTER TABLE "submssion_result" DROP CONSTRAINT "submssion_result_submission_id_fkey";
-
--- ChangeIdType
-SELECT id, REGEXP_REPLACE(id, '[^[:digit:]]', '') FROM submission;
-
--- AlterTable
-ALTER TABLE "submission"
-ALTER COLUMN "id" SET DATA TYPE INTEGER USING id::INTEGER,
-ALTER COLUMN "id" SET NOT NULL;
-
--- CreateSequence
-CREATE SEQUENCE submission_id_seq;
+ALTER TABLE "submssion_result" RENAME COLUMN "submission_id" TO "hex_code_id";
+ALTER TABLE "submssion_result" ADD COLUMN "submission_id" INTEGER;
 
 -- AlterTable
-ALTER TABLE "submission"
-ALTER COLUMN "id" SET DEFAULT nextval('submission_id_seq');
+ALTER TABLE "submission" RENAME COLUMN "id" TO "hex_code";
+ALTER TABLE "submission" DROP CONSTRAINT "submission_pkey";
+ALTER TABLE "submission" ADD COLUMN "id" SERIAL PRIMARY KEY;
+
+UPDATE submssion_result T SET submission_id = (SELECT id FROM submission WHERE hex_code = T.hex_code_id);
 
 -- AlterTable
-ALTER TABLE "submssion_result"
-ALTER COLUMN "submission_id" SET DATA TYPE INTEGER USING submission_id::INTEGER;
+ALTER TABLE "submission" DROP COLUMN "hex_code";
+ALTER TABLE "submssion_result" DROP COLUMN "hex_code_id";
 
 -- AddForeignKey
 ALTER TABLE "submssion_result" ADD CONSTRAINT "submssion_result_submission_id_fkey" FOREIGN KEY ("submission_id") REFERENCES "submission"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -1,6 +1,9 @@
 -- DropForeignKey
 ALTER TABLE "submssion_result" DROP CONSTRAINT "submssion_result_submission_id_fkey";
 
+-- ChangeIdType
+SELECT id, REGEXP_REPLACE(id, '[^0-9]', '', 'g') FROM submission;
+
 -- AlterTable
 ALTER TABLE "submission"
 ALTER COLUMN "id" SET DATA TYPE INTEGER USING id::INTEGER,

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - The primary key for the `submission` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `submission` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `submission_id` on the `submssion_result` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "submssion_result" DROP CONSTRAINT "submssion_result_submission_id_fkey";
+
+-- AlterTable
+ALTER TABLE "submission"
+ALTER COLUMN "id" SET DATA TYPE INTEGER USING id::INTEGER,
+ALTER COLUMN "id" SET NOT NULL;
+
+-- CreateSequence
+CREATE SEQUENCE submission_id_seq;
+
+-- AlterTable
+ALTER TABLE "submission"
+ALTER COLUMN "id" SET DEFAULT nextval('submission_id_seq');
+
+-- AlterTable
+ALTER TABLE "submssion_result"
+ALTER COLUMN "submission_id" SET DATA TYPE INTEGER USING submission_id::INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "submssion_result" ADD CONSTRAINT "submssion_result_submission_id_fkey" FOREIGN KEY ("submission_id") REFERENCES "submission"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -1,11 +1,3 @@
-/*
-  Warnings:
-
-  - The primary key for the `submission` table will be changed. If it partially fails, the table could be left without primary key constraint.
-  - The `id` column on the `submission` table would be dropped and recreated. This will lead to data loss if there is data in the column.
-  - Changed the type of `submission_id` on the `submssion_result` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
-
-*/
 -- DropForeignKey
 ALTER TABLE "submssion_result" DROP CONSTRAINT "submssion_result_submission_id_fkey";
 

--- a/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
+++ b/backend/prisma/migrations/20240104063238_change_submission_id_type/migration.sql
@@ -2,7 +2,7 @@
 ALTER TABLE "submssion_result" DROP CONSTRAINT "submssion_result_submission_id_fkey";
 
 -- ChangeIdType
-SELECT id, REGEXP_REPLACE(id, '[^0-9]', '', 'g') FROM submission;
+SELECT id, REGEXP_REPLACE(id, '[^[:digit:]]', '') FROM submission;
 
 -- AlterTable
 ALTER TABLE "submission"

--- a/backend/prisma/migrations/20240104072555_change_submission_result_table_name/migration.sql
+++ b/backend/prisma/migrations/20240104072555_change_submission_result_table_name/migration.sql
@@ -1,9 +1,3 @@
-/*
-  Warnings:
-
-  - You are about to drop the `submssion_result` table. If the table is not empty, all the data it contains will be lost.
-
-*/
 -- AlterTable
 ALTER TABLE submssion_result RENAME TO submission_result;
 

--- a/backend/prisma/migrations/20240104072555_change_submission_result_table_name/migration.sql
+++ b/backend/prisma/migrations/20240104072555_change_submission_result_table_name/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - You are about to drop the `submssion_result` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE submssion_result RENAME TO submission_result;
+
+-- AlterTable
+ALTER TABLE "submission_result" RENAME CONSTRAINT "submssion_result_pkey" TO "submission_result_pkey";
+
+-- RenameForeignKey
+ALTER TABLE "submission_result" RENAME CONSTRAINT "submssion_result_problem_test_case_id_fkey" TO "submission_result_problem_test_case_id_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "submission_result" RENAME CONSTRAINT "submssion_result_submission_id_fkey" TO "submission_result_submission_id_fkey";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -334,7 +334,7 @@ model WorkbookProblem {
 }
 
 model Submission {
-  id         String       @id // 6 digit hex hash
+  id         Int          @id @default(autoincrement())
   user       User?        @relation(fields: [userId], references: [id], onDelete: SetNull)
   userId     Int?         @map("user_id")
   problem    Problem      @relation(fields: [problemId], references: [id], onDelete: Cascade)
@@ -365,7 +365,7 @@ model Submission {
 model SubmissionResult {
   id                Int             @id @default(autoincrement())
   submission        Submission      @relation(fields: [submissionId], references: [id], onDelete: Cascade)
-  submissionId      String          @map("submission_id")
+  submissionId      Int             @map("submission_id")
   problemTestcase   ProblemTestcase @relation(fields: [problemTestcaseId], references: [id], onDelete: Cascade)
   problemTestcaseId Int             @map("problem_test_case_id")
   result            ResultStatus

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -374,7 +374,7 @@ model SubmissionResult {
   createTime        DateTime        @default(now()) @map("create_time")
   updateTime        DateTime        @updatedAt @map("update_time")
 
-  @@map("submssion_result")
+  @@map("submission_result")
 }
 
 enum ResultStatus {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -996,16 +996,9 @@ const createWorkbooks = async () => {
 }
 
 const createSubmissions = async () => {
-  const generateHash = () => {
-    return Math.floor(Math.random() * 16777215)
-      .toString(16)
-      .padStart(6, '0')
-  }
-
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[0].id,
         problemId: problems[0].id,
         contestId: contest.id,
@@ -1044,7 +1037,6 @@ int main(void) {
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[1].id,
         problemId: problems[1].id,
         contestId: contest.id,
@@ -1083,7 +1075,6 @@ int main(void) {
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[2].id,
         problemId: problems[2].id,
         contestId: contest.id,
@@ -1122,7 +1113,6 @@ int main(void) {
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[3].id,
         problemId: problems[3].id,
         contestId: contest.id,
@@ -1157,7 +1147,6 @@ int main(void) {
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[4].id,
         problemId: problems[4].id,
         contestId: contest.id,
@@ -1196,7 +1185,6 @@ int main(void) {
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[5].id,
         problemId: problems[5].id,
         workbookId: workbooks[0].id,
@@ -1235,7 +1223,6 @@ int main(void) {
   submissions.push(
     await prisma.submission.create({
       data: {
-        id: generateHash(),
         userId: users[6].id,
         problemId: problems[6].id,
         workbookId: workbooks[0].id,


### PR DESCRIPTION
### Description

Closes #1139 

원래는 Submission ID의 type이 String이었는데, 이를 정렬가능하게 바꾸기 위하여 SERIAL (INTEGER AUTOINCREMENT)으로 변경합니다.
또한, 기존 submission result 테이블에서 typo가 있어 이를 수정했습니다.
- SQL문을 손수 작성했으니 확인바랍니다.



### Additional context


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
