### PR TITLE
feat(be): add participants number in finished contest GET API response

### DIFF
--- a/backend/apps/client/src/contest/contest.service.spec.ts
+++ b/backend/apps/client/src/contest/contest.service.spec.ts
@@ -3,20 +3,21 @@ import {
   Prisma,
   type Contest,
   type ContestRecord,
-  type Group,
-  type UserGroup
+  type Group
 } from '@prisma/client'
 import { expect } from 'chai'
 import * as dayjs from 'dayjs'
 import { stub } from 'sinon'
 import { ConflictFoundException } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
-import { ContestService } from './contest.service'
+import { type ContestSelectResult, ContestService } from './contest.service'
 
 const contestId = 1
 const userId = 1
 const groupId = 1
 const undefinedUserId = undefined
+
+const now = dayjs()
 
 const contest = {
   id: contestId,
@@ -24,14 +25,14 @@ const contest = {
   groupId,
   title: 'title',
   description: 'description',
-  startTime: dayjs().add(-1, 'day').toDate(),
-  endTime: dayjs().add(1, 'day').toDate(),
+  startTime: now.add(-1, 'day').toDate(),
+  endTime: now.add(1, 'day').toDate(),
   config: {
     isVisible: true,
     isRankVisible: true
   },
-  createTime: dayjs().add(-1, 'day').toDate(),
-  updateTime: dayjs().add(-1, 'day').toDate(),
+  createTime: now.add(-1, 'day').toDate(),
+  updateTime: now.add(-1, 'day').toDate(),
   group: {
     id: groupId,
     groupName: 'group'
@@ -41,94 +42,117 @@ const contest = {
 }
 
 const contestDetail = {
-  title: 'contest',
-  description: 'description',
-  id: contestId,
-  group: {
-    id: groupId,
-    groupName: 'group'
-  },
-  startTime: dayjs().add(-1, 'day').toDate(),
-  endTime: dayjs().add(-1, 'day').toDate()
+  id: contest.id,
+  group: contest.group,
+  title: contest.title,
+  description: contest.description,
+  startTime: contest.startTime,
+  endTime: contest.endTime,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  _count: {
+    contestRecord: 1
+  }
 }
 
 const ongoingContests = [
   {
-    ...contest,
-    id: contestId,
-    startTime: dayjs().add(-1, 'day').toDate(),
-    endTime: dayjs().add(1, 'day').toDate(),
-    config: {
-      isVisible: false,
-      isRankisVisible: true
-    },
+    id: contest.id,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(-1, 'day').toDate(),
+    endTime: now.add(1, 'day').toDate(),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _count: {
+      contestRecord: 1
+    }
+  }
+] satisfies Partial<ContestSelectResult>[]
+const ongoingContestsWithParticipants = [
+  {
+    id: contest.id,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(-1, 'day').toDate(),
+    endTime: now.add(1, 'day').toDate(),
     participants: 1
   }
-] satisfies Partial<Contest & { participants: number }>[]
+]
 
 const finishedContests = [
   {
-    ...contest,
-    id: contestId + 1,
-    startTime: dayjs().add(-2, 'day').toDate(),
-    endTime: dayjs().add(-1, 'day').toDate(),
-    config: {
-      isVisible: false,
-      isRankisVisible: true
-    },
+    id: contest.id + 1,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(-2, 'day').toDate(),
+    endTime: now.add(-1, 'day').toDate(),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _count: {
+      contestRecord: 1
+    }
+  }
+] satisfies Partial<ContestSelectResult>[]
+const finishedContestsWithParticipants = [
+  {
+    id: contest.id + 1,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(-2, 'day').toDate(),
+    endTime: now.add(-1, 'day').toDate(),
     participants: 1
   }
-] satisfies Partial<Contest & { participants: number }>[]
+]
 
 const upcomingContests = [
   {
-    ...contest,
-    id: contestId + 6,
-    startTime: dayjs().add(1, 'day').toDate(),
-    endTime: dayjs().add(2, 'day').toDate(),
-    config: {
-      isVisible: false,
-      isRankisVisible: true
-    },
+    id: contest.id + 6,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(1, 'day').toDate(),
+    endTime: now.add(2, 'day').toDate(),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _count: {
+      contestRecord: 1
+    }
+  }
+] satisfies Partial<ContestSelectResult>[]
+const upcomingContestsWithParticipants = [
+  {
+    id: contest.id + 6,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(1, 'day').toDate(),
+    endTime: now.add(2, 'day').toDate(),
     participants: 1
   }
-] satisfies Partial<Contest & { participants: number }>[]
+]
 
