### PR TITLE
feat(be): add user info and request id for logging

### DIFF
--- a/backend/libs/logger/src/pino-option.logger.ts
+++ b/backend/libs/logger/src/pino-option.logger.ts
@@ -1,4 +1,5 @@
 import { gray, italic, white } from 'colorette'
+import { randomUUID } from 'crypto'
 import type { Params } from 'nestjs-pino'
 import PinoPretty from 'pino-pretty'
 import type { PrettyOptions } from 'pino-pretty'
@@ -49,6 +50,12 @@ export const pinoLoggerModuleOption: Params = {
             }
           }
         : { user: 'undefined' }
+    },
+    genReqId(req, res) {
+      // TODO: x-request-id를 reverse proxy에서 추가하는 경우, 아래 코드를 변경해야 함. 현재는 request id를 nest에서만 할당하는 것으로 가정.
+      const id = randomUUID()
+      res.setHeader('X-Request-Id', id)
+      return id
     }
   }
 }

--- a/backend/libs/logger/src/pino-option.logger.ts
+++ b/backend/libs/logger/src/pino-option.logger.ts
@@ -3,6 +3,7 @@ import type { Params } from 'nestjs-pino'
 import PinoPretty from 'pino-pretty'
 import type { PrettyOptions } from 'pino-pretty'
 import { format } from 'sql-formatter'
+import type { AuthenticatedRequest } from '@libs/auth'
 
 const pinoPrettyOptions: PrettyOptions = {
   messageFormat: (log, messageKey) => {
@@ -38,6 +39,16 @@ export const pinoLoggerModuleOption: Params = {
         mergeObject = { ...mergeObject, msg: mergeObject.message }
       }
       return mergeObject
+    },
+    customProps(req: AuthenticatedRequest) {
+      return req.user
+        ? {
+            user: {
+              id: req.user.id,
+              username: req.user.username
+            }
+          }
+        : { user: 'undefined' }
     }
   }
 }


### PR DESCRIPTION
### Description
closes #1174
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
request 객체에 user id과 request id를 추가하여 로그 분석 시 용이하도록 합니다.

user id는 로그인이 된 사용자에 한해서 확인 가능합니다.
request id는 모든 요청에 대해 부여됩니다. `Cryto.randomUUID()`를 사용하여 부여합니다.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
