### PR TITLE
feat(fe): edit Data Table's title area

### DIFF
--- a/frontend-client/app/(main)/contest/_components/Columns.tsx
+++ b/frontend-client/app/(main)/contest/_components/Columns.tsx
@@ -6,10 +6,12 @@ import dayjs from 'dayjs'
 
 export const columns: ColumnDef<Contest>[] = [
   {
-    header: 'Name',
+    header: 'Title',
     accessorKey: 'title',
     cell: ({ row }) => (
-      <p className="text-left text-sm md:text-base">{row.original.title}</p>
+      <p className="overflow-hidden text-ellipsis whitespace-nowrap text-left text-sm md:text-base">
+        {row.original.title}
+      </p>
     )
   },
   {

--- a/frontend-client/app/(main)/notice/_components/Columns.tsx
+++ b/frontend-client/app/(main)/notice/_components/Columns.tsx
@@ -21,7 +21,7 @@ export const columns: ColumnDef<Notice>[] = [
           <span
             className={cn(
               row.original.isFixed && 'font-semibold',
-              'text-sm md:text-base'
+              'overflow-hidden text-ellipsis whitespace-nowrap text-sm md:text-base'
             )}
           >
             {row.original.title}

--- a/frontend-client/app/(main)/problem/_components/Columns.tsx
+++ b/frontend-client/app/(main)/problem/_components/Columns.tsx
@@ -11,7 +11,7 @@ export const columns: ColumnDef<Problem>[] = [
     accessorKey: 'title',
     cell: ({ row }) => {
       return (
-        <p className="text-left text-sm md:text-base">{`${row.original.id}. ${row.original.title}`}</p>
+        <p className="overflow-hidden text-ellipsis whitespace-nowrap text-left text-sm md:text-base">{`${row.original.id}. ${row.original.title}`}</p>
       )
     }
   },


### PR DESCRIPTION
### Description
- Data table들의 title에 ellipsis 속성을 주어 text overflow를 처리합니다.
- contest에서 name대신 title을 사용하도록 했습니다.

close #1333

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
