### PR TITLE
fix(be): apply correct decorator name to kakao login handler

### DIFF
--- a/backend/apps/client/src/auth/auth.controller.ts
+++ b/backend/apps/client/src/auth/auth.controller.ts
@@ -122,7 +122,7 @@ export class AuthController {
   }
 
   /** Kakao Login page로 이동 */
-  @AuthNotNeeded()
+  @AuthNotNeededIfOpenSpace()
   @Get('kakao')
   @UseGuards(AuthGuard('kakao'))
   async moveToKakaoLogin() {
@@ -130,7 +130,7 @@ export class AuthController {
   }
 
   /** Kakao login page에서 로그인에 성공한 후 이 endpoint로 redirection */
-  @AuthNotNeeded()
+  @AuthNotNeededIfOpenSpace()
   @Get('kakao-callback')
   @UseGuards(AuthGuard('kakao'))
   async kakaoLogin(


### PR DESCRIPTION
### Description

Closes #1226

카카오 로그인 핸들러에 변경된 `AuthNotNeededIfOpenSpace`가 아닌 `AuthNotNeeded`가 적용되어 발생하는 오류를 해결합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