-const registeredOngoingContests = [
+const registeredOngoingContestsWithParticipants = [
   {
-    ...contest,
-    id: contestId,
-    endTime: new Date('2999-12-01T12:00:00.000+09:00'),
-    config: {
-      isVisible: false,
-      isRankisVisible: true
-    }
+    id: contest.id,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(-1, 'day').toDate(),
+    endTime: now.add(1, 'day').toDate(),
+    participants: 1
   }
-] satisfies Partial<Contest>[]
+]
 
-const registeredUpcomingContests = [
+const registeredUpcomingContestsWithParticipants = [
   {
-    ...contest,
-    id: contestId + 6,
-    startTime: new Date('2999-12-01T12:00:00.000+09:00'),
-    endTime: new Date('2999-12-01T15:00:00.000+09:00'),
-    config: {
-      isVisible: false,
-      isRankisVisible: true
-    }
+    id: contest.id + 6,
+    group: contest.group,
+    title: contest.title,
+    startTime: now.add(1, 'day').toDate(),
+    endTime: now.add(2, 'day').toDate(),
+    participants: 1
   }
-] satisfies Partial<Contest>[]
+]
 
 const contests = [
   ...ongoingContests,
   ...finishedContests,
   ...upcomingContests
-] satisfies Partial<Contest>[]
-
-const userContests = [
-  ...registeredOngoingContests,
-  ...registeredUpcomingContests
-] satisfies Partial<Contest>[]
+] satisfies Partial<ContestSelectResult>[]
 
 const ongoingContest = ongoingContests[0]
 
@@ -154,25 +178,6 @@ const laterContest: Contest = {
   }
 }
 
