### PR TITLE
fix(fe): add fallback style of text editor

### DIFF
--- a/frontend-client/app/(main)/_components/ProblemCard.tsx
+++ b/frontend-client/app/(main)/_components/ProblemCard.tsx
@@ -15,7 +15,7 @@ export default function ProblemCard({ problem }: Props) {
           type={problem.difficulty}
         >{`Level ${problem.difficulty[5]}`}</Badge>
         <CardTitle className="overflow-hidden text-ellipsis whitespace-nowrap text-lg font-semibold">
-          {`#${problem.problemId} ${problem.title}`}
+          {`#${problem.id} ${problem.title}`}
         </CardTitle>
       </CardHeader>
 

--- a/frontend-client/app/(main)/_components/ProblemCards.tsx
+++ b/frontend-client/app/(main)/_components/ProblemCards.tsx
@@ -25,8 +25,8 @@ export default async function ProblemCards() {
       {problems.map((problem) => {
         return (
           <Link
-            key={problem.problemId}
-            href={`/problem/${problem.problemId}` as Route}
+            key={problem.id}
+            href={`/problem/${problem.id}` as Route}
             className="inline-block w-full"
           >
             <ProblemCard problem={problem} />

--- a/frontend-client/app/admin/layout.tsx
+++ b/frontend-client/app/admin/layout.tsx
@@ -8,8 +8,8 @@ import SideBar from './_components/SideBar'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-dvh bg-[#f2f5f9]">
-      <nav className="ml-20 flex w-60 flex-col bg-white p-2 pt-8 text-sm font-medium">
+    <div className="flex h-dvh bg-slate-100">
+      <nav className="flex w-60 flex-col bg-white p-2 pt-8 text-sm font-medium">
         {/* Todo: Group 기능 추가 시, Public Button 대신 GroupSelect 컴포넌트로 변경 */}
         {/* <GroupSelect /> */}
         <Button

--- a/frontend-client/components/TextEditor.tsx
+++ b/frontend-client/components/TextEditor.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   Dialog,
   DialogContent,
@@ -19,6 +17,7 @@ import StarterKit from '@tiptap/starter-kit'
 import { Bold, Italic, List, ListOrdered, Link as LinkIcon } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { Button } from './ui/button'
+import { Skeleton } from './ui/skeleton'
 
 export default function TextEditor({
   placeholder,
@@ -75,7 +74,10 @@ export default function TextEditor({
     },
     [editor]
   )
-  if (!editor) return null
+
+  if (!editor) {
+    return <Skeleton className="h-[241px] max-w-5xl" />
+  }
 
   return (
     <div className="flex flex-col justify-stretch bg-white">
@@ -145,7 +147,7 @@ export default function TextEditor({
           </DialogContent>
         </Dialog>
       </div>
-      <EditorContent className="prose max-w-[1000px]" editor={editor} />
+      <EditorContent className="prose max-w-5xl" editor={editor} />
     </div>
   )
 }

--- a/frontend-client/types/type.ts
+++ b/frontend-client/types/type.ts
@@ -13,9 +13,11 @@ export interface Contest {
 
 export interface WorkbookProblem {
   order: number
-  problemId: number
+  id: number
   title: string
   difficulty: Level
+  submissionCount: number
+  acceptedRate: number
 }
 
 export interface Notice {


### PR DESCRIPTION
### Description

Close #1365 

Tiptap의 `useEditor`로 `editor` 객체가 반환되는데 시간이 걸려, 사용자에게 text editor가 바로 보여지지 않습니다.
아래처럼 fallback 효과를 추가했습니다.

https://github.com/skkuding/codedang/assets/19747913/3ee665d5-5a1f-4ffa-8428-cdeffc15839a

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
