### PR TITLE
feat: add log data of request body

### DIFF
--- a/backend/apps/admin/src/admin.module.ts
+++ b/backend/apps/admin/src/admin.module.ts
@@ -15,7 +15,7 @@ import {
 import { CacheConfigService } from '@libs/cache'
 import { AdminExceptionFilter } from '@libs/exception'
 import { apolloErrorFormatter } from '@libs/exception'
-import { pinoLoggerModuleOption } from '@libs/logger'
+import { LoggingPlugin, pinoLoggerModuleOption } from '@libs/logger'
 import { PrismaModule } from '@libs/prisma'
 import { NoticeModule } from '@admin/notice/notice.module'
 import { AdminController } from './admin.controller'
@@ -62,7 +62,8 @@ import { UserModule } from './user/user.module'
     AdminService,
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: GroupLeaderGuard },
-    { provide: APP_FILTER, useClass: AdminExceptionFilter }
+    { provide: APP_FILTER, useClass: AdminExceptionFilter },
+    LoggingPlugin
   ]
 })
 export class AdminModule implements OnApplicationBootstrap {

--- a/backend/libs/logger/src/apollo-plugin.logger.ts
+++ b/backend/libs/logger/src/apollo-plugin.logger.ts
@@ -1,0 +1,21 @@
+import { Plugin } from '@nestjs/apollo'
+import { Logger } from '@nestjs/common'
+import type { GqlExecutionContext } from '@nestjs/graphql'
+import type { ApolloServerPlugin, GraphQLRequestListener } from '@apollo/server'
+
+@Plugin()
+export class LoggingPlugin implements ApolloServerPlugin {
+  private readonly logger = new Logger(LoggingPlugin.name)
+
+  async requestDidStart(): Promise<
+    GraphQLRequestListener<GqlExecutionContext>
+  > {
+    return {
+      didEncounterErrors: async (requestContext) => {
+        for (const error of requestContext.errors) {
+          this.logger.log(error)
+        }
+      }
+    }
+  }
+}

--- a/backend/libs/logger/src/index.ts
+++ b/backend/libs/logger/src/index.ts
@@ -1,1 +1,2 @@
 export * from './pino-option.logger'
+export * from './apollo-plugin.logger'

--- a/backend/libs/logger/src/pino-option.logger.ts
+++ b/backend/libs/logger/src/pino-option.logger.ts
@@ -56,6 +56,12 @@ export const pinoLoggerModuleOption: Params = {
       const id = randomUUID()
       res.setHeader('X-Request-Id', id)
       return id
+    },
+    serializers: {
+      req(req) {
+        req.body = req.raw?.body
+        return req
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
close #1472

HTTP request에 포함된 body도 로그에 남도록 설정을 추가합니다.
GraphQL 요청에 대해서도 body에 관련 정보가 모두 포함됩니다.

추가로, Apollo Server가 던지는 validation failed error 등의 에러가 기존 admin exception filter를 거치지 않는 문제를 식별하였습니다.
Apollo Server가 반환하는 모든 종류에 대한 에러를 기록하는 플러그인을 만들어 admin 모듈의 공급자로 등록해 두었습니다.



### Additional context
![image](https://github.com/skkuding/codedang/assets/64393421/93730a8c-6874-4619-acba-011abcba40d0)

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
