### PR TITLE
fix(fe): change auth modal responsive

### DIFF
--- a/frontend-client/app/(main)/_components/AuthModal.tsx
+++ b/frontend-client/app/(main)/_components/AuthModal.tsx
@@ -1,8 +1,34 @@
 import useAuthModalStore from '@/stores/authModal'
+import { Transition } from '@headlessui/react'
 import SignIn from './SignIn'
 import SignUp from './SignUp'
 
 export default function AuthModal() {
   const { currentModal } = useAuthModalStore((state) => state)
-  return <>{currentModal === 'signIn' ? <SignIn /> : <SignUp />}</>
+  return (
+    <>
+      <Transition
+        show={currentModal === 'signIn'}
+        enter="transition-opacity duration-150"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <SignIn />
+      </Transition>
+      <Transition
+        show={currentModal === 'signUp'}
+        enter="transition-opacity duration-150"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <SignUp />
+      </Transition>
+    </>
+  )
 }

--- a/frontend-client/app/(main)/_components/AuthModal.tsx
+++ b/frontend-client/app/(main)/_components/AuthModal.tsx
@@ -1,34 +1,8 @@
 import useAuthModalStore from '@/stores/authModal'
-import { Transition } from '@headlessui/react'
 import SignIn from './SignIn'
 import SignUp from './SignUp'
 
 export default function AuthModal() {
   const { currentModal } = useAuthModalStore((state) => state)
-  return (
-    <>
-      <Transition
-        show={currentModal === 'signIn'}
-        enter="transition-opacity duration-150"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-150"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <SignIn />
-      </Transition>
-      <Transition
-        show={currentModal === 'signUp'}
-        enter="transition-opacity duration-150"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-150"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <SignUp />
-      </Transition>
-    </>
-  )
+  return <>{currentModal === 'signIn' ? <SignIn /> : <SignUp />}</>
 }

