### PR TITLE
feat(fe): change textarea and texteditor resizable

### DIFF
--- a/frontend-client/app/admin/problem/[id]/page.tsx
+++ b/frontend-client/app/admin/problem/[id]/page.tsx
@@ -480,7 +480,7 @@ export default function Page({ params }: { params: { id: string } }) {
                 <Textarea
                   id="inputDescription"
                   placeholder="Enter a description..."
-                  className="h-[120px] w-[360px] resize-none bg-white"
+                  className="min-h-[120px] w-[360px] bg-white"
                   {...register('inputDescription')}
                 />
                 {errors.inputDescription && (
@@ -495,7 +495,7 @@ export default function Page({ params }: { params: { id: string } }) {
                 <Textarea
                   id="outputDescription"
                   placeholder="Enter a description..."
-                  className="h-[120px] w-[360px] resize-none bg-white"
+                  className="min-h-[120px] w-[360px] bg-white"
                   {...register('outputDescription')}
                 />
                 {errors.outputDescription && (
@@ -642,7 +642,7 @@ export default function Page({ params }: { params: { id: string } }) {
               <Textarea
                 id="hint"
                 placeholder="Enter a hint"
-                className="h-[120px] w-[760px] resize-none bg-white"
+                className="min-h-[120px] w-[760px] bg-white"
                 {...register('hint')}
               />
             )}

--- a/frontend-client/app/admin/problem/_components/ExampleTextarea.tsx
+++ b/frontend-client/app/admin/problem/_components/ExampleTextarea.tsx
@@ -21,7 +21,7 @@ export default function ExampleTextarea({
   return (
     <div
       className={cn(
-        'relative flex h-[120px] w-full rounded-md border border-gray-200 bg-gray-50 py-3 font-mono shadow-sm',
+        'relative flex min-h-[120px] w-full rounded-md border border-gray-200 bg-gray-50 py-3 font-mono shadow-sm',
         className
       )}
     >
@@ -36,7 +36,7 @@ export default function ExampleTextarea({
       />
       <Textarea
         placeholder="Output"
-        className="resize-none rounded-none border-l border-transparent border-l-gray-200 px-4 py-0 shadow-none focus-visible:ring-0"
+        className="min-h-[120px] rounded-none border-l border-transparent border-l-gray-200 px-4 py-0 shadow-none focus-visible:ring-0"
         {...register(outputName)}
       />
     </div>

--- a/frontend-client/app/admin/problem/create/page.tsx
+++ b/frontend-client/app/admin/problem/create/page.tsx
@@ -375,7 +375,7 @@ export default function Page() {
                 <Textarea
                   id="inputDescription"
                   placeholder="Enter a description..."
-                  className="h-[120px] w-[360px] resize-none bg-white"
+                  className="min-h-[120px] w-[360px] bg-white"
                   {...register('inputDescription')}
                 />
                 {errors.inputDescription && (
@@ -390,7 +390,7 @@ export default function Page() {
                 <Textarea
                   id="outputDescription"
                   placeholder="Enter a description..."
-                  className="h-[120px] w-[360px] resize-none bg-white"
+                  className="min-h-[120px] w-[360px] bg-white"
                   {...register('outputDescription')}
                 />
                 {errors.outputDescription && (
@@ -535,7 +535,7 @@ export default function Page() {
               <Textarea
                 id="hint"
                 placeholder="Enter a hint"
-                className="h-[120px] w-[760px] resize-none bg-white"
+                className="min-h-[120px] w-[760px] bg-white"
                 {...register('hint')}
               />
             )}

--- a/frontend-client/components/TextEditor.tsx
+++ b/frontend-client/components/TextEditor.tsx
@@ -42,7 +42,7 @@ export default function TextEditor({
     editorProps: {
       attributes: {
         class:
-          'rounded-b-md border overflow-y-auto w-full h-[200px] border-input bg-backround px-3 ring-offset-2 disabled:cursur-not-allowed disabled:opacity-50'
+          'rounded-b-md border overflow-y-auto w-full min-h-[200px] border-input bg-backround px-3 ring-offset-2 disabled:cursur-not-allowed disabled:opacity-50 resize-y'
       }
     },
     onUpdate({ editor }) {


### PR DESCRIPTION
### Description
inputDescription outputDescription hint ExampleTextarea 가 resize가 가능하도록 하고 height를 min-height로 수정했습니다.
![image](https://github.com/skkuding/codedang/assets/97675977/e2d80d61-fcdd-4fdc-8ef9-527213f14013)

Closes #1497 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