-const user = {
-  id: userId,
-  contest: userContests
-}
-
-const userGroup: UserGroup = {
-  userId,
-  groupId,
-  isGroupLeader: true,
-  createTime: new Date(),
-  updateTime: new Date()
-}
-const userGroups: UserGroup[] = [
-  userGroup,
-  {
-    ...userGroup,
-    groupId: userGroup.groupId + 1
-  }
-]
 const record: ContestRecord = {
   id: 1,
   contestId,
@@ -183,29 +188,22 @@ const record: ContestRecord = {
   updateTime: new Date()
 }
 
-const participantContests = [
-  { ...ongoingContests[0], contestRecord: [record] },
-  { ...upcomingContests[0], contestRecord: [record] }
-]
-
 const mockPrismaService = {
   contest: {
-    findUnique: stub().resolves(contest),
-    findUniqueOrThrow: stub().resolves(contest),
-    findFirst: stub().resolves(contest),
-    findFirstOrThrow: stub().resolves(contest),
-    findMany: stub().resolves(contests)
+    findUnique: stub(),
+    findUniqueOrThrow: stub(),
+    findFirst: stub(),
+    findFirstOrThrow: stub(),
+    findMany: stub()
   },
   contestRecord: {
-    findFirst: stub().resolves(null),
-    create: stub().resolves(null)
+    findFirst: stub(),
+    findMany: stub(),
+    create: stub()
   },
   userGroup: {
-    findFirst: stub().resolves(userGroup),
-    findMany: stub().resolves(userGroups)
-  },
-  user: {
-    findUnique: stub().resolves(user)
+    findFirst: stub(),
+    findMany: stub()
   },
   getPaginator: PrismaService.prototype.getPaginator
 }
@@ -228,7 +226,8 @@ describe('ContestService', () => {
 
   describe('getContests', () => {
     beforeEach(() => {
-      mockPrismaService.contest.findMany.resolves(participantContests)
+      mockPrismaService.contest.findMany.resolves(contests)
+      mockPrismaService.contestRecord.findMany.resolves([record])
     })
     afterEach(() => {
       mockPrismaService.contest.findMany.reset()
@@ -237,31 +236,34 @@ describe('ContestService', () => {
       expect(
         await service.getContestsByGroupId(undefinedUserId, groupId)
       ).to.deep.equal({
-        ongoing: ongoingContests,
-        upcoming: upcomingContests
+        ongoing: ongoingContestsWithParticipants,
+        upcoming: upcomingContestsWithParticipants
       })
     })
 
     it('should return registered ongoing, registered upcoming, ongoing, upcoming contests', async () => {
-      mockPrismaService.user.findUnique.resolves(user)
-
       expect(await service.getContestsByGroupId(userId, groupId)).to.deep.equal(
         {
-          registeredOngoing: registeredOngoingContests,
-          registeredUpcoming: registeredUpcomingContests,
-          ongoing: ongoingContests,
-          upcoming: upcomingContests
+          registeredOngoing: registeredOngoingContestsWithParticipants,
+          registeredUpcoming: registeredUpcomingContestsWithParticipants,
+          ongoing: ongoingContestsWithParticipants,
+          upcoming: upcomingContestsWithParticipants
         }
       )
     })
   })
 
   describe('getFinishedContests', () => {
+    after(() => {
+      mockPrismaService.contest.findMany.reset()
+    })
     it('should return finished contests when cursor is 0', async () => {
       mockPrismaService.contest.findMany.resolves(finishedContests)
-      expect(await service.getFinishedContestsByGroupId(0, 1)).to.deep.equal({
-        finished: finishedContests
-      })
+      expect(await service.getFinishedContestsByGroupId(null, 1)).to.deep.equal(
+        {
+          finished: finishedContestsWithParticipants
+        }
+      )
     })
   })
 
@@ -299,12 +301,12 @@ describe('ContestService', () => {
 
   describe('getContestsByGroupId', () => {
     it('should return ongoing, upcoming, finished contests', async () => {
-      mockPrismaService.contest.findMany.resolves(participantContests)
+      mockPrismaService.contest.findMany.resolves(contests)
       expect(
         await service.getContestsByGroupId(undefinedUserId, groupId)
       ).to.deep.equal({
-        ongoing: ongoingContests,
-        upcoming: upcomingContests
+        ongoing: ongoingContestsWithParticipants,
+        upcoming: upcomingContestsWithParticipants
       })
       mockPrismaService.contest.findMany.reset()
     })
@@ -321,9 +323,9 @@ describe('ContestService', () => {
         })
       )
 
-      await expect(service.getContest(contestId, groupId)).to.be.rejectedWith(
-        Prisma.PrismaClientKnownRequestError
-      )
+      await expect(
+        service.getContest(contestId + 999, groupId)
+      ).to.be.rejectedWith(Prisma.PrismaClientKnownRequestError)
     })
 
     it('should return contest', async () => {

--- a/backend/apps/client/src/contest/contest.service.ts
+++ b/backend/apps/client/src/contest/contest.service.ts
@@ -137,6 +137,7 @@ export class ContestService {
 
     const finished = await this.prisma.contest.findMany({
       ...paginator,
+      take,
       where: {
         endTime: {
           lte: now


### PR DESCRIPTION
### Description
close #1179 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
#1144 에서는 Ongoing Contest와 Upcoming Contest에 대해 참여자 수를 같이 조회할 수 있도록 하였습니다.

본 PR에서는 Finished Contest에 대해서도 참여자 수를 조회하는 기능을 포함합니다.
- 참여자 수를 계산할 때, Prisma의 _count 기능을 사용하여 contestRecord의 수를 출력하도록 변경
- select option에 _count가 포함되었을 때의 반환 타입을 지정하여 관련 함수 및 test code에서 사용할 수 있게 함
- 응답 객체에 포함되는 `{_count.contestRecord: 1}`을 `{participants: 1}`로 변경

자잘한 버그를 수정합니다.
- getContestByGroupId에서 registeredContest를 반환할 때, ContestRecord에서 데이터를 조회해야 하는데, Contest에서 데이터를 조회하고 있었습니다. (사용자가 참여중인 contest를 찾아야 하는데, 사용자가 생성한 contest를 찾고 있었던 셈)
- getFinishedContests에서 take parameter가 prisma query에 전달되지 않아 pagination이 제대로 동작하지 않는 오류를 수정합니다.


### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
