### PR TITLE
feat(fe): add alert dialog for problem create page

### DIFF
--- a/frontend-client/components/DataTableAdmin.tsx
+++ b/frontend-client/components/DataTableAdmin.tsx
@@ -2,6 +2,17 @@
 
 import { gql } from '@generated'
 import { GET_TAGS } from '@/app/admin/problem/utils'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -86,6 +97,8 @@ export function DataTableAdmin<TData, TValue>({
     getFacetedUniqueValues: getFacetedUniqueValues()
   })
 
+  const selectedRowCount = Object.values(rowSelection).filter(Boolean).length
+
   const DELETE_PROBLEM = gql(`
   mutation DeleteProblem($groupId: Int!, $id: Int!) {
     deleteProblem(groupId: $groupId, id: $id) {
@@ -154,9 +167,34 @@ export function DataTableAdmin<TData, TValue>({
             />
           )}
         </div>
-        <Button onClick={() => handleDeleteRows()} variant="outline">
-          <PiTrashLight fontSize={18} />
-        </Button>
+        {selectedRowCount !== 0 ? (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline">
+                <PiTrashLight fontSize={18} />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to permanently delete {selectedRowCount}{' '}
+                  problem(s)?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction asChild>
+                  <Button onClick={() => handleDeleteRows()}>Continue</Button>
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        ) : (
+          <Button variant="outline">
+            <PiTrashLight fontSize={18} />
+          </Button>
+        )}
       </div>
 
       <div className="rounded-md border">

--- a/frontend-client/components/DataTableAdmin.tsx
+++ b/frontend-client/components/DataTableAdmin.tsx
@@ -179,7 +179,7 @@ export function DataTableAdmin<TData, TValue>({
                 <AlertDialogTitle>Delete</AlertDialogTitle>
                 <AlertDialogDescription>
                   Are you sure you want to permanently delete {selectedRowCount}{' '}
-                  problem(s)?
+                  {page}(s)?
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>


### PR DESCRIPTION
### Description
만약 선택한 row가 1개 이상인 경우 delete 버튼을 눌렀을 때
재확인 모달이 뜨고 Continue를 누르면 row가 삭제됩니다.
![image](https://github.com/skkuding/codedang/assets/97675977/9e100930-c689-450a-b3d8-a4e3716b2bee)
Closes #1480 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
