### PR TITLE
fix(infra): turn keep-alive off for caddy backend

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -25,6 +25,12 @@ dev.codedang.com {
 	handle /api/* {
 		reverse_proxy 127.0.0.1:4000 {
 			header_down -Access-Control-Allow-Origin *
+			# Keep-Alive timeout of Caddy must be longer than of the backend
+			# To prevent error, let's just turn keepalive off (performance is not a big deal)
+			# https://stackoverflow.com/questions/66911457/my-nodejs-app-show-502-error-for-no-reason
+			transport http {
+				keepalive off
+			}
 		}
 
 		# 캐시 설정
@@ -33,11 +39,9 @@ dev.codedang.com {
 			defer
 		}
 
-		# import <pattern> [<args...>]
-		# cors 허용할 도메인 설정
+		# cors 허용할 도메인
 		import cors http://localhost:5173 # frontend server (Vue)
 		import cors http://localhost:5525 # frontend server (Next.js)
-		import cors http://localhost:5555 # api docs server
 	}
 
 	handle /logs/* {
@@ -45,7 +49,15 @@ dev.codedang.com {
 	}
 
 	handle /graphql {
-		reverse_proxy 127.0.0.1:3000
+		reverse_proxy 127.0.0.1:3000 {
+			transport http {
+				keepalive off
+			}
+		}
+
+		# cors 허용할 도메인
+		import cors http://localhost:5173 # frontend server (Vue)
+		import cors http://localhost:5525 # frontend server (Next.js)
 	}
 
 	handle {

--- a/frontend-client/app/admin/problem/[id]/page.tsx
+++ b/frontend-client/app/admin/problem/[id]/page.tsx
@@ -198,14 +198,14 @@ export default function Page({ params }: { params: { id: string } }) {
   const fetchedDifficulty = problemData?.getProblem.difficulty
   const fetchedLangauges = problemData?.getProblem.languages ?? []
   const fetchedTags =
-    problemData?.getProblem.problemTag.map(({ tag }) => +tag.id) ?? []
-
-  const fetchedTemplateLanguage =
-    problemData?.getProblem.template?.map(
-      (template: string) => JSON.parse(template)[0]?.language
-    ) ?? []
+    problemData?.getProblem.problemTag?.map(({ tag }) => +tag.id) ?? []
 
   useEffect(() => {
+    const fetchedTemplateLanguage =
+      problemData?.getProblem.template?.map(
+        (template: string) => JSON.parse(template)[0]?.language
+      ) ?? []
+
     setLanguages(
       problemData?.getProblem.languages?.map((language: Language) => ({
         language,
@@ -240,11 +240,11 @@ export default function Page({ params }: { params: { id: string } }) {
     setValue('languages', data.languages ?? [])
     setValue(
       'tags.create',
-      data.problemTag.map((problemTag) => Number(problemTag.tag.id))
+      data.problemTag?.map((problemTag) => Number(problemTag.tag.id)) ?? []
     )
     setValue(
       'tags.delete',
-      data.problemTag.map((problemTag) => Number(problemTag.tag.id))
+      data.problemTag?.map((problemTag) => Number(problemTag.tag.id)) ?? []
     )
     setValue('description', data.description)
     setValue('inputDescription', data.inputDescription)


### PR DESCRIPTION
### Description

몇 주 간의 노력 끝에... dev 서버 타임아웃의 원인을 찾았습니다.
요약하면 HTTP Keep-Alive 세팅이 원인이었습니다.

지금 서버 구성은 아래 그림처럼 되어있는데, backend의 Node.js는 기본적으로 Keep-Alive timeout이 5초로 설정되어있습니다. 반면 Caddy에서 backend 방향으로는 2분으로 설정되어있고요.

```mermaid
flowchart LR
  사용자 --- Caddy
  subgraph 서버
    Caddy --- backend
  end
```

이렇게 reverse proxy의 keepalive 세팅값이 backend보다 길면 타임아웃이 뜰 수 있다고 합니다.
backend에서는 keepalive가 만료되었지만 reverse proxy에서는 기존 커넥션으로 요청 보내면 이미 끊긴 상태인 거죠.
> 참고1: [My NodeJS app show 502 error for no reason](https://stackoverflow.com/questions/66911457/my-nodejs-app-show-502-error-for-no-reason)
> 참고2: [NestJS 혹은 Express에서 간헐적으로 502 응답이 오는 경우](https://velog.io/@dramatic/NestJS-%ED%98%B9%EC%9D%80-Express%EC%97%90%EC%84%9C-%EA%B0%84%ED%97%90%EC%A0%81%EC%9C%BC%EB%A1%9C-502-%EC%9D%91%EB%8B%B5%EC%9D%B4-%EC%98%A4%EB%8A%94-%EA%B2%BD%EC%9A%B0)

Troubleshooting하면서 이상했던 점 중 하나가, 페이지를 여러 번 새로고침하면 특정 시점부터 타임아웃이 뜨는 건데,
지금 원인을 알고 재현해보니 첫 접속 이후 정확히 5초 이후 새로고침을 하면 타임아웃이 뜨네요.

그리고 이러한 에러가 브라우저나 Bruno 등에서는 뜨지 않았는데, 얘네는 HTTP/2를 써서 Keep-Alive 관련 문제가 없었고, Vercel 등에서 Node.js로 보내는 요청은 HTTP/1.1을 써서 Keep-Alive 문제가 있었던 걸로 보입니다 (뇌피셜)

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
