### PR TITLE
fix(fe): prevent to go first page in admin data table

### DIFF
--- a/frontend-client/app/admin/layout.tsx
+++ b/frontend-client/app/admin/layout.tsx
@@ -4,7 +4,6 @@ import type { Route } from 'next'
 import Link from 'next/link'
 import { FaArrowRightFromBracket } from 'react-icons/fa6'
 import ClientApolloProvider from './_components/ApolloProvider'
-// import GroupSelect from './_components/GroupSelect'
 import SideBar from './_components/SideBar'
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/frontend-client/app/admin/problem/_components/Columns.tsx
+++ b/frontend-client/app/admin/problem/_components/Columns.tsx
@@ -4,8 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
 import { useMutation } from '@apollo/client'
-import type { ColumnDef } from '@tanstack/react-table'
-import { useState } from 'react'
+import type { ColumnDef, Row } from '@tanstack/react-table'
 import { FiEyeOff } from 'react-icons/fi'
 import { FiEye } from 'react-icons/fi'
 
@@ -35,32 +34,29 @@ const EDIT_VISIBLE = gql(`
   }
 `)
 
-function VisibleCell({ isVisible, id }: { isVisible: boolean; id: number }) {
-  const [updateVisible] = useMutation(EDIT_VISIBLE, {
-    fetchPolicy: 'no-cache'
-  })
-  const [isVisibleState, setIsVisibleState] = useState(isVisible)
+function VisibleCell({ row }: { row: Row<DataTableProblem> }) {
+  const [updateVisible] = useMutation(EDIT_VISIBLE)
 
   return (
     <div className="flex space-x-2">
       <Switch
         id="hidden-mode"
-        checked={isVisibleState}
+        checked={row.original.isVisible}
         onCheckedChange={() => {
-          setIsVisibleState(!isVisibleState)
+          row.original.isVisible = !row.original.isVisible
           updateVisible({
             variables: {
               groupId: 1,
               input: {
-                id,
-                isVisible: !isVisibleState
+                id: row.original.id,
+                isVisible: row.original.isVisible
               }
             }
           })
         }}
       />
       <div className="flex items-center justify-center">
-        {isVisibleState ? (
+        {row.original.isVisible ? (
           <FiEye className="text-primary h-[14px] w-[14px]" />
         ) : (
           <FiEyeOff className="h-[14px] w-[14px] text-gray-400" />
@@ -215,9 +211,7 @@ export const columns: ColumnDef<DataTableProblem>[] = [
       <DataTableColumnHeader column={column} title="Visible" />
     ),
     cell: ({ row }) => {
-      return (
-        <VisibleCell isVisible={row.original.isVisible} id={row.original.id} />
-      )
+      return <VisibleCell row={row} />
     }
   }
 ]

--- a/frontend-client/app/admin/problem/_components/Columns.tsx
+++ b/frontend-client/app/admin/problem/_components/Columns.tsx
@@ -36,7 +36,9 @@ const EDIT_VISIBLE = gql(`
 `)
 
 function VisibleCell({ isVisible, id }: { isVisible: boolean; id: number }) {
-  const [updateVisible] = useMutation(EDIT_VISIBLE)
+  const [updateVisible] = useMutation(EDIT_VISIBLE, {
+    fetchPolicy: 'no-cache'
+  })
   const [isVisibleState, setIsVisibleState] = useState(isVisible)
 
   return (

--- a/frontend-client/app/admin/problem/page.tsx
+++ b/frontend-client/app/admin/problem/page.tsx
@@ -9,7 +9,6 @@ import { useQuery } from '@apollo/client'
 import { Language, Level } from '@generated/graphql'
 import { PlusCircleIcon } from 'lucide-react'
 import Link from 'next/link'
-import * as React from 'react'
 import { columns } from './_components/Columns'
 import UploadDialog from './_components/UploadDialog'
 
@@ -44,8 +43,6 @@ const GET_PROBLEMS = gql(`
     }
   }
 `)
-
-export const dynamic = 'force-dynamic'
 
 export default function Page() {
   const { data, loading, refetch } = useQuery(GET_PROBLEMS, {

--- a/frontend-client/components/DataTableAdmin.tsx
+++ b/frontend-client/components/DataTableAdmin.tsx
@@ -23,12 +23,7 @@ import {
   TableRow
 } from '@/components/ui/table'
 import { useQuery, useMutation } from '@apollo/client'
-import type {
-  ColumnDef,
-  ColumnFiltersState,
-  SortingState,
-  VisibilityState
-} from '@tanstack/react-table'
+import type { ColumnDef, SortingState } from '@tanstack/react-table'
 import {
   flexRender,
   getCoreRowModel,
@@ -63,8 +58,6 @@ export function DataTableAdmin<TData, TValue>({
   data
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = useState({})
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [sorting, setSorting] = useState<SortingState>([])
   const pathname = usePathname()
   const page = pathname.split('/').pop()
@@ -80,15 +73,11 @@ export function DataTableAdmin<TData, TValue>({
     columns,
     state: {
       sorting,
-      columnVisibility,
-      rowSelection,
-      columnFilters
+      rowSelection
     },
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/frontend-client/components/DataTableAdmin.tsx
+++ b/frontend-client/components/DataTableAdmin.tsx
@@ -75,6 +75,7 @@ export function DataTableAdmin<TData, TValue>({
       sorting,
       rowSelection
     },
+    autoResetPageIndex: false,
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,


### PR DESCRIPTION
### Description

fetching(useMutation) -> updating cache data -> useQuery의 data updating -> data table rerendering -> page 0으로 되돌아가짐

위 상황 때문에 초기 화면으로 바뀌기 때문에 요청은 보내지만 caching은 하지 않도록 했으나 이러면 다른 페이지 갔다가 돌아오면 변경 전 내용을 보여주기 때문에 더 검색해보니 react table에 `autoResetPageIndex: false` 옵션을 주면 page index를 초기화 시키지 않는 것을 알 수 있었음

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
