### PR TITLE
fix(be): provide type to the nullable Args explicitly in GraphQL

### DIFF
--- a/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/backend/apps/admin/src/contest/contest.resolver.ts
@@ -34,7 +34,7 @@ export class ContestResolver {
     @Args('take', ParseIntPipe) take: number,
     @Args('groupId', { defaultValue: OPEN_SPACE_ID }, ParseIntPipe)
     groupId: number,
-    @Args('cursor', { nullable: true }, CursorValidationPipe)
+    @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null
   ) {
     return await this.contestService.getContests(take, groupId, cursor)

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -45,7 +45,7 @@ export class GroupResolver {
   @Query(() => [FindGroup])
   @UseRolesGuard()
   async getGroups(
-    @Args('cursor', { nullable: true }, CursorValidationPipe)
+    @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
     @Args('take', { type: () => Int }) take: number
   ) {

--- a/backend/apps/admin/src/problem/problem.resolver.ts
+++ b/backend/apps/admin/src/problem/problem.resolver.ts
@@ -90,7 +90,7 @@ export class ProblemResolver {
   async getProblems(
     @Args('groupId', { defaultValue: OPEN_SPACE_ID }, ParseIntPipe)
     groupId: number,
-    @Args('cursor', { nullable: true }, CursorValidationPipe)
+    @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
     @Args('take', { type: () => Int }) take: number,
     @Args('input') input: FilterProblemsInput

--- a/backend/apps/admin/src/user/user.resolver.ts
+++ b/backend/apps/admin/src/user/user.resolver.ts
@@ -6,7 +6,7 @@ import {
   ParseIntPipe,
   NotFoundException
 } from '@nestjs/common'
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql'
 import { User } from '@generated'
 import { OPEN_SPACE_ID } from '@libs/constants'
 import { CursorValidationPipe } from '@libs/pipe'
@@ -23,7 +23,7 @@ export class UserResolver {
   async getGroupMembers(
     @Args('groupId', { defaultValue: OPEN_SPACE_ID }, ParseIntPipe)
     groupId: number,
-    @Args('cursor', { nullable: true }, CursorValidationPipe)
+    @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
     @Args('take', ParseIntPipe) take: number,
     @Args('leaderOnly', { defaultValue: false }) leaderOnly: boolean


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fixes #1167

> We should be aware that when we declare our type as a nullable union (e.g. string | null), we need to explicitly provide the type to the @Field decorator.

(참고: https://typegraphql.com/docs/0.17.4/types-and-fields.html) 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
