### PR TITLE
fix(infra): change panic to print

### DIFF
--- a/apps/iris/src/observability/metric.go
+++ b/apps/iris/src/observability/metric.go
@@ -21,7 +21,7 @@ func SetGlobalMeterProvider() {
 	// Create resource.
 	res, err := newMetricResource()
 	if err != nil {
-		panic(err)
+		reportErr(err, "failed to create metric resource")
 	}
 
 	// Create a meter provider.
@@ -29,7 +29,7 @@ func SetGlobalMeterProvider() {
 	// accepts a MeterProvider instance.
 	meterProvider, err := newMeterProvider(res, defaultMetricDuration)
 	if err != nil {
-		panic(err)
+		reportErr(err, "failed to create metric provider")
 	}
 
 	// Register as global meter provider so that it can be used via otel.Meter
@@ -80,7 +80,7 @@ func GetMemoryMeter(meter metric.Meter) {
 			return nil
 		}),
 	); err != nil {
-		panic(err)
+		reportErr(err, "failed to create memory meter")
 	}
 }
 
@@ -102,6 +102,6 @@ func GetCPUMeter(meter metric.Meter, duration time.Duration) {
 			return nil
 		}),
 	); err != nil {
-		panic(err)
+		reportErr(err, "failed to create CPU meter")
 	}
 }


### PR DESCRIPTION
### Description
panic 함수 사용시 iris 서버가 다운될수 있어서 fmt 함수로 에러를 프린트하게 변경하였습니다

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