--- a/frontend-client/app/(main)/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/(main)/_components/HeaderAuthPanel.tsx
@@ -43,7 +43,7 @@ export default function HeaderAuthPanel({ session }: HeaderAuthPanelProps) {
               Sign Up
             </Button>
           </DialogTrigger>
-          <DialogContent className="min-h-[30rem] max-w-[20rem]">
+          <DialogContent className="min-h-[30rem] max-w-[20.5rem]">
             <AuthModal />
           </DialogContent>
         </Dialog>

--- a/frontend-client/app/(main)/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/(main)/_components/HeaderAuthPanel.tsx
@@ -43,7 +43,7 @@ export default function HeaderAuthPanel({ session }: HeaderAuthPanelProps) {
               Sign Up
             </Button>
           </DialogTrigger>
-          <DialogContent className="h-[520px] max-w-[22rem]">
+          <DialogContent className="min-h-[30rem] max-w-[20rem]">
             <AuthModal />
           </DialogContent>
         </Dialog>

--- a/frontend-client/app/(main)/_components/SignIn.tsx
+++ b/frontend-client/app/(main)/_components/SignIn.tsx
@@ -38,43 +38,45 @@ export default function SignIn() {
     }
   }
   return (
-    <div className="flex w-full flex-col gap-3">
-      <div className="mb-8 flex justify-center py-4">
+    <div className="flex h-full w-full flex-col justify-between">
+      <div className="flex justify-center pt-4">
         <Image src={CodedangLogo} alt="코드당" height={64} />
       </div>
-      <form
-        className="flex w-full flex-col gap-3"
-        onSubmit={handleSubmit(onSubmit)}
-      >
-        <Input placeholder="ID" type="text" {...register('username')} />
-        <Input
-          placeholder="Password"
-          type="password"
-          {...register('password')}
-        />
-        <Button className="w-full" type="submit">
-          Sign In
-        </Button>
-      </form>
-      <div className="mb-1 mt-4 flex items-center justify-center gap-5">
-        <Separator className="flex-1" />
-        <p className="w-fit flex-none text-center text-xs text-gray-500">
-          OR continue with
-        </p>
-        <Separator className="flex-1" />
+      <div className="flex flex-col gap-4">
+        <form
+          className="flex w-full flex-col gap-3"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <Input placeholder="ID" type="text" {...register('username')} />
+          <Input
+            placeholder="Password"
+            type="password"
+            {...register('password')}
+          />
+          <Button className="w-full" type="submit">
+            Sign In
+          </Button>
+        </form>
+        <div className="flex items-center justify-center gap-5">
+          <Separator className="flex-1" />
+          <p className="w-fit flex-none text-center text-xs text-gray-500">
+            OR continue with
+          </p>
+          <Separator className="flex-1" />
+        </div>
+        <div className="flex w-full items-center justify-center gap-5">
+          <div className="flex aspect-square w-12 cursor-pointer items-center justify-center rounded-full bg-[#FEE500] hover:opacity-80">
+            <Image src={KakaotalkLogo} alt="카카오톡" width={20} />
+          </div>
+          <div className="flex aspect-square w-12 cursor-pointer items-center justify-center rounded-full bg-[#EEEEEE] hover:opacity-80">
+            <FcGoogle size="22" />
+          </div>
+          <div className="flex aspect-square w-12 cursor-pointer items-center justify-center rounded-full bg-[#212528] hover:opacity-80">
+            <FaGithub className="text-white" size="22" />
+          </div>
+        </div>
       </div>
-      <div className="flex w-full items-center justify-center gap-5">
-        <div className="flex aspect-square w-12 cursor-pointer items-center justify-center rounded-full bg-[#FEE500] hover:opacity-80">
-          <Image src={KakaotalkLogo} alt="카카오톡" width={20} />
-        </div>
-        <div className="flex aspect-square w-12 cursor-pointer items-center justify-center rounded-full bg-[#EEEEEE] hover:opacity-80">
-          <FcGoogle size="22" />
-        </div>
-        <div className="flex aspect-square w-12 cursor-pointer items-center justify-center rounded-full bg-[#212528] hover:opacity-80">
-          <FaGithub className="text-white" size="22" />
-        </div>
-      </div>
-      <div className="mt-12 flex items-center justify-between">
+      <div className="flex items-center justify-between">
         <Button
           onClick={() => showSignUp()}
           variant={'link'}

--- a/frontend-client/app/(main)/_components/SignUp.tsx
+++ b/frontend-client/app/(main)/_components/SignUp.tsx
@@ -25,9 +25,12 @@ export default function SignUp() {
         </button>
       )}
 
-      <div className="absolute left-8 top-10">
-        <Image src={CodedangLogo} alt="codedang" width={70} />
-      </div>
+      <Image
+        className="absolute left-8 top-10"
+        src={CodedangLogo}
+        alt="codedang"
+        width={70}
+      />
 
       {modalPage === 0 && <SignUpWelcome />}
       {modalPage === 1 && <SignUpEmailVerify />}

--- a/frontend-client/app/(main)/_components/SignUp.tsx
+++ b/frontend-client/app/(main)/_components/SignUp.tsx
@@ -25,7 +25,7 @@ export default function SignUp() {
         </button>
       )}
 
-      <div className="absolute left-10 top-10">
+      <div className="absolute left-8 top-10">
         <Image src={CodedangLogo} alt="codedang" width={70} />
       </div>
 

