### PR TITLE
feat(be): add accept rate to problem api

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,5 +32,6 @@
     "source=${localEnv:HOME}/.aws,target=/home/node/.aws,type=bind,consistency=cached"
   ],
   // Connect as non-root user (https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user)
-  "remoteUser": "node"
+  "remoteUser": "node",
+  "initializeCommand": "echo 'Hello World!'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,6 +32,5 @@
     "source=${localEnv:HOME}/.aws,target=/home/node/.aws,type=bind,consistency=cached"
   ],
   // Connect as non-root user (https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user)
-  "remoteUser": "node",
-  "initializeCommand": "echo 'Hello World!'"
+  "remoteUser": "node"
 }

--- a/backend/apps/client/src/problem/dto/related-problems.response.dto.ts
+++ b/backend/apps/client/src/problem/dto/related-problems.response.dto.ts
@@ -17,4 +17,12 @@ export class RelatedProblemsResponseDto {
   @Expose()
   @Transform(({ obj }) => obj.problem.difficulty, { toClassOnly: true })
   difficulty: Level
+
+  @Expose()
+  @Transform(({ obj }) => obj.problem.submissionCount, { toClassOnly: true })
+  submissionCount: number
+
+  @Expose()
+  @Transform(({ obj }) => obj.problem.acceptedRate, { toClassOnly: true })
+  acceptedRate: number
 }

--- a/collection/client/Problem/Get contest problems/Succeed.bru
+++ b/collection/client/Problem/Get contest problems/Succeed.bru
@@ -17,7 +17,10 @@ query {
 
 assert {
   res.status: eq 200
-  res.body[0].id: isString 
-  res.body[0].problemId: isNumber 
-  res.body[0].title: isString 
+  res.body[0].order: isNumber 
+  res.body[0].problemId: isNumber
+  res.body[0].title: isString
+  res.body[0].difficulty: isString 
+  res.body[0].submissionCount: isNumber 
+  res.body[0].acceptedRate: isNumber 
 }

--- a/collection/client/Problem/Get group contest problem by ID/Succeed.bru
+++ b/collection/client/Problem/Get group contest problem by ID/Succeed.bru
@@ -12,18 +12,21 @@ get {
 
 assert {
   res.status: eq 200
-  res("id"): isString
-  res("problem").id: isNumber 
-  res("problem").title: isString 
-  res("problem").description: isString 
-  res("problem").inputDescription: isString 
-  res("problem").outputDescription: isString 
-  res("problem").hint: isString 
-  res("problem").languages: isDefined 
-  res("problem").timeLimit: isNumber 
-  res("problem").memoryLimit: isNumber 
-  res("problem").difficulty: isString 
-  res("problem").source: isString 
+  res("order"): isNumber 
+  res("problem").id: isNumber
+  res("problem").title: isString
+  res("problem").description: isString
+  res("problem").inputDescription: isString
+  res("problem").outputDescription: isString
+  res("problem").hint: isString
+  res("problem").languages: isDefined
+  res("problem").timeLimit: isNumber
+  res("problem").memoryLimit: isNumber
+  res("problem").difficulty: isString
+  res("problem").source: isString
+  res("problem").submissionCount: isNumber 
+  res("problem").acceptedCount: isNumber 
+  res("problem").acceptedRate: isNumber 
 }
 
 script:pre-request {

--- a/collection/client/Problem/Get group contest problems/Succeed.bru
+++ b/collection/client/Problem/Get group contest problems/Succeed.bru
@@ -21,6 +21,8 @@ assert {
   res.body[0].problemId: isNumber
   res.body[0].title: isString
   res.body[0].difficulty: isString
+  res.body[0].submissionCount: isNumber 
+  res.body[0].acceptedRate: isNumber 
 }
 
 script:pre-request {

--- a/collection/client/Problem/Get group workbook problem by ID/Succeed.bru
+++ b/collection/client/Problem/Get group workbook problem by ID/Succeed.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res("id"): isString
+  res("order"): isNumber 
   res("problem").id: isNumber
   res("problem").title: isString
   res("problem").description: isString
@@ -24,6 +24,9 @@ assert {
   res("problem").memoryLimit: isNumber
   res("problem").difficulty: isString
   res("problem").source: isString
+  res("problem").submissionCount: isNumber 
+  res("problem").acceptedCount: isNumber 
+  res("problem").acceptedRate: isNumber 
 }
 
 script:pre-request {


### PR DESCRIPTION
### Description

problem의 related problems response dto를 수정하였습니다.

get group workbook problems 및 get group contest problems 요청 시 기존에는 problemID와 title, difficulty를 반환해 주었습니다.
여기에 acceptRate와 submissionCount를 추가하였습니다.

bruno collection의 client/problem 내의 assert 문서를 수정하였습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
