### PR TITLE
fix(be): modify the logic of calculating total field

### DIFF
--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -111,6 +111,18 @@ export class ProblemRepository {
     })
   }
 
+  async getProblemTotalCount(groupId: number, search?: string) {
+    return await this.prisma.problem.count({
+      where: {
+        groupId,
+        title: {
+          // TODO: 검색 방식 변경 시 함께 변경 요함
+          contains: search
+        }
+      }
+    })
+  }
+
   async getProblemTags(problemId: number): Promise<Partial<Tag>[]> {
     return (
       await this.prisma.problemTag.findMany({
@@ -187,6 +199,14 @@ export class ProblemRepository {
     })
   }
 
+  async getContestProblemTotalCount(contestId: number) {
+    return await this.prisma.contestProblem.count({
+      where: {
+        contestId
+      }
+    })
+  }
+
   async getContestProblem(contestId: number, problemId: number) {
     return await this.prisma.contestProblem.findUniqueOrThrow({
       where: {
@@ -232,6 +252,14 @@ export class ProblemRepository {
         problem: {
           select: this.problemsSelectOption
         }
+      }
+    })
+  }
+
+  async getWorkbookProblemTotalCount(workbookId: number) {
+    return await this.prisma.workbookProblem.count({
+      where: {
+        workbookId
       }
     })
   }

--- a/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/backend/apps/client/src/problem/problem.service.spec.ts
@@ -42,17 +42,20 @@ const db = {
   problem: {
     findMany: stub(),
     findFirst: stub(),
-    findUniqueOrThrow: stub()
+    findUniqueOrThrow: stub(),
+    count: stub().resolves(2)
   },
   contestProblem: {
     findMany: stub(),
     findUnique: stub(),
-    findUniqueOrThrow: stub()
+    findUniqueOrThrow: stub(),
+    count: stub().resolves(2)
   },
   workbookProblem: {
     findMany: stub(),
     findUnique: stub(),
-    findUniqueOrThrow: stub()
+    findUniqueOrThrow: stub(),
+    count: stub().resolves(2)
   },
   tag: {
     findMany: stub()

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -51,9 +51,14 @@ export class ProblemService {
       }
     })
 
+    const total = await this.problemRepository.getProblemTotalCount(
+      options.groupId,
+      options.search
+    )
+
     return plainToInstance(ProblemsResponseDto, {
       problems: await Promise.all(problems),
-      total: problems.length
+      total
     })
   }
 
@@ -85,12 +90,17 @@ export class ContestProblemService {
       cursor,
       take
     )
+
     if (data.length > 0 && data[0].contest.startTime > new Date()) {
       throw new ForbiddenAccessException('Contest is not started yet.')
     }
+
+    const total =
+      await this.problemRepository.getContestProblemTotalCount(contestId)
+
     return plainToInstance(RelatedProblemsResponseDto, {
       problems: data,
-      total: data.length
+      total
     })
   }
 
@@ -134,9 +144,13 @@ export class WorkbookProblemService {
       cursor,
       take
     )
+
+    const total =
+      await this.problemRepository.getWorkbookProblemTotalCount(workbookId)
+
     return plainToInstance(RelatedProblemsResponseDto, {
       problems: data,
-      total: data.length
+      total
     })
   }
 


### PR DESCRIPTION
### Description

Closes #1344

#1330 PR에서 총 문제 수를 반환하는 total 필드를 만들었는데, 총 문제 수가 아닌 take에 의해 가져와진 문제의 수를 반환하는 문제를 해결합니다.
prisma의 `count` api를 활용한 함수를 작성해 `total` 필드에 넣는 방식으로 구현하였습니다.


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
