### PR TITLE
fix(infra): exclude host header for traffic to amplify

### DIFF
--- a/infra/modules/codedang-infra/cloudfront.tf
+++ b/infra/modules/codedang-infra/cloudfront.tf
@@ -13,6 +13,10 @@ data "aws_cloudfront_origin_request_policy" "allow_all" {
   name = "Managed-AllViewer"
 }
 
+data "aws_cloudfront_origin_request_policy" "exclude_host_header" {
+  name = "Managed-AllViewerExceptHostHeader"
+}
+
 resource "aws_cloudfront_distribution" "main" {
   origin {
     domain_name = "amplify.codedang.com"
@@ -57,18 +61,12 @@ resource "aws_cloudfront_distribution" "main" {
   aliases = ["codedang.com"]
 
   default_cache_behavior {
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id       = "frontend" # TODO: do not hard-code origin_id
-    viewer_protocol_policy = "redirect-to-https"
-
-    forwarded_values {
-      query_string = true
-
-      cookies {
-        forward = "none"
-      }
-    }
+    allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods           = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id         = "frontend" # TODO: do not hard-code origin_id
+    viewer_protocol_policy   = "redirect-to-https"
+    cache_policy_id          = data.aws_cloudfront_cache_policy.disable.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.exclude_host_header.id
   }
 
   ordered_cache_behavior {

--- a/infra/modules/codedang-infra/ecs-api-asg.tf
+++ b/infra/modules/codedang-infra/ecs-api-asg.tf
@@ -94,7 +94,7 @@ resource "aws_launch_template" "ec2_template_api" {
     resource_type = "instance"
 
     tags = {
-      Name = "Codedang-Api-Instance"
+      Name = "Codedang-ECS-API"
     }
   }
 }

--- a/infra/modules/codedang-infra/ecs-iris-asg.tf
+++ b/infra/modules/codedang-infra/ecs-iris-asg.tf
@@ -92,7 +92,7 @@ resource "aws_launch_template" "ec2_template_iris" {
     resource_type = "instance"
 
     tags = {
-      Name = "launch template for codedang-ecs-iris"
+      Name = "Codedang-ECS-Iris"
     }
   }
 }


### PR DESCRIPTION
### Description

Cloudfront에서 Amplify로 frontend(Next.js) 요청을 보낼 때, host 헤더가 포함되어 요청이 제대로 동작하지 않습니다.
Host 헤더를 제외하도록 Cloudfront의 origin policy를 변경합니다.

추가로 ECS의 EC2 instance 이름을 API와 iris를 통일시켰습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
