### PR TITLE
fix(be): modify getProblem sample field

### DIFF
--- a/backend/apps/client/src/problem/dto/problem.response.dto.ts
+++ b/backend/apps/client/src/problem/dto/problem.response.dto.ts
@@ -1,4 +1,4 @@
-import { type Language, Level, type Tag } from '@prisma/client'
+import { type Language, Level, type Tag, ExampleIO } from '@prisma/client'
 import { Exclude, Expose } from 'class-transformer'
 
 @Exclude()
@@ -22,7 +22,6 @@ export class ProblemResponseDto {
   @Expose() submissionCount: number
   @Expose() acceptedCount: number
   @Expose() acceptedRate: number
-  @Expose() inputExamples: string[]
-  @Expose() outputExamples: string[]
+  @Expose() samples: Partial<ExampleIO>[]
   @Expose() tags: Partial<Tag>[]
 }

--- a/backend/apps/client/src/problem/dto/problem.response.dto.ts
+++ b/backend/apps/client/src/problem/dto/problem.response.dto.ts
@@ -1,4 +1,4 @@
-import { type Language, Level, type Tag, ExampleIO } from '@prisma/client'
+import { type Language, Level, type Tag, type ExampleIO } from '@prisma/client'
 import { Exclude, Expose } from 'class-transformer'
 
 @Exclude()

--- a/backend/apps/client/src/problem/problem.repository.ts
+++ b/backend/apps/client/src/problem/problem.repository.ts
@@ -44,7 +44,13 @@ export class ProblemRepository {
     memoryLimit: true,
     source: true,
     acceptedCount: true,
-    samples: true
+    samples: {
+      select: {
+        id: true,
+        input: true,
+        output: true
+      }
+    }
   }
 
   private readonly codeDraftSelectOption = {


### PR DESCRIPTION
### Description

기존 getProblem을 통해서는 sample field를 가져오지 않는다는 문제가 있었습니다.
이에 Expose field를 수정하고, 원래는 updatetime, problemid, createtime 등 모든 정보를 다 받았지만, select해 sampleId, input, output만을 가져오도록 수정했습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
