### PR TITLE
feat: add contest dummy data

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -30,7 +30,9 @@ let publicGroup: Group
 let privateGroup: Group
 const problems: Problem[] = []
 const problemTestcases: ProblemTestcase[] = []
-let contest: Contest
+const endedContests: Contest[] = []
+const ongoingContests: Contest[] = []
+const upcomingContests: Contest[] = []
 const workbooks: Workbook[] = []
 const privateWorkbooks: Workbook[] = []
 const submissions: Submission[] = []
@@ -864,10 +866,11 @@ const createProblems = async () => {
 
 const createContests = async () => {
   // add ongoing contenst
-  contest = await prisma.contest.create({
-    data: {
-      title: 'SKKU Coding Platform 모의대회',
-      description: `<p>
+  ongoingContests.push(
+    await prisma.contest.create({
+      data: {
+        title: 'SKKU Coding Platform 모의대회',
+        description: `<p>
   대통령은 내란 또는 외환의 죄를 범한 경우를 제외하고는 재직중 형사상의 소추를
   받지 아니한다. 모든 국민은 자기의 행위가 아닌 친족의 행위로 인하여 불이익한
   처우를 받지 아니한다.
@@ -897,55 +900,247 @@ const createContests = async () => {
   체포·구속·압수·수색 또는 심문을 받지 아니하며, 법률과 적법한 절차에 의하지
   아니하고는 처벌·보안처분 또는 강제노역을 받지 아니한다.
 </p>`,
-      createdById: superAdminUser.id,
-      groupId: publicGroup.id,
-      startTime: dayjs().add(-30, 'day').toDate(),
-      endTime: dayjs().add(30, 'day').toDate(),
-      config: {
-        isVisible: true,
-        isRankVisible: true
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-30, 'day').toDate(),
+        endTime: dayjs().add(30, 'day').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: true
+        }
       }
-    }
-  })
+    })
+  )
 
-  // add ended contest
-  await prisma.contest.create({
-    data: {
-      title: 'Long Time Ago Contest',
-      description: '<p>이 대회는 오래 전에 끝났어요</p>',
-      createdById: superAdminUser.id,
-      groupId: publicGroup.id,
-      startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
-      endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
-      config: {
-        isVisible: true,
-        isRankVisible: false
+  ongoingContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '24년도 소프트웨어학과 신입생 입학 테스트1',
+        description: '<p>이 대회는 현재 진행 중입니다 !</p>',
+        createdById: superAdminUser.id,
+        groupId: privateGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(0, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(0, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: true
+        }
       }
-    }
-  })
+    })
+  )
 
-  // add oncoming contest
-  await prisma.contest.create({
-    data: {
-      title: 'Future Contest',
-      description: '<p>이 대회는 언젠가 열리겠죠...?</p>',
-      createdById: superAdminUser.id,
-      groupId: privateGroup.id,
-      startTime: dayjs().add(-1, 'hour').add(1, 'year').toDate(),
-      endTime: dayjs().add(2, 'hour').add(1, 'year').toDate(),
-      config: {
-        isVisible: true,
-        isRankVisible: true
+  ongoingContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '24년도 소프트웨어학과 신입생 입학 테스트2',
+        description: '<p>이 대회는 현재 진행 중입니다 !</p>',
+        createdById: superAdminUser.id,
+        groupId: privateGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(0, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(0, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: true
+        }
       }
-    }
-  })
+    })
+  )
+
+  ongoingContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '24년도 소프트웨어학과 신입생 입학 테스트3',
+        description: '<p>이 대회는 현재 진행 중입니다 !</p>',
+        createdById: superAdminUser.id,
+        groupId: privateGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(0, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(0, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: true
+        }
+      }
+    })
+  )
+
+  // add ended contests
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: 'Long Time Ago Contest',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '23년도 소프트웨어학과 신입생 입학 테스트',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '소프트의 아침',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '소프트의 낮',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '소프트의 밤',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '2023 SKKU 프로그래밍 대회',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '소프트의 오전',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  endedContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '소프트의 오후',
+        description: '<p>이 대회는 오래 전에 끝났어요</p>',
+        createdById: superAdminUser.id,
+        groupId: publicGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(-1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(-1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: false
+        }
+      }
+    })
+  )
+
+  // add upcoming contests
+  upcomingContests.push(
+    await prisma.contest.create({
+      data: {
+        title: 'Future Contest',
+        description: '<p>이 대회는 언젠가 열리겠죠...?</p>',
+        createdById: superAdminUser.id,
+        groupId: privateGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: true
+        }
+      }
+    })
+  )
+
+  upcomingContests.push(
+    await prisma.contest.create({
+      data: {
+        title: '2024 SKKU 프로그래밍 대회',
+        description: '<p>이 대회는 언젠가 열리겠죠...?</p>',
+        createdById: superAdminUser.id,
+        groupId: privateGroup.id,
+        startTime: dayjs().add(-1, 'hour').add(1, 'year').toDate(),
+        endTime: dayjs().add(2, 'hour').add(1, 'year').toDate(),
+        config: {
+          isVisible: true,
+          isRankVisible: true
+        }
+      }
+    })
+  )
 
   // add problems to contest
   for (const problem of problems) {
     await prisma.contestProblem.create({
       data: {
         order: problem.id,
-        contestId: contest.id,
+        contestId: ongoingContests[0].id,
         problemId: problem.id
       }
     })
@@ -1004,7 +1199,7 @@ const createSubmissions = async () => {
       data: {
         userId: users[0].id,
         problemId: problems[0].id,
-        contestId: contest.id,
+        contestId: ongoingContests[0].id,
         code: [
           {
             id: 1,
@@ -1042,7 +1237,7 @@ int main(void) {
       data: {
         userId: users[1].id,
         problemId: problems[1].id,
-        contestId: contest.id,
+        contestId: ongoingContests[0].id,
         code: [
           {
             id: 1,
@@ -1080,7 +1275,7 @@ int main(void) {
       data: {
         userId: users[2].id,
         problemId: problems[2].id,
-        contestId: contest.id,
+        contestId: ongoingContests[0].id,
         code: [
           {
             id: 1,
@@ -1118,7 +1313,7 @@ int main(void) {
       data: {
         userId: users[3].id,
         problemId: problems[3].id,
-        contestId: contest.id,
+        contestId: ongoingContests[0].id,
         code: [
           {
             id: 1,
@@ -1152,7 +1347,7 @@ int main(void) {
       data: {
         userId: users[4].id,
         problemId: problems[4].id,
-        contestId: contest.id,
+        contestId: ongoingContests[0].id,
         code: [
           {
             id: 1,


### PR DESCRIPTION
### Description

Issue: #1175 

backend/prisma/seed.ts 파일에 Contest 더미 데이터를 추가했습니다.

ended, ongoing, upcoming 별로 카테고리를 나누어 데이터를 저장하기 위해 기존에 하나의 데이터만 저장하던 `contest` 변수를
`endedContests`, `ongoingContests`, `upcomingContests` 세 개로 나누어 array 타입으로 저장했습니다.

또한, 하나의 contest 정보만 가지고 있다고 가정한 후 구현한 problem 데이터 저장 코드나 submission 관련 코드의 원활한 작동을 위해
ongoingContests변수의 첫 번째 데이터(`ongoingContests[0]`)가 기준이 되도록 수정했습니다.


### Additional context

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
