### PR TITLE
fix(be): convert can register property into is registered

### DIFF
--- a/backend/apps/client/src/contest/contest.service.ts
+++ b/backend/apps/client/src/contest/contest.service.ts
@@ -280,16 +280,16 @@ export class ContestService {
   }
 
   async getContest(id: number, groupId = OPEN_SPACE_ID, userId?: number) {
-    // check if the user can register this contest
+    // check if the user has already registered this contest
     // initial value is false
-    let canRegister = false
+    let isRegistered = false
     let contest
     if (userId) {
       const hasRegistered = await this.prisma.contestRecord.findFirst({
         where: { userId, contestId: id }
       })
-      if (!hasRegistered) {
-        canRegister = true
+      if (hasRegistered) {
+        isRegistered = true
       }
     }
     try {
@@ -353,7 +353,7 @@ export class ContestService {
     // combine contest and sortedContestRecordsWithUserDetail
     return {
       ...contest,
-      canRegister
+      isRegistered
     }
   }
 

--- a/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/backend/apps/client/src/problem/problem.service.spec.ts
@@ -265,7 +265,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        canRegister: false
+        isRegistered: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -287,7 +287,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        canRegister: false
+        isRegistered: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -325,7 +325,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.future(),
         endTime: faker.date.future(),
-        canRegister: false
+        isRegistered: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -339,7 +339,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        canRegister: true
+        isRegistered: false
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -356,7 +356,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        canRegister: false
+        isRegistered: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
 
@@ -379,7 +379,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        canRegister: false
+        isRegistered: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
 
@@ -412,7 +412,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.future(),
         endTime: faker.date.future(),
-        canRegister: false
+        isRegistered: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
       await expect(
@@ -425,7 +425,7 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        canRegister: true
+        isRegistered: false
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
       await expect(

--- a/backend/apps/client/src/problem/problem.service.ts
+++ b/backend/apps/client/src/problem/problem.service.ts
@@ -89,11 +89,11 @@ export class ContestProblemService {
       userId
     )
     const now = new Date()
-    if (!contest.canRegister && contest.startTime > now) {
+    if (contest.isRegistered && contest.startTime > now) {
       throw new ForbiddenAccessException(
         'Cannot access to problems before the contest starts.'
       )
-    } else if (contest.canRegister && contest.endTime > now) {
+    } else if (!contest.isRegistered && contest.endTime > now) {
       throw new ForbiddenAccessException(
         'Register to access the problems of this contest.'
       )
@@ -125,11 +125,11 @@ export class ContestProblemService {
       userId
     )
     const now = new Date()
-    if (!contest.canRegister && contest.startTime > now) {
+    if (contest.isRegistered && contest.startTime > now) {
       throw new ForbiddenAccessException(
         'Cannot access to problems before the contest starts.'
       )
-    } else if (contest.canRegister && contest.endTime > now) {
+    } else if (!contest.isRegistered && contest.endTime > now) {
       throw new ForbiddenAccessException('Register to access this problem.')
     }
 

--- a/collection/client/Contest/Get contest by ID/Succeed.bru
+++ b/collection/client/Contest/Get contest by ID/Succeed.bru
@@ -24,12 +24,7 @@ assert {
   res("group.groupName"): isString
   res("description"): isString
   res("_count.contestRecord"): isNumber
-  res("standings[0].user.id"): isNumber
-  res("standings[0].user.username"): isString
-  res("standings[0].score"): isNumber
-  res("standings[0].totalPenalty"): isNumber
-  res("standings[0].standing"): isNumber
-  res("canRegister"): isBoolean
+  res("isRegistered"): isBoolean
 }
 
 script:pre-request {
@@ -38,23 +33,23 @@ script:pre-request {
 
 docs {
   ## Get Contest by ID
-  
-  하나의 대회 정보와 Contest 참여자 정보, 로그인한 유저가 해당 Contest에 참여가능한지 여부에 대한 정보를 가져옵니다. (로그인 하지 않은 유저는 Open Space의 Contest 정보만 볼 수 있고, `canRegister`는 항상 `false`)
+
+  하나의 대회 정보와 Contest 참여자 정보, 로그인한 유저가 해당 Contest에 참여가능한지 여부에 대한 정보를 가져옵니다. (로그인 하지 않은 유저는 Open Space의 Contest 정보만 볼 수 있고, `isRegistered`는 항상 `false`)
   ### Path
-  
+
   | 이름 | 타입 | 설명 |
   |-----|-----|-----|
   |id|Integer|Contest(대회) ID|
-  
+
   ### Query
-  
+
   | 이름 | 타입 | 설명 |
   |-----|-----|-----|
   |groupId|Integer|대회가 속한 Group ID|
-  
+
   ### Error Case
-  
+
   #### [404] Contest does not exist
-  
+
   존재하지 않는 ContestID를 Path로 주면 오류가 납니다.
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`User`가 `Contest` 정보를 가져올 때, 해당 `Contest`에 이미 등록했는지/안했는지를 알 수 있는 `isRegistered` property를 추가했습니다. (기존의 `canRegister`에서 변경한 것입니다.)
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
변수명이 `가입할 수 있는가?`에서 `이미 가입했는가?`로 바뀐 만큼 기존의 로직들에서 해당 변수의 boolean값들이 toggle돼야 해서, 그렇게 처리했습니다.
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
