### PR TITLE
fix(deps): fix invalid go version format in go.mod

### DIFF
--- a/iris/go.mod
+++ b/iris/go.mod
@@ -1,6 +1,6 @@
 module github.com/skkuding/codedang/iris
 
-go 1.21.6
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     "schedule:weekly",
     ":label(dependencies)"
   ],
+  "constraints": {
+    "go": "1.19.1" // for Gitpod
+  },
   "rangeStrategy": "bump",
   "reviewers": ["dotoleeoak"],
   "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
### Description

Close #1342

Gitpod에서 Go 버전을 1.19.1을 쓰기 때문에, Renovate bot이 Go를 업데이트 할 때에도 해당 버전에서 지원하는 버전 형식으로 업데이트하도록 해요.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
