### PR TITLE
fix(fe): edit login and signup modal

### DIFF
--- a/frontend-client/app/(main)/_components/HeaderAuthPanel.tsx
+++ b/frontend-client/app/(main)/_components/HeaderAuthPanel.tsx
@@ -43,7 +43,12 @@ export default function HeaderAuthPanel({ session }: HeaderAuthPanelProps) {
               Sign Up
             </Button>
           </DialogTrigger>
-          <DialogContent className="min-h-[30rem] max-w-[20.5rem]">
+          <DialogContent
+            className="min-h-[30rem] max-w-[20.5rem]"
+            onInteractOutside={(e) => {
+              e.preventDefault()
+            }}
+          >
             <AuthModal />
           </DialogContent>
         </Dialog>

--- a/frontend-client/app/(main)/_components/SignIn.tsx
+++ b/frontend-client/app/(main)/_components/SignIn.tsx
@@ -58,7 +58,7 @@ export default function SignIn() {
           className="flex w-full flex-col gap-3"
           onSubmit={handleSubmit(onSubmit)}
         >
-          <Input placeholder="ID" type="text" {...register('username')} />
+          <Input placeholder="User ID" type="text" {...register('username')} />
           <Input
             placeholder="Password"
             type="password"

--- a/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
@@ -120,6 +120,7 @@ export default function SignUpEmailVerify() {
           </div>
           <Input
             type="number"
+            className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             placeholder="Verification Code"
             {...register('verificationCode', {
               onChange: () => verifyCode()

--- a/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
@@ -107,6 +107,12 @@ export default function SignUpEmailVerify() {
           className="w-64"
           placeholder="Email Address"
           {...register('email')}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              sendEmail()
+            }
+          }}
         />
       )}
       {errors.email && (

--- a/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
@@ -6,6 +6,7 @@ import useSignUpModalStore from '@/stores/signUpModal'
 import { zodResolver } from '@hookform/resolvers/zod'
 import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
+import { useInterval } from 'react-use'
 import { z } from 'zod'
 
 interface EmailVerifyInput {
@@ -43,15 +44,14 @@ export default function SignUpEmailVerify() {
   const [emailVerified, setEmailVerified] = useState<boolean>(false)
   const [emailAuthToken, setEmailAuthToken] = useState<string>('')
 
-  useEffect(() => {
-    let interval: string | number | NodeJS.Timeout | undefined
-    if (sentEmail && timer > 0) {
-      interval = setInterval(() => {
+  useInterval(
+    () => {
+      if (timer > 0) {
         setTimer((prevTimer) => prevTimer - 1)
-      }, 1000)
-    }
-    return () => clearInterval(interval)
-  }, [sentEmail, timer])
+      }
+    },
+    sentEmail ? 1000 : null
+  )
 
   useEffect(() => {
     if (timer === 0) {
@@ -199,7 +199,7 @@ export default function SignUpEmailVerify() {
         </Button>
       ) : (
         <Button
-          type="button"
+          type="submit"
           className="mb-8 mt-2 w-64"
           onClick={() => {
             setExpired(false)

--- a/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
@@ -21,7 +21,7 @@ const schema = z.object({
     .max(6, { message: 'Code must be 6 characters long' })
 })
 
-const timeLimit = 3000
+const timeLimit = 300
 
 export default function SignUpEmailVerify() {
   const [timer, setTimer] = useState(timeLimit)

--- a/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
+++ b/frontend-client/app/(main)/_components/SignUpEmailVerify.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 import { baseUrl } from '@/lib/vars'
 import useSignUpModalStore from '@/stores/signUpModal'
 import { zodResolver } from '@hookform/resolvers/zod'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -21,7 +21,11 @@ const schema = z.object({
     .max(6, { message: 'Code must be 6 characters long' })
 })
 
+const timeLimit = 3000
+
 export default function SignUpEmailVerify() {
+  const [timer, setTimer] = useState(timeLimit)
+  const [expired, setExpired] = useState(false)
   const { nextModal, setFormData } = useSignUpModalStore((state) => state)
   const {
     handleSubmit,
@@ -38,6 +42,29 @@ export default function SignUpEmailVerify() {
   const [codeError, setCodeError] = useState<string>('')
   const [emailVerified, setEmailVerified] = useState<boolean>(false)
   const [emailAuthToken, setEmailAuthToken] = useState<string>('')
+
+  useEffect(() => {
+    let interval: string | number | NodeJS.Timeout | undefined
+    if (sentEmail && timer > 0) {
+      interval = setInterval(() => {
+        setTimer((prevTimer) => prevTimer - 1)
+      }, 1000)
+    }
+    return () => clearInterval(interval)
+  }, [sentEmail, timer])
+
+  useEffect(() => {
+    if (timer === 0) {
+      setExpired(true)
+    }
+  }, [timer])
+
+  const formatTimer = () => {
+    const minutes = Math.floor(timer / 60)
+    const seconds = timer % 60
+    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`
+  }
+
   const onSubmit = (data: EmailVerifyInput) => {
     setFormData({
       ...data,
@@ -99,6 +126,9 @@ export default function SignUpEmailVerify() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-1">
+      {sentEmail && !expired && (
+        <p className="absolute right-10 top-10 text-red-500">{formatTimer()}</p>
+      )}
       <p className="mb-4 text-left text-xl font-bold text-blue-500">Sign Up</p>
       {!sentEmail && (
         <Input
@@ -138,11 +168,19 @@ export default function SignUpEmailVerify() {
         {errors.verificationCode ? errors.verificationCode?.message : codeError}
       </p>
       {sentEmail &&
+        !expired &&
         !errors.verificationCode &&
         codeError === '' &&
         !emailVerified && (
           <p className="text-xs text-blue-500">We&apos;ve sent an email!</p>
         )}
+      {expired && (
+        <p className="text-xs text-red-500">
+          Verification code expired
+          <br />
+          Please resend an email and try again
+        </p>
+      )}
       {!sentEmail ? (
         <Button
           type="button"
@@ -151,13 +189,25 @@ export default function SignUpEmailVerify() {
         >
           Send Email
         </Button>
-      ) : (
+      ) : !expired ? (
         <Button
           type="submit"
           className={cn('mb-8 mt-2 w-64', !emailVerified && 'bg-gray-400')}
           disabled={!emailVerified}
         >
           Next
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          className="mb-8 mt-2 w-64"
+          onClick={() => {
+            setExpired(false)
+            setTimer(timeLimit)
+            sendEmail()
+          }}
+        >
+          Resend Email
         </Button>
       )}
     </form>


### PR DESCRIPTION
### Description
1. ID를 User ID로 수정
2. email 버튼 클릭 없이 엔터만 눌러도 전송
3. Verification Code input에 arrows 제거
4. 5분 타이머 설정
5. dialog 바깥 클릭으로 인한 모달 닫힘 방지
![image](https://github.com/skkuding/codedang/assets/97675977/b254ac70-92c6-4152-b7e5-5e8ad60ed2b2)
![image](https://github.com/skkuding/codedang/assets/97675977/a60ea83b-a290-461b-a14d-482e9dd5d355)



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Close #1380 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
