### PR TITLE
fix(fe): change reissue logic and add revalidate option

### DIFF
--- a/frontend-client/lib/utils.ts
+++ b/frontend-client/lib/utils.ts
@@ -11,7 +11,10 @@ export const cn = (...inputs: ClassValue[]) => {
 export const fetcher = ky.create({
   prefixUrl: baseUrl,
   throwHttpErrors: false,
-  retry: 0
+  retry: 0,
+  next: {
+    revalidate: 10 // 10 seconds
+  }
 })
 
 export const fetcherWithAuth = fetcher.extend({


### PR DESCRIPTION
### Description

- reissue 과정에서 401 뜨면 logout 되게 설정
- 일단 임시로 fetch 10초마다 revalidate하게 설정
  - 추후에 페이지 별로 잘 설계하면 좋을 것 같음

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
