### PR TITLE
fix(iris): resolve iris folder creation failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,6 @@ services:
     image: ghcr.io/skkuding/codedang-iris:latest
     container_name: iris
     restart: always
-    read_only: true
     depends_on:
       setup:
         condition: service_completed_successfully


### PR DESCRIPTION
### Description

폴더를 만드는 권한이 iris 컨테이너에 없어서 채점이 안되는 이슈를 해결했습니다.
docker-compose.yml에 들어간 read-only 옵션을 지우니까 해결됐어요

제 실수로 iris가 안 돌아가고 있었네요 😅

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
