### PR TITLE
fix(be): remove default cursor value

### DIFF
--- a/backend/apps/admin/src/contest/contest.service.spec.ts
+++ b/backend/apps/admin/src/contest/contest.service.spec.ts
@@ -71,7 +71,8 @@ const db = {
     create: stub().resolves(Contest),
     update: stub().resolves(Contest),
     delete: stub().resolves(Contest)
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('ContestService', () => {

--- a/backend/apps/admin/src/contest/contest.service.ts
+++ b/backend/apps/admin/src/contest/contest.service.ts
@@ -31,15 +31,12 @@ export class ContestService {
   ) {}
 
   async getContests(take: number, groupId: number, cursor: number | null) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     return await this.prisma.contest.findMany({
+      ...paginator,
       where: { groupId },
-      skip,
-      take,
-      cursor: {
-        id: cursor ?? 1
-      }
+      take
     })
   }
 

--- a/backend/apps/admin/src/group/group.service.spec.ts
+++ b/backend/apps/admin/src/group/group.service.spec.ts
@@ -78,7 +78,8 @@ const db = {
     create: stub().resolves(null),
     findUnique: stub(),
     deleteMany: stub().resolves({ count: userGroup.length })
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('GroupService', () => {

--- a/backend/apps/admin/src/group/group.service.ts
+++ b/backend/apps/admin/src/group/group.service.ts
@@ -55,21 +55,18 @@ export class GroupService {
   }
 
   async getGroups(cursor: number | null, take: number) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     return (
       await this.prisma.group.findMany({
+        ...paginator,
+        take,
         select: {
           id: true,
           groupName: true,
           description: true,
           config: true,
           userGroup: true
-        },
-        take,
-        skip,
-        cursor: {
-          id: cursor ?? 1
         }
       })
     ).map((data) => {

--- a/backend/apps/admin/src/problem/problem.service.spec.ts
+++ b/backend/apps/admin/src/problem/problem.service.spec.ts
@@ -59,7 +59,8 @@ const db = {
     findMany: stub(),
     update: stub()
   },
-  $transaction: stub()
+  $transaction: stub(),
+  getPaginator: PrismaService.prototype.getPaginator
 }
 const exampleWorkbook: Workbook = {
   id: 1,

--- a/backend/apps/admin/src/problem/problem.service.ts
+++ b/backend/apps/admin/src/problem/problem.service.ts
@@ -274,7 +274,7 @@ export class ProblemService {
     cursor: number | null,
     take: number
   ) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     const whereOptions: ProblemWhereInput = {}
     if (input.difficulty) {
@@ -287,14 +287,11 @@ export class ProblemService {
     }
 
     return await this.prisma.problem.findMany({
+      ...paginator,
       where: {
         ...whereOptions,
         groupId
       },
-      cursor: {
-        id: cursor ?? 1
-      },
-      skip,
       take
     })
   }

--- a/backend/apps/admin/src/user/user.service.spec.ts
+++ b/backend/apps/admin/src/user/user.service.spec.ts
@@ -124,7 +124,8 @@ const db = {
   user: {
     findUnique: stub(),
     findMany: stub()
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('UserService', () => {

--- a/backend/apps/admin/src/user/user.service.ts
+++ b/backend/apps/admin/src/user/user.service.ts
@@ -27,30 +27,13 @@ export class UserService {
     take: number,
     leaderOnly: boolean
   ) {
-    // Cannot use prisma paginator because of composite key
-    type Paginator = {
-      skip?: number
-      cursor?: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        userId_groupId: {
-          userId: number
-          groupId: number
-        }
+    const paginator = this.prisma.getPaginator(cursor, (value) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      userId_groupId: {
+        userId: value,
+        groupId
       }
-    }
-
-    const paginator: Paginator = cursor
-      ? {
-          skip: 1,
-          cursor: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            userId_groupId: {
-              userId: cursor,
-              groupId
-            }
-          }
-        }
-      : {}
+    }))
 
     const userGroups = await this.prisma.userGroup.findMany({
       ...paginator,

--- a/backend/apps/client/src/contest/contest.service.spec.ts
+++ b/backend/apps/client/src/contest/contest.service.spec.ts
@@ -196,7 +196,8 @@ const mockPrismaService = {
   },
   user: {
     findUnique: stub().resolves(user)
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('ContestService', () => {

--- a/backend/apps/client/src/contest/contest.service.ts
+++ b/backend/apps/client/src/contest/contest.service.ts
@@ -116,10 +116,11 @@ export class ContestService {
     take: number,
     groupId = OPEN_SPACE_ID
   ) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
     const now = new Date()
 
     const finished = await this.prisma.contest.findMany({
+      ...paginator,
       where: {
         endTime: {
           lte: now
@@ -129,11 +130,6 @@ export class ContestService {
           path: ['isVisible'],
           equals: true
         }
-      },
-      skip,
-      take,
-      cursor: {
-        id: cursor ?? 1
       },
       select: this.contestSelectOption,
       orderBy: {

--- a/backend/apps/client/src/group/group.service.spec.ts
+++ b/backend/apps/client/src/group/group.service.spec.ts
@@ -41,7 +41,8 @@ const db = {
     findFirst: stub(),
     findMany: stub(),
     findUnique: stub()
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('GroupService', () => {

--- a/backend/apps/client/src/group/group.service.ts
+++ b/backend/apps/client/src/group/group.service.ts
@@ -125,13 +125,12 @@ export class GroupService {
   }
 
   async getGroups(cursor: number | null, take: number) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     const groups = (
       await this.prisma.group.findMany({
+        ...paginator,
         take,
-        skip,
-        cursor: { id: cursor ?? 1 },
         where: {
           NOT: {
             id: 1

--- a/backend/apps/client/src/notice/notice.service.spec.ts
+++ b/backend/apps/client/src/notice/notice.service.spec.ts
@@ -62,7 +62,8 @@ const db = {
   },
   userGroup: {
     findMany: stub().resolves([groupId])
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('NoticeService', () => {

--- a/backend/apps/client/src/notice/notice.service.ts
+++ b/backend/apps/client/src/notice/notice.service.ts
@@ -11,14 +11,16 @@ export class NoticeService {
     take: number,
     groupId = OPEN_SPACE_ID
   ) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     const notices = await this.prisma.notice.findMany({
+      ...paginator,
       where: {
         groupId,
         isVisible: true,
         isFixed: false
       },
+      take,
       select: {
         id: true,
         title: true,
@@ -29,11 +31,6 @@ export class NoticeService {
             username: true
           }
         }
-      },
-      take,
-      skip,
-      cursor: {
-        id: cursor ?? 1
       }
     })
 

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { Injectable } from '@nestjs/common'
 import type { Problem, Tag } from '@prisma/client'
 import { PrismaService } from '@libs/prisma'
@@ -127,28 +126,13 @@ export class ProblemRepository {
     cursor: number | null,
     take: number
   ) {
-    // Cannot use prisma paginator because of composite key
-    type Paginator = {
-      skip?: number
-      cursor?: {
-        contestId_problemId: {
-          contestId: number
-          problemId: number
-        }
+    const paginator = this.prisma.getPaginator(cursor, (value) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      contestId_problemId: {
+        contestId,
+        problemId: value
       }
-    }
-
-    const paginator: Paginator = cursor
-      ? {
-          skip: 1,
-          cursor: {
-            contestId_problemId: {
-              contestId,
-              problemId: cursor
-            }
-          }
-        }
-      : {}
+    }))
 
     return await this.prisma.contestProblem.findMany({
       ...paginator,
@@ -196,28 +180,13 @@ export class ProblemRepository {
     cursor: number | null,
     take: number
   ) {
-    // Cannot use prisma paginator because of composite key
-    type Paginator = {
-      skip?: number
-      cursor?: {
-        workbookId_problemId: {
-          workbookId: number
-          problemId: number
-        }
+    const paginator = this.prisma.getPaginator(cursor, (value) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      workbookId_problemId: {
+        workbookId,
+        problemId: value
       }
-    }
-
-    const paginator: Paginator = cursor
-      ? {
-          skip: 1,
-          cursor: {
-            workbookId_problemId: {
-              workbookId,
-              problemId: cursor
-            }
-          }
-        }
-      : {}
+    }))
 
     return await this.prisma.workbookProblem.findMany({
       ...paginator,

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Injectable } from '@nestjs/common'
 import type { Problem, Tag } from '@prisma/client'
 import { PrismaService } from '@libs/prisma'
@@ -40,13 +41,10 @@ export class ProblemRepository {
   }
 
   async getProblems(cursor: number | null, take: number, groupId: number) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     return await this.prisma.problem.findMany({
-      cursor: {
-        id: cursor ?? 1
-      },
-      skip,
+      ...paginator,
       take,
       where: {
         groupId
@@ -129,17 +127,31 @@ export class ProblemRepository {
     cursor: number | null,
     take: number
   ) {
-    const skip = cursor ? 1 : 0
+    // Cannot use prisma paginator because of composite key
+    type Paginator = {
+      skip?: number
+      cursor?: {
+        contestId_problemId: {
+          contestId: number
+          problemId: number
+        }
+      }
+    }
+
+    const paginator: Paginator = cursor
+      ? {
+          skip: 1,
+          cursor: {
+            contestId_problemId: {
+              contestId,
+              problemId: cursor
+            }
+          }
+        }
+      : {}
 
     return await this.prisma.contestProblem.findMany({
-      cursor: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        contestId_problemId: {
-          contestId,
-          problemId: cursor ?? 1
-        }
-      },
-      skip,
+      ...paginator,
       take,
       where: { contestId },
       select: {
@@ -184,17 +196,31 @@ export class ProblemRepository {
     cursor: number | null,
     take: number
   ) {
-    const skip = cursor ? 1 : 0
+    // Cannot use prisma paginator because of composite key
+    type Paginator = {
+      skip?: number
+      cursor?: {
+        workbookId_problemId: {
+          workbookId: number
+          problemId: number
+        }
+      }
+    }
+
+    const paginator: Paginator = cursor
+      ? {
+          skip: 1,
+          cursor: {
+            workbookId_problemId: {
+              workbookId,
+              problemId: cursor
+            }
+          }
+        }
+      : {}
 
     return await this.prisma.workbookProblem.findMany({
-      cursor: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        workbookId_problemId: {
-          workbookId,
-          problemId: cursor ?? 1
-        }
-      },
-      skip,
+      ...paginator,
       take,
       where: { workbookId },
       select: {

--- a/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/backend/apps/client/src/problem/problem.service.spec.ts
@@ -53,7 +53,8 @@ const db = {
   },
   problemTag: {
     findMany: stub()
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 const ARBITRARY_VAL = 1

--- a/backend/apps/client/src/workbook/workbook.service.spec.ts
+++ b/backend/apps/client/src/workbook/workbook.service.spec.ts
@@ -110,7 +110,8 @@ const db = {
   },
   workbookProblem: {
     findMany: stub()
-  }
+  },
+  getPaginator: PrismaService.prototype.getPaginator
 }
 
 describe('WorkbookService', () => {

--- a/backend/apps/client/src/workbook/workbook.service.ts
+++ b/backend/apps/client/src/workbook/workbook.service.ts
@@ -12,18 +12,20 @@ export class WorkbookService {
     take: number,
     groupId = OPEN_SPACE_ID
   ) {
-    const skip = cursor ? 1 : 0
+    const paginator = this.prisma.getPaginator(cursor)
 
     const workbooks = await this.prisma.workbook.findMany({
+      ...paginator,
       where: {
         groupId,
         isVisible: true
       },
-      select: { id: true, title: true, description: true, updateTime: true },
-      skip,
       take,
-      cursor: {
-        id: cursor ?? 1
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        updateTime: true
       }
     })
     return workbooks

--- a/backend/libs/prisma/src/prisma.service.ts
+++ b/backend/libs/prisma/src/prisma.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PrismaClient } from '@prisma/client'
 
-type Paginate = { skip?: number; cursor?: { id: number } }
+type Paginator = { skip?: number; cursor?: { id: number } }
 
 @Injectable()
 export class PrismaService extends PrismaClient {
@@ -17,7 +17,7 @@ export class PrismaService extends PrismaClient {
   }
 
   // Use explicit type to avoid Prisma query argument type error
-  getPaginator(cursor: number | null): Paginate {
+  getPaginator(cursor: number | null): Paginator {
     if (cursor == null) {
       return {}
     }

--- a/backend/libs/prisma/src/prisma.service.ts
+++ b/backend/libs/prisma/src/prisma.service.ts
@@ -26,7 +26,7 @@ export class PrismaService extends PrismaClient {
     customCursor: (number) => T
   ): Paginator<T>
 
-  getPaginator<T>(cursor: number | T | null, customCursor?: (number) => T) {
+  getPaginator<T>(cursor: number | null, customCursor?: (arg: number) => T) {
     if (cursor == null) {
       return {}
     }

--- a/backend/libs/prisma/src/prisma.service.ts
+++ b/backend/libs/prisma/src/prisma.service.ts
@@ -21,19 +21,16 @@ export class PrismaService extends PrismaClient {
 
   // Use explicit type to avoid Prisma query argument type error
   getPaginator(cursor: number | null): Paginator<number>
-  getPaginator<T>(
-    cursor: number | null,
-    customCursor: (number) => T
-  ): Paginator<T>
+  getPaginator<T>(cursor: number | null, transform: (number) => T): Paginator<T>
 
-  getPaginator<T>(cursor: number | null, customCursor?: (arg: number) => T) {
+  getPaginator<T>(cursor: number | null, transform?: (arg: number) => T) {
     if (cursor == null) {
       return {}
     }
-    if (customCursor) {
+    if (transform) {
       return {
         skip: 1,
-        cursor: customCursor(cursor)
+        cursor: transform(cursor)
       }
     }
     return {

--- a/backend/libs/prisma/src/prisma.service.ts
+++ b/backend/libs/prisma/src/prisma.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PrismaClient } from '@prisma/client'
 
+type Paginate = { skip?: number; cursor?: { id: number } }
+
 @Injectable()
 export class PrismaService extends PrismaClient {
   constructor(private config: ConfigService) {
@@ -12,5 +14,18 @@ export class PrismaService extends PrismaClient {
         }
       }
     })
+  }
+
+  // Use explicit type to avoid Prisma query argument type error
+  getPaginator(cursor: number | null): Paginate {
+    if (cursor == null) {
+      return {}
+    }
+    return {
+      skip: 1,
+      cursor: {
+        id: cursor
+      }
+    }
   }
 }

--- a/backend/libs/prisma/src/prisma.service.ts
+++ b/backend/libs/prisma/src/prisma.service.ts
@@ -21,7 +21,10 @@ export class PrismaService extends PrismaClient {
 
   // Use explicit type to avoid Prisma query argument type error
   getPaginator(cursor: number | null): Paginator<number>
-  getPaginator<T>(cursor: number | null, transform: (number) => T): Paginator<T>
+  getPaginator<T>(
+    cursor: number | null,
+    transform: (arg: number) => T
+  ): Paginator<T>
 
   getPaginator<T>(cursor: number | null, transform?: (arg: number) => T) {
     if (cursor == null) {


### PR DESCRIPTION
### Description

Close #1155 
Cursor 값이 주어지지 않은 경우 Prisma query에 cursor 값을 설정하지 않습니다.

이를 위해 `PrismaService`에 `getPaginator` 함수를 만들었습니다.

### 사용법

```ts
const paginator = this.prisma.getPaginator(cursor)

const data = await this.prisma.model.findMany({
  ...paginator,
  take
})
```

```ts
// cursor가 ID가 아닌 경우
const paginator = this.prisma.getPaginator(cursor, (value) => ({
  contestId_problemId: {
    contestId,
    problemId: value
  }
}))
```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
