### PR TITLE
fix(infra): use longer timeout value

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -3,6 +3,7 @@ name: CD - Development
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Caddyfile
+++ b/Caddyfile
@@ -21,16 +21,18 @@
 	}
 }
 
+# Keep-Alive timeout of reverse proxy must be longer than of the backend
+# Set timeout of Caddy to 60s and of the backend to 61s to avoid timeout error
+# https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/
+servers {
+	timeouts {
+		idle 1m
+	}
+}
+
 dev.codedang.com {
 	handle /api/* {
-		reverse_proxy 127.0.0.1:4000 {
-			# Keep-Alive timeout of Caddy must be longer than of the backend
-			# To prevent error, let's just turn keepalive off (performance is not a big deal)
-			# https://stackoverflow.com/questions/66911457/my-nodejs-app-show-502-error-for-no-reason
-			transport http {
-				keepalive off
-			}
-		}
+		reverse_proxy 127.0.0.1:4000
 
 		# 캐시 설정
 		header {
@@ -48,11 +50,7 @@ dev.codedang.com {
 	}
 
 	handle /graphql {
-		reverse_proxy 127.0.0.1:3000 {
-			transport http {
-				keepalive off
-			}
-		}
+		reverse_proxy 127.0.0.1:3000
 
 		# cors 허용할 도메인
 		import cors http://localhost:5173 # frontend server (Vue)

--- a/Caddyfile
+++ b/Caddyfile
@@ -21,12 +21,15 @@
 	}
 }
 
-# Keep-Alive timeout of reverse proxy must be longer than of the backend
-# Set timeout of Caddy to 60s and of the backend to 61s to avoid timeout error
-# https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/
-servers {
-	timeouts {
-		idle 1m
+# Global options
+{
+	# Keep-Alive timeout of reverse proxy must be longer than of the backend
+	# Set timeout of Caddy to 60s and of the backend to 61s to avoid timeout error
+	# https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/
+	servers {
+		timeouts {
+			idle 1m
+		}
 	}
 }
 

--- a/backend/apps/admin/src/admin.module.ts
+++ b/backend/apps/admin/src/admin.module.ts
@@ -1,9 +1,10 @@
 import { ApolloDriver, type ApolloDriverConfig } from '@nestjs/apollo'
 import { CacheModule } from '@nestjs/cache-manager'
-import { Module } from '@nestjs/common'
+import { Module, type OnApplicationBootstrap } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
-import { APP_GUARD } from '@nestjs/core'
+import { APP_GUARD, type HttpAdapterHost } from '@nestjs/core'
 import { GraphQLModule } from '@nestjs/graphql'
+import type { Server } from 'http'
 import { LoggerModule } from 'nestjs-pino'
 import {
   JwtAuthModule,
@@ -62,4 +63,15 @@ import { UserModule } from './user/user.module'
     { provide: APP_GUARD, useClass: GroupLeaderGuard }
   ]
 })
-export class AdminModule {}
+export class AdminModule implements OnApplicationBootstrap {
+  constructor(private readonly refHost: HttpAdapterHost) {}
+
+  onApplicationBootstrap() {
+    // Keep-Alive timeout of reverse proxy must be longer than of the backend
+    // Set timeout of Caddy to 60s and of the backend to 61s to avoid timeout error
+    // https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/
+    const server: Server = this.refHost.httpAdapter.getHttpServer()
+    server.keepAliveTimeout = 61 * 1000
+    server.headersTimeout = 62 * 1000
+  }
+}

--- a/backend/apps/client/src/app.module.ts
+++ b/backend/apps/client/src/app.module.ts
@@ -1,8 +1,9 @@
 import { MailerModule } from '@nestjs-modules/mailer'
 import { CacheModule } from '@nestjs/cache-manager'
-import { Module } from '@nestjs/common'
+import { Module, type OnApplicationBootstrap } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
-import { APP_GUARD } from '@nestjs/core'
+import { APP_GUARD, type HttpAdapterHost } from '@nestjs/core'
+import type { Server } from 'http'
 import { LoggerModule } from 'nestjs-pino'
 import { JwtAuthModule, JwtAuthGuard } from '@libs/auth'
 import { CacheConfigService } from '@libs/cache'
@@ -49,4 +50,15 @@ import { WorkbookModule } from './workbook/workbook.module'
   controllers: [AppController],
   providers: [AppService, { provide: APP_GUARD, useClass: JwtAuthGuard }]
 })
-export class AppModule {}
+export class AppModule implements OnApplicationBootstrap {
+  constructor(private readonly refHost: HttpAdapterHost) {}
+
+  onApplicationBootstrap() {
+    // Keep-Alive timeout of reverse proxy must be longer than of the backend
+    // Set timeout of Caddy to 60s and of the backend to 61s to avoid timeout error
+    // https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/
+    const server: Server = this.refHost.httpAdapter.getHttpServer()
+    server.keepAliveTimeout = 61 * 1000
+    server.headersTimeout = 62 * 1000
+  }
+}


### PR DESCRIPTION
### Description

#1437 에서 완전히 타임아웃 에러가 해결된 거 같지 않아서 좀 고쳐봅니다
NestJS의 타임아웃 값을 61초로 늘렸고(기본 5초), Caddy의 servers.timeouts.idle 값을 60초로 조정했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
