### PR TITLE
fix(be): add missing type to admin server

### DIFF
--- a/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/backend/apps/admin/src/contest/contest.resolver.ts
@@ -27,8 +27,13 @@ export class ContestResolver {
 
   @Query(() => [Contest])
   async getContests(
-    @Args('take', new RequiredIntPipe('take')) take: number,
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args('take', { type: () => Int }, new RequiredIntPipe('take'))
+    take: number,
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null
@@ -39,7 +44,11 @@ export class ContestResolver {
   @Mutation(() => Contest)
   async createContest(
     @Args('input') input: CreateContestInput,
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Context('req') req: AuthenticatedRequest
   ) {
@@ -63,7 +72,7 @@ export class ContestResolver {
 
   @Mutation(() => Contest)
   async updateContest(
-    @Args('groupId', GroupIDPipe) groupId: number,
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
     @Args('input') input: UpdateContestInput
   ) {
     try {
@@ -82,8 +91,9 @@ export class ContestResolver {
 
   @Mutation(() => Contest)
   async deleteContest(
-    @Args('groupId', GroupIDPipe) groupId: number,
-    @Args('contestId', new RequiredIntPipe('contestId')) contestId: number
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
+    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+    contestId: number
   ) {
     try {
       return await this.contestService.deleteContest(groupId, contestId)
@@ -104,8 +114,9 @@ export class ContestResolver {
 
   @Mutation(() => PublicizingRequest)
   async createPublicizingRequest(
-    @Args('groupId', GroupIDPipe) groupId: number,
-    @Args('contestId', new RequiredIntPipe('contestId')) contestId: number
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
+    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+    contestId: number
   ) {
     try {
       return await this.contestService.createPublicizingRequest(
@@ -127,7 +138,8 @@ export class ContestResolver {
   @Mutation(() => PublicizingResponse)
   @UseRolesGuard()
   async handlePublicizingRequest(
-    @Args('contestId', new RequiredIntPipe('contestId')) contestId: number,
+    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+    contestId: number,
     @Args('isAccepted', ParseBoolPipe) isAccepted: boolean
   ) {
     try {
@@ -146,8 +158,9 @@ export class ContestResolver {
 
   @Mutation(() => [ContestProblem])
   async importProblemsToContest(
-    @Args('groupId', GroupIDPipe) groupId: number,
-    @Args('contestId', new RequiredIntPipe('contestId')) contestId: number,
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
+    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+    contestId: number,
     @Args('problemIds', { type: () => [Int] }) problemIds: number[]
   ) {
     try {

--- a/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/backend/apps/admin/src/contest/contest.resolver.ts
@@ -27,7 +27,11 @@ export class ContestResolver {
 
   @Query(() => [Contest])
   async getContests(
-    @Args('take', { type: () => Int }, new RequiredIntPipe('take'))
+    @Args(
+      'take',
+      { type: () => Int, defaultValue: 10 },
+      new RequiredIntPipe('take')
+    )
     take: number,
     @Args(
       'groupId',

--- a/backend/apps/admin/src/group/group.resolver.ts
+++ b/backend/apps/admin/src/group/group.resolver.ts
@@ -41,7 +41,7 @@ export class GroupResolver {
   async getGroups(
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
-    @Args('take', { type: () => Int }) take: number
+    @Args('take', { type: () => Int, defaultValue: 10 }) take: number
   ) {
     return await this.groupService.getGroups(cursor, take)
   }

--- a/backend/apps/admin/src/problem/problem.resolver.ts
+++ b/backend/apps/admin/src/problem/problem.resolver.ts
@@ -36,7 +36,11 @@ export class ProblemResolver {
   @Mutation(() => Problem)
   async createProblem(
     @Context('req') req: AuthenticatedRequest,
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Args('input') input: CreateProblemInput
   ) {
@@ -64,7 +68,11 @@ export class ProblemResolver {
   @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async uploadProblems(
     @Context('req') req: AuthenticatedRequest,
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Args('input') input: UploadFileInput
   ) {
@@ -85,7 +93,11 @@ export class ProblemResolver {
 
   @Query(() => [Problem])
   async getProblems(
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
@@ -97,9 +109,13 @@ export class ProblemResolver {
 
   @Query(() => Problem)
   async getProblem(
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
-    @Args('id', new RequiredIntPipe('id')) id: number
+    @Args('id', { type: () => Int }, new RequiredIntPipe('id')) id: number
   ) {
     try {
       return await this.problemService.getProblem(id, groupId)
@@ -117,7 +133,11 @@ export class ProblemResolver {
 
   @Mutation(() => Problem)
   async updateProblem(
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Args('input') input: UpdateProblemInput
   ) {
@@ -143,9 +163,13 @@ export class ProblemResolver {
 
   @Mutation(() => Problem)
   async deleteProblem(
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
-    @Args('id', new RequiredIntPipe('id')) id: number
+    @Args('id', { type: () => Int }, new RequiredIntPipe('id')) id: number
   ) {
     try {
       return await this.problemService.deleteProblem(id, groupId)

--- a/backend/apps/admin/src/problem/problem.resolver.ts
+++ b/backend/apps/admin/src/problem/problem.resolver.ts
@@ -101,7 +101,7 @@ export class ProblemResolver {
     groupId: number,
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
-    @Args('take', { type: () => Int }) take: number,
+    @Args('take', { type: () => Int, defaultValue: 10 }) take: number,
     @Args('input') input: FilterProblemsInput
   ) {
     return await this.problemService.getProblems(input, groupId, cursor, take)

--- a/backend/apps/admin/src/user/user.resolver.ts
+++ b/backend/apps/admin/src/user/user.resolver.ts
@@ -20,11 +20,16 @@ export class UserResolver {
 
   @Query(() => [GroupMember])
   async getGroupMembers(
-    @Args('groupId', { defaultValue: OPEN_SPACE_ID }, GroupIDPipe)
+    @Args(
+      'groupId',
+      { type: () => Int, defaultValue: OPEN_SPACE_ID },
+      GroupIDPipe
+    )
     groupId: number,
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
-    @Args('take', new RequiredIntPipe('take')) take: number,
+    @Args('take', { type: () => Int }, new RequiredIntPipe('take'))
+    take: number,
     @Args('leaderOnly', { defaultValue: false }) leaderOnly: boolean
   ) {
     return await this.userService.getGroupMembers(
@@ -37,8 +42,9 @@ export class UserResolver {
 
   @Mutation(() => UserGroup)
   async updateGroupMember(
-    @Args('userId', new RequiredIntPipe('userId')) userId: number,
-    @Args('groupId', GroupIDPipe) groupId: number,
+    @Args('userId', { type: () => Int }, new RequiredIntPipe('userId'))
+    userId: number,
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
     @Args('toGroupLeader') toGroupLeader: boolean
   ) {
     try {
@@ -60,8 +66,9 @@ export class UserResolver {
 
   @Mutation(() => UserGroup)
   async deleteGroupMember(
-    @Args('userId', new RequiredIntPipe('userId')) userId: number,
-    @Args('groupId', GroupIDPipe) groupId: number
+    @Args('userId', { type: () => Int }, new RequiredIntPipe('userId'))
+    userId: number,
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number
   ) {
     try {
       return await this.userService.deleteGroupMember(userId, groupId)
@@ -77,7 +84,9 @@ export class UserResolver {
   }
 
   @Query(() => [User])
-  async getJoinRequests(@Args('groupId', GroupIDPipe) groupId: number) {
+  async getJoinRequests(
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number
+  ) {
     try {
       return await this.userService.getJoinRequests(groupId)
     } catch (error) {
@@ -88,8 +97,9 @@ export class UserResolver {
 
   @Mutation(() => UserGroup)
   async handleJoinRequest(
-    @Args('groupId', GroupIDPipe) groupId: number,
-    @Args('userId', new RequiredIntPipe('userId')) userId: number,
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
+    @Args('userId', { type: () => Int }, new RequiredIntPipe('userId'))
+    userId: number,
     @Args('isAccept') isAccept: boolean
   ) {
     try {

--- a/backend/apps/admin/src/user/user.resolver.ts
+++ b/backend/apps/admin/src/user/user.resolver.ts
@@ -28,7 +28,11 @@ export class UserResolver {
     groupId: number,
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
-    @Args('take', { type: () => Int }, new RequiredIntPipe('take'))
+    @Args(
+      'take',
+      { type: () => Int, defaultValue: 10 },
+      new RequiredIntPipe('take')
+    )
     take: number,
     @Args('leaderOnly', { defaultValue: false }) leaderOnly: boolean
   ) {


### PR DESCRIPTION
### Description

Closes #1294 

`groupId`, `contestId` 등을 `@Arg()`를 통해 전달받을 때 graphql scalar type을 명시하지 않으면 Int가 Float로 지정되는 문제를 해결합니다.

아래 코드와 같이 `@Args()`의 옵션으로 `type: () => Int`가 명시되어있지 않은 부분에 추가했습니다.
만약 `type`이 명시되어있지 않으면, 타입스크립트에서 `number`에 대해 schema.gql에서 Float로 지정됩니다. (그래서 Bruno 작성할 때 타입을 Int로 지정하면 에러남)
```
## 수정 후
@Args('take', { type: () => Int, defaultValue: 10 }) take: number
```


### Additional context

`take`에 기본값 10 설정 되어있지 않은 부분이 있어 함께 추가했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