--- a/frontend-client/app/(main)/_components/SignUp.tsx
+++ b/frontend-client/app/(main)/_components/SignUp.tsx
@@ -15,7 +15,7 @@ export default function SignUp() {
   const { modalPage, backModal } = useSignUpModalStore((state) => state)
 
   return (
-    <div className="flex flex-col items-center justify-center ">
+    <div className="flex h-full flex-col items-center justify-center">
       {!(modalPage === 0) && (
         <button
           onClick={backModal}
@@ -24,17 +24,16 @@ export default function SignUp() {
           <IoMdArrowBack />
         </button>
       )}
-      <Image
-        src={CodedangLogo}
-        alt="codedang"
-        width={70}
-        className="absolute left-10 top-10"
-      />
+
+      <div className="absolute left-10 top-10">
+        <Image src={CodedangLogo} alt="codedang" width={70} />
+      </div>
 
       {modalPage === 0 && <SignUpWelcome />}
       {modalPage === 1 && <SignUpEmailVerify />}
       {modalPage === 2 && <SignUpRegister />}
-      <div className="absolute bottom-6 mt-4 flex items-center justify-center">
+
+      <div className="absolute bottom-6 flex items-center justify-center">
         <span className="h-5 w-fit text-xs leading-5 text-gray-500">
           Already have account?
         </span>

--- a/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 import { baseUrl } from '@/lib/vars'
 import useSignUpModalStore from '@/stores/signUpModal'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -97,74 +98,61 @@ export default function SignUpEmailVerify() {
   }
 
   return (
-    <div className="mb-24 mt-24">
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <p className="mb-5 mt-8 text-left text-xl font-bold text-blue-500">
-          Sign Up
-        </p>
-        {!sentEmail && (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-1">
+      <p className="mb-4 text-left text-xl font-bold text-blue-500">Sign Up</p>
+      {!sentEmail && (
+        <Input
+          id="email"
+          type="email"
+          className="w-64"
+          placeholder="Email Address"
+          {...register('email')}
+        />
+      )}
+      {errors.email && (
+        <p className="text-xs text-red-500">{errors.email?.message}</p>
+      )}
+      <p className="text-xs text-red-500">{emailError}</p>
+      {sentEmail && (
+        <>
+          <div className="text-sm font-semibold text-gray-500">
+            {emailContent}
+          </div>
           <Input
-            id="email"
-            type="email"
-            className="w-64"
-            placeholder="Email Address"
-            {...register('email')}
+            type="number"
+            placeholder="Verification Code"
+            {...register('verificationCode', {
+              onChange: () => verifyCode()
+            })}
           />
+        </>
+      )}
+      <p className="text-xs text-red-500">
+        {errors.verificationCode ? errors.verificationCode?.message : codeError}
+      </p>
+      {sentEmail &&
+        !errors.verificationCode &&
+        codeError === '' &&
+        !emailVerified && (
+          <p className="text-xs text-blue-500">We&apos;ve sent an email!</p>
         )}
-        {errors.email && (
-          <p className="mt-1 text-xs text-red-500">{errors.email?.message}</p>
-        )}
-        <p className="mt-1 text-xs text-red-500">{emailError}</p>
-        {sentEmail && (
-          <>
-            <div className="mb-2 text-sm font-semibold text-gray-500">
-              {emailContent}
-            </div>
-            <Input
-              type="number"
-              placeholder="Verification Code"
-              {...register('verificationCode', {
-                onChange: () => verifyCode()
-              })}
-            />
-          </>
-        )}
-        {errors.verificationCode ? (
-          <p className="mt-1 text-xs text-red-500">
-            {errors.verificationCode?.message}
-          </p>
-        ) : (
-          <p className="mt-1 text-xs text-red-500">{codeError}</p>
-        )}
-        {sentEmail &&
-          !errors.verificationCode &&
-          codeError === '' &&
-          !emailVerified && (
-            <p className="mt-1 text-xs text-blue-500">
-              We&apos;ve sent an email!
-            </p>
-          )}
-
-        {!sentEmail ? (
-          <Button
-            type="button"
-            className="mt-3 w-64"
-            onClick={() => sendEmail()}
-          >
-            Send Email
-          </Button>
-        ) : (
-          <Button
-            type="submit"
-            className={`${
-              emailVerified ? 'mt-3 w-64' : 'mt-3 w-64 bg-gray-400'
-            }`}
-            disabled={!emailVerified}
-          >
-            Next
-          </Button>
-        )}
-      </form>
-    </div>
+      {!sentEmail ? (
+        <Button
+          type="button"
+          className="mb-8 mt-2 w-64"
+          onClick={() => sendEmail()}
+        >
+          Send Email
+        </Button>
+      ) : (
+        <Button
+          type="submit"
+          className={cn('mb-8 mt-2 w-64', !emailVerified && 'bg-gray-400')}
+          disabled={!emailVerified}
+        >
+          Next
+        </Button>
+      )}
+    </form>
   )
 }

--- a/frontend-client/app/(main)/_components/SignUpRegister.tsx
+++ b/frontend-client/app/(main)/_components/SignUpRegister.tsx
@@ -122,14 +122,12 @@ export default function SignUpRegister() {
   }
 
   return (
-    <div className="mb-5 mt-12 flex w-full flex-col p-4">
+    <div className="mb-5 mt-12 flex w-full flex-col px-2 py-4">
       <form
         className="flex w-full flex-col gap-4"
         onSubmit={handleSubmit(onSubmit)}
       >
-        <p className="mb-2 text-left text-xl font-bold text-blue-500">
-          Sign Up
-        </p>
+        <p className="text-left text-xl font-bold text-blue-500">Sign Up</p>
         <div className="flex flex-col gap-1">
           <Input
             placeholder="Your name"

--- a/frontend-client/app/(main)/_components/SignUpRegister.tsx
+++ b/frontend-client/app/(main)/_components/SignUpRegister.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 import { baseUrl } from '@/lib/vars'
 import useSignUpModalStore from '@/stores/signUpModal'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -126,8 +127,10 @@ export default function SignUpRegister() {
         className="flex w-full flex-col gap-4"
         onSubmit={handleSubmit(onSubmit)}
       >
-        <p className="text-left text-xl font-bold text-blue-500">Sign Up</p>
-        <div>
+        <p className="mb-2 text-left text-xl font-bold text-blue-500">
+          Sign Up
+        </p>
+        <div className="flex flex-col gap-1">
           <Input
             placeholder="Your name"
             {...register('realName', {
@@ -138,7 +141,7 @@ export default function SignUpRegister() {
             }}
           />
           {inputFocus === 1 && (
-            <div className="mt-1 text-xs text-gray-500">
+            <div className="text-xs text-gray-500">
               <ul className="list-disc pl-4">
                 <li>Your name must be less than 20 characters</li>
                 <li>Your name can only contain alphabet letters</li>
@@ -146,11 +149,11 @@ export default function SignUpRegister() {
             </div>
           )}
           {errors.realName && (
-            <p className="mt-1 text-xs text-red-500">Unavailable</p>
+            <p className="text-xs text-red-500">Unavailable</p>
           )}
         </div>
 
-        <div>
+        <div className="flex flex-col gap-1">
           <div className="flex gap-2">
             <Input
               placeholder="User ID"
@@ -165,16 +168,17 @@ export default function SignUpRegister() {
             <Button
               onClick={() => checkUserName()}
               type="button"
-              className={`flex aspect-square w-12 items-center justify-center rounded-md ${
-                !disableUsername ? '' : 'bg-gray-400'
-              }`}
+              className={cn(
+                disableUsername && 'bg-gray-400',
+                'flex aspect-square w-12 items-center justify-center rounded-md'
+              )}
               disabled={disableUsername}
             >
               <FaCheck className="text-white" size="20" />
             </Button>
           </div>
           {inputFocus === 2 && (
-            <div className="mt-1 text-xs text-gray-500">
+            <div className="text-xs text-gray-500">
               <ul className="list-disc pl-4">
                 <li>User ID used for log in</li>
                 <li>
@@ -186,18 +190,18 @@ export default function SignUpRegister() {
             </div>
           )}
           {errors.username ? (
-            <p className="mt-1 text-xs text-red-500">Unavailable</p>
+            <p className="text-xs text-red-500">Unavailable</p>
           ) : (
             usernameVerify &&
             (disableUsername ? (
-              <p className="mt-1 text-xs text-blue-500">Available</p>
+              <p className="text-xs text-blue-500">Available</p>
             ) : (
-              <p className="mt-1 text-xs text-red-500">Unavailable</p>
+              <p className="text-xs text-red-500">Unavailable</p>
             ))
           )}
         </div>
 
-        <div>
+        <div className="flex flex-col gap-1">
           <div className="flex justify-between gap-2">
             <Input
               placeholder="Password"
@@ -210,7 +214,7 @@ export default function SignUpRegister() {
               }}
             />
             <span
-              className="mt-3"
+              className="flex items-center"
               onClick={() => setPasswordShow(!passwordShow)}
             >
               {passwordShow ? (
@@ -222,9 +226,10 @@ export default function SignUpRegister() {
           </div>
           {inputFocus === 3 && (
             <div
-              className={`${
-                !errors.password ? 'text-gray-500' : 'text-red-500'
-              } mt-1 text-xs`}
+              className={cn(
+                errors.password ? 'text-red-500' : 'text-gray-500',
+                'text-xs'
+              )}
             >
               <ul className="pl-4">
                 <li className="list-disc">
@@ -237,7 +242,7 @@ export default function SignUpRegister() {
           )}
         </div>
 
-        <div>
+        <div className="flex flex-col gap-1">
           <div className="flex justify-between gap-2">
             <Input
               {...register('passwordAgain', {
@@ -250,7 +255,7 @@ export default function SignUpRegister() {
               }}
             />
             <span
-              className="mt-3"
+              className="flex items-center"
               onClick={() => setPasswordAgainShow(!passwordAgainShow)}
             >
               {passwordAgainShow ? (
@@ -261,13 +266,13 @@ export default function SignUpRegister() {
             </span>
           </div>
           {errors.passwordAgain && (
-            <p className="mt-1 text-xs text-red-500">Incorrect</p>
+            <p className="text-xs text-red-500">Incorrect</p>
           )}
         </div>
 
         <Button
           disabled={!isValid || !disableUsername}
-          className={`${isValid && disableUsername ? '' : 'bg-gray-400'}`}
+          className={cn(isValid && disableUsername ? '' : 'bg-gray-400')}
           type="submit"
         >
           Register

--- a/frontend-client/app/(main)/_components/SignUpWelcome.tsx
+++ b/frontend-client/app/(main)/_components/SignUpWelcome.tsx
@@ -11,19 +11,16 @@ import { FcGoogle } from 'react-icons/fc'
 export default function SignUpWelcome() {
   const { nextModal } = useSignUpModalStore((state) => state)
   return (
-    <div className="mb-20 mt-36">
-      <p className="mb-3 text-center text-xl font-semibold text-blue-500">
+    <div className="flex flex-col gap-3">
+      <p className="text-center text-xl font-semibold text-blue-500">
         &quot;Welcome to CODEDANG&quot;
       </p>
-
-      <div className="flex w-full flex-col gap-3">
-        <Button className="w-full" onClick={() => nextModal()}>
-          Sign up with Email
-        </Button>
-      </div>
-      <div className="mb-1 mt-4 flex items-center justify-center gap-5">
+      <Button className="w-full" onClick={() => nextModal()}>
+        Sign up with Email
+      </Button>
+      <div className="flex items-center justify-center gap-5">
         <Separator className="flex-1" />
-        <p className="mb-3 w-fit flex-none text-center text-xs text-gray-500">
+        <p className="w-fit flex-none text-center text-xs text-gray-500">
           continue with
         </p>
         <Separator className="flex-1" />

--- a/frontend-client/package.json
+++ b/frontend-client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.1",
+    "@headlessui/react": "^1.7.18",
     "@hookform/resolvers": "^3.3.4",
     "@lezer/highlight": "^1.2.0",
     "@monaco-editor/react": "^4.6.0",

--- a/frontend-client/package.json
+++ b/frontend-client/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.1",
-    "@headlessui/react": "^1.7.18",
     "@hookform/resolvers": "^3.3.4",
     "@lezer/highlight": "^1.2.0",
     "@monaco-editor/react": "^4.6.0",

--- a/frontend-client/stores/authModal.ts
+++ b/frontend-client/stores/authModal.ts
@@ -12,13 +12,13 @@ const useAuthModalStore = create<AuthModalStore>(
       set({ currentModal: '' })
       setTimeout(() => {
         set({ currentModal: 'signIn' })
-      }, 150)
+      }, 180)
     },
     showSignUp: () => {
       set({ currentModal: '' })
       setTimeout(() => {
         set({ currentModal: 'signUp' })
-      }, 150)
+      }, 180)
     }
   })
 )


### PR DESCRIPTION
### Description
아래와 같이 조건 불일치 문구가 떠도 기존과 다르게 모달 height가 늘어납니다.
<img width="500" alt="image" src="https://github.com/skkuding/codedang/assets/97675977/aebbaf30-5126-4fe3-bda3-daba001d3bee">

#### 모달 height가 고정되지 않아 Transition이 적용되지 않았던 문제
* 트랜지션 간 timeout 길이 조정으로 해결

enter(150ms) timeout(180ms) leave(100ms) 로 수정
timeout과 leave은 동시에 시작되나 leave 이후에 80ms의 시간이 남아서
transition이 정상적으로 작동됩니다. 
(leave와 timeout 시간 차가 넉넉하지 않으면 애니메이션이 튑니다)


#### cn을 사용하여 중복된 코드를 줄이고 최대한 flex와 gap으로 전환했습니다.

전부 flex로 다루기에는
뒤로 가기 버튼이 없다 생기면서 코드당 로고가 움직이기에
뒤로 가기 버튼, 코드당 로고, 모달 전환 버튼은 absolute로 고정했습니다.

Close #1265 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
DialogHeader, DialogFooter 사용을 시도했으나 
불필요한 여백도 생기고 별다른 이점이 없었습니다. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
