### PR TITLE
fix(fe): edit sonner duration, message

### DIFF
--- a/frontend-client/app/(main)/_components/SignIn.tsx
+++ b/frontend-client/app/(main)/_components/SignIn.tsx
@@ -37,7 +37,7 @@ export default function SignIn() {
 
       if (!res?.error) {
         router.refresh()
-        toast.success('Successfully logged in')
+        toast.success('Login Successful')
       } else {
         toast.error('Failed to log in')
       }

--- a/frontend-client/app/layout.tsx
+++ b/frontend-client/app/layout.tsx
@@ -40,7 +40,12 @@ export default function RootLayout({
     <html lang="en" className={cn(noto.variable, manrope.variable)}>
       <body>
         {children}
-        <Toaster richColors position="top-center" />
+        <Toaster
+          richColors
+          position="top-center"
+          closeButton={true}
+          duration={2000}
+        />
       </body>
     </html>
   )


### PR DESCRIPTION
### Description

Sonner의 duration을 5000->2000으로 줄이고, 닫기 버튼을 추가했습니다.
메시지를 Login Successful로 바꿈

close #1417

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
