### PR TITLE
feat(be): add order option to problem list api

### DIFF
--- a/backend/apps/client/src/problem/problem.controller.ts
+++ b/backend/apps/client/src/problem/problem.controller.ts
@@ -21,24 +21,19 @@ export class ProblemController {
   private readonly logger = new Logger(ProblemController.name)
 
   constructor(private readonly problemService: ProblemService) {}
-
-  @Get()
-  async searchProblemTitle(@Query('search') search: string) {
-    try {
-      return await this.problemService.searchProblemTitle(search)
-    } catch (error) {
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
-  }
-
   @Get()
   async getProblems(
     @Query('cursor', CursorValidationPipe) cursor: number | null,
-    @Query('take', ParseIntPipe) take: number
+    @Query('take', ParseIntPipe) take: number,
+    @Query('search') search: string
   ) {
     try {
-      return await this.problemService.getProblems(cursor, take, OPEN_SPACE_ID)
+      return await this.problemService.getProblems({
+        cursor,
+        take,
+        search,
+        groupId: OPEN_SPACE_ID
+      })
     } catch (error) {
       this.logger.error(error)
       throw new InternalServerErrorException()
@@ -76,7 +71,7 @@ export class GroupProblemController {
     @Query('take', ParseIntPipe) take: number
   ) {
     try {
-      return await this.problemService.getProblems(cursor, take, groupId)
+      return await this.problemService.getProblems({ cursor, take, groupId })
     } catch (error) {
       this.logger.error(error)
       throw new InternalServerErrorException()

--- a/backend/apps/client/src/problem/problem.controller.ts
+++ b/backend/apps/client/src/problem/problem.controller.ts
@@ -12,8 +12,9 @@ import {
 import { Prisma } from '@prisma/client'
 import { AuthNotNeeded, GroupMemberGuard } from '@libs/auth'
 import { OPEN_SPACE_ID } from '@libs/constants'
-import { CursorValidationPipe } from '@libs/pipe'
+import { CursorValidationPipe, ZodValidationPipe } from '@libs/pipe'
 import { ProblemService } from './problem.service'
+import { ProblemOrder, problemOrderSchema } from './schema/problem-order.schema'
 
 @Controller('problem')
 @AuthNotNeeded()
@@ -25,13 +26,16 @@ export class ProblemController {
   async getProblems(
     @Query('cursor', CursorValidationPipe) cursor: number | null,
     @Query('take', ParseIntPipe) take: number,
-    @Query('search') search: string
+    @Query('search') search: string,
+    @Query('order', new ZodValidationPipe(problemOrderSchema))
+    order: ProblemOrder
   ) {
     try {
       return await this.problemService.getProblems({
         cursor,
         take,
         search,
+        order,
         groupId: OPEN_SPACE_ID
       })
     } catch (error) {

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -39,14 +39,27 @@ export class ProblemRepository {
     outputExamples: true
   }
 
-  async getProblems(cursor: number | null, take: number, groupId: number) {
+  async getProblems({
+    cursor,
+    take,
+    groupId,
+    search
+  }: {
+    cursor: number | null
+    take: number
+    groupId: number
+    search?: string
+  }) {
     const paginator = this.prisma.getPaginator(cursor)
 
     return await this.prisma.problem.findMany({
       ...paginator,
       take,
       where: {
-        groupId
+        groupId,
+        title: {
+          contains: search
+        }
       },
       select: {
         ...this.problemsSelectOption,
@@ -56,23 +69,6 @@ export class ProblemRepository {
           }
         }
       }
-    })
-  }
-
-  // TODO/FIXME: postgreSQL의 full text search를 사용하여 검색하려 했으나
-  // 그럴 경우 띄어쓰기를 기준으로 나눠진 단어 단위로만 검색이 가능하다
-  // ex) "hello world"를 검색하면 "hello"와 "world"로 검색이 된다.
-  // 글자 단위로 검색하기 위해서, 성능을 희생하더라도 contains를 사용하여 구현했다.
-  // 추후에 검색 성능을 개선할 수 있는 방법을 찾아보자
-  // 아니면 텍스트가 많은 field에서는 full-text search를 사용하고, 텍스트가 적은 field에서는 contains를 사용하는 방법도 고려해보자.
-  async searchProblemTitle(search: string): Promise<Partial<Problem>[]> {
-    return await this.prisma.problem.findMany({
-      where: {
-        title: {
-          contains: search
-        }
-      },
-      select: this.problemsSelectOption
     })
   }
 

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Injectable } from '@nestjs/common'
-import type { Problem, Tag } from '@prisma/client'
+import type { Prisma, Problem, Tag } from '@prisma/client'
 import { PrismaService } from '@libs/prisma'
+import type { ProblemOrder } from './schema/problem-order.schema'
 
 /**
  * repository에서는 partial entity를 반환합니다.
@@ -43,18 +45,39 @@ export class ProblemRepository {
     cursor,
     take,
     groupId,
+    order,
     search
   }: {
     cursor: number | null
     take: number
     groupId: number
+    order?: ProblemOrder
     search?: string
   }) {
     const paginator = this.prisma.getPaginator(cursor)
 
+    const orderByMapper: Record<
+      ProblemOrder,
+      Prisma.ProblemOrderByWithRelationAndSearchRelevanceInput
+    > = {
+      'id-asc': { id: 'asc' },
+      'id-desc': { id: 'desc' },
+      'title-asc': { title: 'asc' },
+      'title-desc': { title: 'desc' },
+      'level-asc': { difficulty: 'asc' },
+      'level-desc': { difficulty: 'desc' },
+      'acrate-asc': { acceptedRate: 'asc' },
+      'acrate-desc': { acceptedRate: 'desc' },
+      'submit-asc': { submissionCount: 'asc' },
+      'submit-desc': { submissionCount: 'desc' }
+    }
+
+    const orderBy = orderByMapper[order ?? 'id-asc']
+
     return await this.prisma.problem.findMany({
       ...paginator,
       take,
+      orderBy,
       where: {
         groupId,
         title: {

--- a/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/backend/apps/client/src/problem/problem.service.spec.ts
@@ -130,7 +130,11 @@ describe('ProblemService', () => {
       db.tag.findMany.resolves([mockTag])
 
       // when
-      const result = await service.getProblems(1, 2, OPEN_SPACE_ID)
+      const result = await service.getProblems({
+        cursor: 1,
+        take: 2,
+        groupId: OPEN_SPACE_ID
+      })
 
       // then
       expect(result).to.deep.equal(

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -12,6 +12,7 @@ import { ProblemsResponseDto } from './dto/problems.response.dto'
 import { RelatedProblemResponseDto } from './dto/related-problem.response.dto'
 import { RelatedProblemsResponseDto } from './dto/related-problems.response.dto'
 import { ProblemRepository } from './problem.repository'
+import type { ProblemOrder } from './schema/problem-order.schema'
 
 @Injectable()
 export class ProblemService {
@@ -21,6 +22,7 @@ export class ProblemService {
     cursor: number | null
     take: number
     groupId: number
+    order?: ProblemOrder
     search?: string
   }) {
     let unprocessedProblems = await this.problemRepository.getProblems(options)

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -17,12 +17,13 @@ import { ProblemRepository } from './problem.repository'
 export class ProblemService {
   constructor(private readonly problemRepository: ProblemRepository) {}
 
-  async getProblems(cursor: number | null, take: number, groupId: number) {
-    let unprocessedProblems = await this.problemRepository.getProblems(
-      cursor,
-      take,
-      groupId
-    )
+  async getProblems(options: {
+    cursor: number | null
+    take: number
+    groupId: number
+    search?: string
+  }) {
+    let unprocessedProblems = await this.problemRepository.getProblems(options)
 
     unprocessedProblems = unprocessedProblems.filter(
       (problem) => problem.exposeTime <= new Date()
@@ -47,10 +48,6 @@ export class ProblemService {
     })
 
     return plainToInstance(ProblemsResponseDto, await Promise.all(problems))
-  }
-  async searchProblemTitle(search: string) {
-    const data = await this.problemRepository.searchProblemTitle(search)
-    return plainToInstance(ProblemsResponseDto, data)
   }
 
   async getProblem(problemId: number, groupId = OPEN_SPACE_ID) {

--- a/backend/apps/client/src/problem/schema/problem-order.schema.ts
+++ b/backend/apps/client/src/problem/schema/problem-order.schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const problemOrderSchema = z
+  .union([
+    z.literal('id-asc'),
+    z.literal('id-desc'),
+    z.literal('title-asc'),
+    z.literal('title-desc'),
+    z.literal('level-asc'),
+    z.literal('level-desc'),
+    z.literal('acrate-asc'),
+    z.literal('acrate-desc'),
+    z.literal('submit-asc'),
+    z.literal('submit-desc')
+  ])
+  .default('id-asc')
+
+export type ProblemOrder = z.infer<typeof problemOrderSchema>

--- a/backend/libs/pipe/src/index.ts
+++ b/backend/libs/pipe/src/index.ts
@@ -1,1 +1,2 @@
 export * from './cursor-validation.pipe'
+export * from './zod-validation.pipe'

--- a/backend/libs/pipe/src/zod-validation.pipe.ts
+++ b/backend/libs/pipe/src/zod-validation.pipe.ts
@@ -1,0 +1,15 @@
+import { BadRequestException, type PipeTransform } from '@nestjs/common'
+import type { ZodSchema } from 'zod'
+
+export class ZodValidationPipe implements PipeTransform {
+  constructor(private schema: ZodSchema) {}
+
+  transform(value: unknown) {
+    try {
+      const parsedValue = this.schema.parse(value)
+      return parsedValue
+    } catch (error) {
+      throw new BadRequestException('Validation failed')
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -50,7 +50,8 @@
     "passport-jwt": "^4.0.1",
     "pino-http": "^9.0.0",
     "pino-pretty": "^10.3.1",
-    "reflect-metadata": "^0.1.14"
+    "reflect-metadata": "^0.1.14",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "start:prod": "node dist/apps/backend/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "mocha \"*/**/*.spec.ts\"",
+    "test:watch": "mocha --watch \"*/**/*.spec.ts\"",
     "test:debug": "mocha --inspect \"*/**/*.spec.ts\""
   },
   "dependencies": {

--- a/collection/client/Problem/Get all problems/Succeed.bru
+++ b/collection/client/Problem/Get all problems/Succeed.bru
@@ -13,7 +13,8 @@ get {
 query {
   take: 5
   ~search: 정
-  ~cursor: 1
+  ~cursor: 4
+  ~order: level-desc
 }
 
 assert {
@@ -38,5 +39,13 @@ docs {
   |take  |Integer|가져올 문제 개수|
   |cursor|Integer|cursor 값 다음 take 만큼 문제들을 반환|
   |search|String |검색 키워드|
+  |order |String |정렬 기준 (아래 참고)|
   
+  ### 정렬 기준 옵션
+  
+  - `id-asc`, `id-desc`
+  - `title-asc`, `title-desc`
+  - `level-asc`, `level-desc`
+  - `acrate-asc`, `acrate-desc`
+  - `submit-asc`, `submit-desc`
 }

--- a/collection/client/Problem/Get all problems/Succeed.bru
+++ b/collection/client/Problem/Get all problems/Succeed.bru
@@ -12,15 +12,31 @@ get {
 
 query {
   take: 5
+  ~search: 정
   ~cursor: 1
 }
 
 assert {
   res.status: eq 200
-  res.body[0].id: isNumber 
-  res.body[0].title: isString 
-  res.body[0].difficulty: isString 
-  res.body[0].submissionCount: isNumber 
-  res.body[0].acceptedRate: isNumber 
-  res.body[0].tags: isDefined 
+  res.body[0].id: isNumber
+  res.body[0].title: isString
+  res.body[0].difficulty: isString
+  res.body[0].submissionCount: isNumber
+  res.body[0].acceptedRate: isNumber
+  res.body[0].tags: isDefined
+}
+
+docs {
+  # Get Problems
+  
+  공개된 문제 목록을 가져옵니다.
+  
+  ## Query
+  
+  | 이름 | 타입 | 설명 |
+  |-----|-----|-----|
+  |take  |Integer|가져올 문제 개수|
+  |cursor|Integer|cursor 값 다음 take 만큼 문제들을 반환|
+  |search|String |검색 키워드|
+  
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       reflect-metadata:
         specifier: ^0.1.14
         version: 0.1.14
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@faker-js/faker':
         specifier: ^8.3.1


### PR DESCRIPTION
### Description

Close #1123 

Problem 목록 API(`/problem`)에 정렬 옵션을 추가합니다.
사용 방법은 Bruno docs에 추가해뒀습니다.

<img width="932" alt="image" src="https://github.com/skkuding/codedang/assets/19747913/ec85c2b0-0b8f-4772-8442-51c6cc61d847">

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
