### PR TITLE
fix(fe): remove delay at switching visible option

### DIFF
--- a/frontend-client/app/admin/problem/_components/Columns.tsx
+++ b/frontend-client/app/admin/problem/_components/Columns.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
 import { useMutation } from '@apollo/client'
 import type { ColumnDef } from '@tanstack/react-table'
+import { useState } from 'react'
 import { FiEyeOff } from 'react-icons/fi'
 import { FiEye } from 'react-icons/fi'
 
@@ -36,26 +37,28 @@ const EDIT_VISIBLE = gql(`
 
 function VisibleCell({ isVisible, id }: { isVisible: boolean; id: number }) {
   const [updateVisible] = useMutation(EDIT_VISIBLE)
+  const [isVisibleState, setIsVisibleState] = useState(isVisible)
 
   return (
     <div className="flex space-x-2">
       <Switch
         id="hidden-mode"
-        checked={isVisible}
+        checked={isVisibleState}
         onCheckedChange={() => {
+          setIsVisibleState(!isVisibleState)
           updateVisible({
             variables: {
               groupId: 1,
               input: {
                 id,
-                isVisible: !isVisible
+                isVisible: !isVisibleState
               }
             }
           })
         }}
       />
       <div className="flex items-center justify-center">
-        {isVisible ? (
+        {isVisibleState ? (
           <FiEye className="text-primary h-[14px] w-[14px]" />
         ) : (
           <FiEyeOff className="h-[14px] w-[14px] text-gray-400" />
@@ -210,8 +213,9 @@ export const columns: ColumnDef<DataTableProblem>[] = [
       <DataTableColumnHeader column={column} title="Visible" />
     ),
     cell: ({ row }) => {
-      const isVisible: boolean = row.getValue('isVisible')
-      return <VisibleCell isVisible={isVisible} id={row.original.id} />
+      return (
+        <VisibleCell isVisible={row.original.isVisible} id={row.original.id} />
+      )
     }
   }
 ]

--- a/frontend-client/components/DataTableAdmin.tsx
+++ b/frontend-client/components/DataTableAdmin.tsx
@@ -124,7 +124,6 @@ export function DataTableAdmin<TData, TValue>({
           }
         })
       } else {
-        console.log('delete', row.original.id)
         return Promise.resolve()
       }
     })


### PR DESCRIPTION
### Description

기존에는 업데이트 요청 -> 새로운 데이터 요청 -> visible 여부 render라서 느리게 switching이 되었음
render용으로 state 따로 만들어 업데이트 요청과 render간 delay 없앰

좋은 해결방법은 아닌 것 같아서 나중에 데이터 수정 데이터 표시 로직 같이 얘기할 필요 있어보임

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
