### PR TITLE
docs(be): fix send-pin-for-pw-reset-api docs

### DIFF
--- a/collection/client/User/(TODO) Send Pin for Password Reset/401- Unauthorized.bru
+++ b/collection/client/User/(TODO) Send Pin for Password Reset/401- Unauthorized.bru
@@ -12,6 +12,6 @@ post {
 
 body:json {
   {
-    "email": "skkucodingplatform@gmail.com"
+    "email": "unregisteredmail@gmail.com"
   }
 }

--- a/collection/client/User/(TODO) Send Pin for Password Reset/Succeed.bru
+++ b/collection/client/User/(TODO) Send Pin for Password Reset/Succeed.bru
@@ -15,7 +15,3 @@ body:json {
     "email": "skkucodingplatform@gmail.com"
   }
 }
-
-script:pre-request {
-  await require("./login").loginUser(req);
-}


### PR DESCRIPTION
### Description

Closes #1493

비밀번호를 초기화하는 api sendPinForPasswordReset에 대한 Bruno docs의 잘못된 부분을 수정합니다.

- 로그인이 필요하지 않은 기능임에도 불구하고 pre-script로 로그인이 들어가있음
- 잘못된 이메일(등록되지 않은 이메일)이 작성되어있어야 하는 에러 관련 docs에 제대로 된 이메일이 들어가있음

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
