### PR TITLE
fix(cd): double quotes in tfvars are missing

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -109,9 +109,13 @@ jobs:
       - name: Create Terraform variable file
         working-directory: ./infra/deploy
         run: |
-          echo "${{ secrets.TFVARS }}" >> terraform.tfvars
-          echo "${{ secrets.OAUTH_GITHUB }}" >> terraform.tfvars
-          echo "${{ secrets.OAUTH_KAKAO }}" >> terraform.tfvars
+          echo $TFVARS >> terraform.tfvars
+          echo $OAUTH_GITHUB >> terraform.tfvars
+          echo $OAUTH_KAKAO >> terraform.tfvars
+        env:
+          TFVARS: ${{ secrets.TFVARS }}
+          OAUTH_GITHUB: ${{ secrets.OAUTH_GITHUB }}
+          OAUTH_KAKAO: ${{ secrets.OAUTH_KAKAO }}
 
       - name: Terraform Init
         working-directory: ./infra/deploy


### PR DESCRIPTION
### Description

CD Pipeline이 동작이 잘 안됩니다...
`terraform.tfvars`를 만들 때 환경변수 내 쌍따옴표(`"`)가 제대로 전달되지 않았네요

https://github.com/skkuding/codedang/actions/runs/7912234474/job/21598329578

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
