### PR TITLE
fix(infra): expose email auth header with cors request

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -13,6 +13,7 @@
 			Access-Control-Allow-Origin "{header.Origin}"
 			Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE"
 			Access-Control-Allow-Headers "Content-Type, Authorization, Email-Auth, Apollo-Require-Preflight"
+			Access-Control-Expose-Headers "Email-Auth"
 		}
 		respond "" 204
 	}
@@ -28,6 +29,7 @@
 			Access-Control-Allow-Origin "{header.Origin}"
 			Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE"
 			Access-Control-Allow-Headers "Content-Type, Authorization, Email-Auth, Apollo-Require-Preflight"
+			Access-Control-Expose-Headers "Email-Auth"
 		}
 	}
 }


### PR DESCRIPTION
### Description

프론트엔드에서 `Email-Auth` 값을 못 읽는다고 해서 Caddyfile에 CORS 설정 추가했어요

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
