### PR TITLE
chore(be): add code-size field to submission model

### DIFF
--- a/backend/apps/client/src/submission/submission.service.ts
+++ b/backend/apps/client/src/submission/submission.service.ts
@@ -198,6 +198,7 @@ export class SubmissionService implements OnModuleInit {
         result: ResultStatus.Judging,
         userId,
         problemId: problem.id,
+        codeSize: new TextEncoder().encode(code[0].text).length,
         ...data
       }
     })
@@ -406,7 +407,8 @@ export class SubmissionService implements OnModuleInit {
         },
         createTime: true,
         language: true,
-        result: true
+        result: true,
+        codeSize: true
       }
     })
   }
@@ -443,7 +445,8 @@ export class SubmissionService implements OnModuleInit {
         code: true,
         createTime: true,
         result: true,
-        submissionResult: true
+        submissionResult: true,
+        codeSize: true
       }
     })
     if (
@@ -542,7 +545,8 @@ export class SubmissionService implements OnModuleInit {
         },
         createTime: true,
         language: true,
-        result: true
+        result: true,
+        codeSize: true
       }
     })
   }
@@ -585,7 +589,8 @@ export class SubmissionService implements OnModuleInit {
       },
       select: {
         userId: true,
-        submissionResult: true
+        submissionResult: true,
+        codeSize: true
       }
     })
 

--- a/backend/prisma/migrations/20240201082532_add_codesize_to_submission/migration.sql
+++ b/backend/prisma/migrations/20240201082532_add_codesize_to_submission/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "submission" ADD COLUMN     "code_size" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -355,6 +355,7 @@ model Submission {
   ///   "locked": boolean
   /// }
   code       Json[]
+  codeSize   Int?         @map("code_size")
   language   Language
   result     ResultStatus
   createTime DateTime     @default(now()) @map("create_time")


### PR DESCRIPTION
### Description

closes #1282

Submission 모델에 `codeSize` 필드를 추가하고 Submission 정보를 READ할 때 함께 표시되도록 합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
