### PR TITLE
refactor(fe): change card and footer design

### DIFF
--- a/frontend-client/app/(main)/_components/Badge.tsx
+++ b/frontend-client/app/(main)/_components/Badge.tsx
@@ -21,7 +21,7 @@ export default function Badge({ type, children }: Props) {
   return (
     <div
       className={cn(
-        'inline-flex items-center justify-center gap-2 self-start rounded px-2 py-0.5 font-bold',
+        'inline-flex items-center justify-center gap-2 self-start rounded px-2 py-0.5 font-bold text-white',
         variants[type]
       )}
     >

--- a/frontend-client/app/(main)/_components/ContestCard.tsx
+++ b/frontend-client/app/(main)/_components/ContestCard.tsx
@@ -30,7 +30,7 @@ export default function ContestCard({ contest }: Props) {
   return (
     <Card
       className={cn(
-        'flex w-full flex-col justify-between gap-1 rounded-md border-0 text-white transition hover:scale-105 hover:opacity-80',
+        'flex w-full flex-col justify-between gap-1 border-none text-white shadow-none transition hover:scale-105 hover:opacity-80',
         variants[contest.status]
       )}
     >
@@ -38,21 +38,25 @@ export default function ContestCard({ contest }: Props) {
         <Badge type={contest.status}>
           <p>{contest.status}</p>
         </Badge>
-
-        <CardTitle className="text-lg font-semibold">{contest.title}</CardTitle>
+        <CardTitle className="overflow-hidden text-ellipsis text-nowrap text-lg font-semibold">
+          {contest.title}
+        </CardTitle>
       </CardHeader>
-
-      <CardContent className="flex items-center gap-1 text-xs text-white opacity-80">
+      <CardContent className="inline-flex items-center gap-1 text-nowrap text-xs text-white opacity-80">
         {contest.status === 'finished' ? (
           <>
-            <FaRegCalendarAlt />
-            {startTime} - {endTime}
+            <FaRegCalendarAlt className="shrink-0" />
+            <p className="overflow-hidden text-ellipsis text-nowrap">
+              {startTime} - {endTime}
+            </p>
           </>
         ) : (
           <>
-            <FaRegClock />
+            <FaRegClock className="shrink-0" />
             {contest.status === 'ongoing' ? 'Ends in' : 'Starts in'}
-            <TimeDiff timeRef={contest.endTime}></TimeDiff>
+            <p className="overflow-hidden text-ellipsis text-nowrap">
+              <TimeDiff timeRef={contest.endTime}></TimeDiff>
+            </p>
           </>
         )}
       </CardContent>

--- a/frontend-client/app/(main)/_components/Footer.tsx
+++ b/frontend-client/app/(main)/_components/Footer.tsx
@@ -17,12 +17,12 @@ export default function Footer() {
     }
   }
   return (
-    <footer className="mt-8 w-full items-center">
-      <div className="flex h-[125px] w-full flex-col items-end justify-center gap-3 bg-gray-50 px-20 pb-[30px] text-gray-400 md:flex-row md:justify-between">
-        <div>
-          <p className="font-bold">(c) SKKUDING / Since 2021</p>
-        </div>
-        <div className="flex flex-row items-center justify-center gap-4">
+    <footer className="mt-8 flex h-[100px] w-full items-center justify-center bg-gray-50 md:h-[125px] md:items-end">
+      <div className="flex w-full max-w-7xl flex-col justify-center gap-1 p-5 text-gray-400 md:flex-row md:justify-between md:gap-3">
+        <p className="text-center text-sm font-bold">
+          (c) SKKUDING / Since 2021
+        </p>
+        <div className="flex items-center justify-center gap-4">
           <a
             href="https://pf.kakao.com/_UKraK/chat"
             rel="noreferrer noopener"
@@ -54,7 +54,7 @@ export default function Footer() {
             href="https://skkuding.dev/"
           >
             <IoIosLink
-              className="cursor-pointer hover:text-slate-600"
+              className="cursor-pointer hover:text-gray-500"
               size="26"
             />
           </a>

--- a/frontend-client/app/(main)/_components/ProblemCard.tsx
+++ b/frontend-client/app/(main)/_components/ProblemCard.tsx
@@ -9,13 +9,12 @@ interface Props {
 
 export default function ProblemCard({ problem }: Props) {
   return (
-    <Card className="flex w-full flex-col justify-between gap-1 rounded-md border-gray-300 bg-gray-50 transition hover:scale-105 hover:opacity-80">
+    <Card className="flex w-full flex-col justify-between gap-1 shadow-none transition hover:scale-105 hover:opacity-80">
       <CardHeader className="pb-0">
         <Badge
           type={problem.difficulty}
         >{`Level ${problem.difficulty[5]}`}</Badge>
-
-        <CardTitle className="line-clamp-2 overflow-hidden break-keep text-lg font-semibold tracking-normal text-gray-700">
+        <CardTitle className="overflow-hidden text-ellipsis text-nowrap text-lg font-semibold">
           {`#${problem.problemId} ${problem.title}`}
         </CardTitle>
       </CardHeader>

--- a/frontend-client/app/(main)/_components/TimeDiff.tsx
+++ b/frontend-client/app/(main)/_components/TimeDiff.tsx
@@ -25,8 +25,8 @@ export default function TimeDiff({ timeRef }: Props) {
     .padStart(2, '0')
 
   return (
-    <p>
+    <>
       {days}D {hours + diff.format(':mm:ss')}
-    </p>
+    </>
   )
 }

--- a/frontend-client/app/(main)/page.tsx
+++ b/frontend-client/app/(main)/page.tsx
@@ -60,17 +60,14 @@ export default async function Home() {
       {contests.length !== 0 && (
         <div className="flex w-full flex-col gap-3">
           <div className="flex w-full items-center justify-between text-gray-700">
-            <p className="text-xl font-bold md:text-2xl">Contest</p>
+            <p className="text-xl font-bold">Contest</p>
             <Link href="/contest">
-              <Button
-                variant="ghost"
-                className="h-6 rounded-md border border-gray-500 px-3 text-sm font-semibold text-gray-500"
-              >
+              <Button variant="outline" className="h-8">
                 More
               </Button>
             </Link>
           </div>
-          <div className="flex w-full gap-5">
+          <div className="grid w-full grid-cols-3 gap-5">
             {contests.map((contest) => {
               return (
                 <Link
@@ -88,19 +85,14 @@ export default async function Home() {
       {problems.length !== 0 && (
         <div className="flex w-full flex-col gap-3">
           <div className="flex w-full items-center justify-between text-gray-700">
-            <p className="text-xl font-bold md:text-2xl">
-              Professor’s Recommendation
-            </p>
+            <p className="text-xl font-bold">Professor’s Recommendation</p>
             <Link href={'/workbook/1' as Route}>
-              <Button
-                variant="ghost"
-                className="h-6 rounded-md border border-gray-500 px-3 text-sm font-semibold text-gray-500"
-              >
+              <Button variant="outline" className="h-8">
                 More
               </Button>
             </Link>
           </div>
-          <div className="flex w-full gap-5">
+          <div className="grid w-full grid-cols-3 gap-5">
             {problems.map((problem) => {
               return (
                 <Link

--- a/frontend-client/components.json
+++ b/frontend-client/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "default",
+  "style": "new-york",
   "rsc": true,
   "tsx": true,
   "tailwind": {

--- a/frontend-client/components/ui/card.tsx
+++ b/frontend-client/components/ui/card.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
-import * as React from 'react'
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -8,13 +9,13 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-3xl border border-gray-400 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50',
+      "rounded-xl border border-gray-200 bg-white text-gray-950 shadow dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50",
       className
     )}
     {...props}
   />
 ))
-Card.displayName = 'Card'
+Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -22,11 +23,11 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
     {...props}
   />
 ))
-CardHeader.displayName = 'CardHeader'
+CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -34,14 +35,11 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn(
-      'text-2xl font-semibold leading-none tracking-tight',
-      className
-    )}
+    className={cn("font-semibold leading-none tracking-tight", className)}
     {...props}
   />
 ))
-CardTitle.displayName = 'CardTitle'
+CardTitle.displayName = "CardTitle"
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -49,19 +47,19 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('text-sm text-gray-500 dark:text-gray-400', className)}
+    className={cn("text-sm text-gray-500 dark:text-gray-400", className)}
     {...props}
   />
 ))
-CardDescription.displayName = 'CardDescription'
+CardDescription.displayName = "CardDescription"
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
 ))
-CardContent.displayName = 'CardContent'
+CardContent.displayName = "CardContent"
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -69,10 +67,10 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex items-center p-3 pl-6', className)}
+    className={cn("flex items-center p-6 pt-0", className)}
     {...props}
   />
 ))
-CardFooter.displayName = 'CardFooter'
+CardFooter.displayName = "CardFooter"
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/frontend-client/components/ui/card.tsx
+++ b/frontend-client/components/ui/card.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
-
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
+import * as React from 'react'
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -9,13 +8,13 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-gray-200 bg-white text-gray-950 shadow dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50",
+      'rounded-xl border border-gray-200 bg-white text-gray-950 shadow dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50',
       className
     )}
     {...props}
   />
 ))
-Card.displayName = "Card"
+Card.displayName = 'Card'
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -23,11 +22,11 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
     {...props}
   />
 ))
-CardHeader.displayName = "CardHeader"
+CardHeader.displayName = 'CardHeader'
 
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -35,11 +34,11 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
+    className={cn('font-semibold leading-none tracking-tight', className)}
     {...props}
   />
 ))
-CardTitle.displayName = "CardTitle"
+CardTitle.displayName = 'CardTitle'
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -47,19 +46,19 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-gray-500 dark:text-gray-400", className)}
+    className={cn('text-sm text-gray-500 dark:text-gray-400', className)}
     {...props}
   />
 ))
-CardDescription.displayName = "CardDescription"
+CardDescription.displayName = 'CardDescription'
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
 ))
-CardContent.displayName = "CardContent"
+CardContent.displayName = 'CardContent'
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -67,10 +66,10 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn('flex items-center p-6 pt-0', className)}
     {...props}
   />
 ))
-CardFooter.displayName = "CardFooter"
+CardFooter.displayName = 'CardFooter'
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
### Description

<img width="1781" alt="Screenshot 2024-01-15 at 8 20 21 PM" src="https://github.com/skkuding/codedang/assets/50468628/522bd646-7b2c-4e2f-9f4b-3ee77a51642b">

- card component 통합 및 추가 refactor 요소가 보이지만 일단 스타일 위주로 수정함
- badge 흰색으로 고정
- ellipse 스타일 추가
- footer 반응형 부분 고치고 요소들 구조 수정함
- more button shadcn으로 바꿈
- card component 뉴욕 디자인으로 바꿈
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
