### PR TITLE
chore(be): add resolve-field for contest-problem, workbook-problem

### DIFF
--- a/apps/backend/apps/admin/src/problem/problem.module.ts
+++ b/apps/backend/apps/admin/src/problem/problem.module.ts
@@ -1,11 +1,22 @@
 import { Module } from '@nestjs/common'
 import { StorageModule } from '@admin/storage/storage.module'
 import { ProblemTagResolver, TagResolver } from './problem-tag.resolver'
-import { ProblemResolver } from './problem.resolver'
+import {
+  ContestProblemResolver,
+  ProblemResolver,
+  WorkbookProblemResolver
+} from './problem.resolver'
 import { ProblemService } from './problem.service'
 
 @Module({
   imports: [StorageModule],
-  providers: [ProblemResolver, ProblemTagResolver, TagResolver, ProblemService]
+  providers: [
+    ProblemResolver,
+    ProblemTagResolver,
+    TagResolver,
+    ProblemService,
+    ContestProblemResolver,
+    WorkbookProblemResolver
+  ]
 })
 export class ProblemModule {}

--- a/apps/backend/apps/admin/src/problem/problem.resolver.ts
+++ b/apps/backend/apps/admin/src/problem/problem.resolver.ts
@@ -218,6 +218,89 @@ export class ProblemResolver {
       throw new InternalServerErrorException()
     }
   }
+}
+
+@Resolver(() => ContestProblem)
+export class ContestProblemResolver {
+  private readonly logger = new Logger(ProblemResolver.name)
+
+  constructor(private readonly problemService: ProblemService) {}
+
+  @Query(() => [ContestProblem], { name: 'getContestProblems' })
+  async getContestProblems(
+    @Args(
+      'groupId',
+      { defaultValue: OPEN_SPACE_ID, type: () => Int },
+      GroupIDPipe
+    )
+    groupId: number,
+    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+    contestId: number
+  ) {
+    try {
+      return await this.problemService.getContestProblems(groupId, contestId)
+    } catch (error) {
+      if (
+        error instanceof UnprocessableDataException ||
+        error instanceof ForbiddenAccessException
+      ) {
+        throw error.convert2HTTPException()
+      } else if (error.code == 'P2025') {
+        throw new NotFoundException(error.message)
+      }
+      this.logger.error(error)
+      throw new InternalServerErrorException(error.message)
+    }
+  }
+
+  @Mutation(() => [ContestProblem])
+  async updateContestProblemsOrder(
+    @Args(
+      'groupId',
+      { defaultValue: OPEN_SPACE_ID, type: () => Int },
+      GroupIDPipe
+    )
+    groupId: number,
+    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+    contestId: number,
+    @Args('orders', { type: () => [Int] }, ParseArrayPipe) orders: number[]
+  ) {
+    try {
+      return await this.problemService.updateContestProblemsOrder(
+        groupId,
+        contestId,
+        orders
+      )
+    } catch (error) {
+      if (
+        error instanceof UnprocessableDataException ||
+        error instanceof ForbiddenAccessException
+      ) {
+        throw error.convert2HTTPException()
+      } else if (error.code == 'P2025') {
+        throw new NotFoundException(error.message)
+      }
+      this.logger.error(error)
+      throw new InternalServerErrorException(error.message)
+    }
+  }
+
+  @ResolveField('problem', () => Problem)
+  async getProblem(@Parent() contestProblem: ContestProblem) {
+    try {
+      return await this.problemService.getProblemById(contestProblem.problemId)
+    } catch (error) {
+      this.logger.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+}
+
+@Resolver(() => WorkbookProblem)
+export class WorkbookProblemResolver {
+  private readonly logger = new Logger(ProblemResolver.name)
+
+  constructor(private readonly problemService: ProblemService) {}
 
   @Query(() => [WorkbookProblem], { name: 'getWorkbookProblems' })
   async getWorkbookProblems(
@@ -279,62 +362,13 @@ export class ProblemResolver {
     }
   }
 
-  @Query(() => [ContestProblem], { name: 'getContestProblems' })
-  async getContestProblems(
-    @Args(
-      'groupId',
-      { defaultValue: OPEN_SPACE_ID, type: () => Int },
-      GroupIDPipe
-    )
-    groupId: number,
-    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
-    contestId: number
-  ) {
+  @ResolveField('problem', () => Problem)
+  async getProblem(@Parent() workbookProblem: WorkbookProblem) {
     try {
-      return await this.problemService.getContestProblems(groupId, contestId)
+      return await this.problemService.getProblemById(workbookProblem.problemId)
     } catch (error) {
-      if (
-        error instanceof UnprocessableDataException ||
-        error instanceof ForbiddenAccessException
-      ) {
-        throw error.convert2HTTPException()
-      } else if (error.code == 'P2025') {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException(error.message)
-    }
-  }
-
-  @Mutation(() => [ContestProblem])
-  async updateContestProblemsOrder(
-    @Args(
-      'groupId',
-      { defaultValue: OPEN_SPACE_ID, type: () => Int },
-      GroupIDPipe
-    )
-    groupId: number,
-    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
-    contestId: number,
-    @Args('orders', { type: () => [Int] }, ParseArrayPipe) orders: number[]
-  ) {
-    try {
-      return await this.problemService.updateContestProblemsOrder(
-        groupId,
-        contestId,
-        orders
-      )
-    } catch (error) {
-      if (
-        error instanceof UnprocessableDataException ||
-        error instanceof ForbiddenAccessException
-      ) {
-        throw error.convert2HTTPException()
-      } else if (error.code == 'P2025') {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException(error.message)
+      console.log(error)
+      throw new InternalServerErrorException()
     }
   }
 }

--- a/apps/backend/apps/admin/src/problem/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.ts
@@ -310,6 +310,14 @@ export class ProblemService {
     })
   }
 
+  async getProblemById(id: number) {
+    return await this.prisma.problem.findFirstOrThrow({
+      where: {
+        id
+      }
+    })
+  }
+
   async updateProblem(input: UpdateProblemInput, groupId: number) {
     const { id, languages, template, tags, testcases, samples, ...data } = input
     const problem = await this.getProblem(id, groupId)

--- a/collection/admin/Problem/Get Contest Problems/Succeed.bru
+++ b/collection/admin/Problem/Get Contest Problems/Succeed.bru
@@ -19,6 +19,11 @@ body:graphql {
       score
       createTime
       updateTime
+      problem {
+        id
+        title
+        description
+      }
     }
   }
   

--- a/collection/admin/Problem/Get WorkbookProblems/Succeed.bru
+++ b/collection/admin/Problem/Get WorkbookProblems/Succeed.bru
@@ -18,6 +18,11 @@ body:graphql {
       problemId
       createTime
       updateTime
+      problem {
+        id
+        title
+        description
+      }
     }
   }
   


### PR DESCRIPTION
### Description

Closes #1556 

GraphQL 요청의 결과로 반환된 ContestProblem의 Problem 내부의 값을 조회할 수 있도록 구현합니다.
같은 방법으로 WorkbookProblem에 대해 구현합니다.


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
