### PR TITLE
feat(be): implement transaction rollback in unit test

### DIFF
--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -18,14 +18,15 @@ import { GroupService } from './group.service'
 import type { UserGroupData } from './interface/user-group-data.interface'
 
 chai.use(chaiExclude)
-describe('GroupService', async () => {
+describe('GroupService', () => {
   let service: GroupService
   let cache: Cache
   let tx: FlatTransactionClient
 
   const prisma = new PrismaClient().$extends(transactionExtension)
 
-  beforeEach(async () => {
+  beforeEach(async function () {
+    this.timeout(3000)
     //transaction client
     tx = await prisma.$begin()
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -195,7 +195,7 @@ describe('GroupService', async () => {
     beforeEach(async () => {
       // override the useValue of PrismaService
       tx = await prisma.$begin()
-      overridePrismaService(tx)
+      await overridePrismaService(tx)
       const group = await tx.group.create({
         data: {
           groupName: 'test',
@@ -304,7 +304,7 @@ describe('GroupService', async () => {
     beforeEach(async () => {
       // override the useValue of PrismaService
       tx = await prisma.$begin()
-      overridePrismaService(tx)
+      await overridePrismaService(tx)
       await tx.userGroup.createMany({
         data: [
           {

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -28,7 +28,6 @@ describe('GroupService', () => {
   beforeEach(async function () {
     // TODO: CI 테스트에서 timeout이 걸리는 문제를 우회하기 위해서 timeout을 0으로 설정 (timeout disabled)
     // local에서는 timeout을 disable 하지 않아도 테스트가 정상적으로 동작함 (default setting: 2000ms)
-    // timeout이 큰 문제라면 해결을 해야 하는 부분이지만, 현재로서는 사실 큰 문제는 없어 보임 (로컬에서 테스트가 엄청 느려지는 것이 아님)
     this.timeout(0)
     //transaction client
     tx = await prisma.$begin()

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -4,6 +4,8 @@ import { Test, type TestingModule } from '@nestjs/testing'
 import { Prisma, PrismaClient } from '@prisma/client'
 import type { Cache } from 'cache-manager'
 import { expect } from 'chai'
+import * as chai from 'chai'
+import chaiExclude from 'chai-exclude'
 import { stub } from 'sinon'
 import { JOIN_GROUP_REQUEST_EXPIRE_TIME } from '@libs/constants'
 import {
@@ -15,6 +17,7 @@ import { transactionExtension } from '@libs/prisma'
 import { GroupService } from './group.service'
 import type { UserGroupData } from './interface/user-group-data.interface'
 
+chai.use(chaiExclude)
 describe('GroupService', async () => {
   let service: GroupService
   let cache: Cache

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -26,17 +26,13 @@ describe('GroupService', () => {
   const prisma = new PrismaClient().$extends(transactionExtension)
 
   beforeEach(async function () {
-    this.timeout(3000)
+    this.timeout(0)
     //transaction client
     tx = await prisma.$begin()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GroupService,
-        {
-          provide: PrismaService,
-          useValue: tx
-        },
-
+        { provide: PrismaService, useValue: tx },
         ConfigService,
         {
           provide: CACHE_MANAGER,
@@ -172,7 +168,7 @@ describe('GroupService', () => {
     })
   })
 
-  describe('joinGroupById', async () => {
+  describe('joinGroupById', () => {
     let groupId: number
     const userId = 4
     beforeEach(async () => {
@@ -277,7 +273,7 @@ describe('GroupService', () => {
     })
   })
 
-  describe('leaveGroup', async () => {
+  describe('leaveGroup', () => {
     const groupId = 3
     const userId = 4
     beforeEach(async () => {

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -21,33 +21,13 @@ chai.use(chaiExclude)
 describe('GroupService', async () => {
   let service: GroupService
   let cache: Cache
+  let tx: FlatTransactionClient
+
   const prisma = new PrismaClient().$extends(transactionExtension)
 
-  const overridePrismaService = async (transaction: FlatTransactionClient) => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        GroupService,
-        {
-          provide: PrismaService,
-          useValue: transaction
-        },
-        ConfigService,
-        {
-          provide: CACHE_MANAGER,
-          useFactory: () => ({
-            set: () => [],
-            get: () => []
-          })
-        }
-      ]
-    }).compile()
-    service = module.get<GroupService>(GroupService)
-    cache = module.get<Cache>(CACHE_MANAGER)
-  }
-
   beforeEach(async () => {
-    // initial transaction client
-    const tx: FlatTransactionClient = await prisma.$begin()
+    //transaction client
+    tx = await prisma.$begin()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GroupService,
@@ -194,11 +174,7 @@ describe('GroupService', async () => {
   describe('joinGroupById', async () => {
     let groupId: number
     const userId = 4
-    let tx: FlatTransactionClient
     beforeEach(async () => {
-      // override the useValue of PrismaService
-      tx = await prisma.$begin()
-      await overridePrismaService(tx)
       const group = await tx.group.create({
         data: {
           groupName: 'test',
@@ -303,11 +279,7 @@ describe('GroupService', async () => {
   describe('leaveGroup', async () => {
     const groupId = 3
     const userId = 4
-    let tx: FlatTransactionClient
     beforeEach(async () => {
-      // override the useValue of PrismaService
-      tx = await prisma.$begin()
-      await overridePrismaService(tx)
       await tx.userGroup.createMany({
         data: [
           {

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -18,8 +18,8 @@ import type { UserGroupData } from './interface/user-group-data.interface'
 describe('GroupService', async () => {
   let service: GroupService
   let cache: Cache
-
   const prisma = new PrismaClient().$extends(transactionExtension)
+
   const overridePrismaService = async (transaction: FlatTransactionClient) => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -43,7 +43,8 @@ describe('GroupService', async () => {
   }
 
   beforeEach(async () => {
-    const tx = await prisma.$begin()
+    // initial transaction client
+    const tx: FlatTransactionClient = await prisma.$begin()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GroupService,
@@ -190,7 +191,7 @@ describe('GroupService', async () => {
   describe('joinGroupById', async () => {
     let groupId: number
     const userId = 4
-    let tx
+    let tx: FlatTransactionClient
     beforeEach(async () => {
       // override the useValue of PrismaService
       tx = await prisma.$begin()
@@ -299,7 +300,7 @@ describe('GroupService', async () => {
   describe('leaveGroup', async () => {
     const groupId = 3
     const userId = 4
-    let tx
+    let tx: FlatTransactionClient
     beforeEach(async () => {
       // override the useValue of PrismaService
       tx = await prisma.$begin()

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -26,6 +26,9 @@ describe('GroupService', () => {
   const prisma = new PrismaClient().$extends(transactionExtension)
 
   beforeEach(async function () {
+    // TODO: CI 테스트에서 timeout이 걸리는 문제를 우회하기 위해서 timeout을 0으로 설정 (timeout disabled)
+    // local에서는 timeout을 disable 하지 않아도 테스트가 정상적으로 동작함 (default setting: 2000ms)
+    // timeout이 큰 문제라면 해결을 해야 하는 부분이지만, 현재로서는 사실 큰 문제는 없어 보임 (로컬에서 테스트가 엄청 느려지는 것이 아님)
     this.timeout(0)
     //transaction client
     tx = await prisma.$begin()

--- a/apps/backend/libs/prisma/src/index.ts
+++ b/apps/backend/libs/prisma/src/index.ts
@@ -1,2 +1,3 @@
 export * from './prisma.module'
 export * from './prisma.service'
+export * from './transaction.extension'

--- a/apps/backend/libs/prisma/src/transaction.extension.ts
+++ b/apps/backend/libs/prisma/src/transaction.extension.ts
@@ -1,0 +1,71 @@
+import { Prisma } from '@prisma/client'
+import { PrismaService } from './prisma.service'
+
+export type FlatTransactionClient = Prisma.TransactionClient & {
+  $commit: () => Promise<void>
+  $rollback: () => Promise<void>
+}
+
+const ROLLBACK = { [Symbol.for('prisma.client.extension.rollback')]: true }
+
+export const transactionExtension = Prisma.defineExtension({
+  client: {
+    async $begin() {
+      const prisma = Prisma.getExtensionContext(this)
+      let setTxClient: (txClient: Prisma.TransactionClient) => void
+      let commit: () => void
+      let rollback: () => void
+
+      // a promise for getting the tx inner client
+      const txClient = new Promise<Prisma.TransactionClient>((res) => {
+        setTxClient = res
+      })
+
+      // a promise for controlling the transaction
+      const txPromise = new Promise((_res, _rej) => {
+        commit = () => _res(undefined)
+        rollback = () => _rej(ROLLBACK)
+      })
+
+      // opening a transaction to control externally
+      if (
+        '$transaction' in prisma &&
+        typeof prisma.$transaction === 'function'
+      ) {
+        const tx = prisma
+          .$transaction((txClient) => {
+            setTxClient(txClient as unknown as Prisma.TransactionClient)
+            return txPromise
+          })
+          .catch((e) => {
+            if (e === ROLLBACK) {
+              return
+            }
+            throw e
+          })
+
+        // return a proxy TransactionClient with `$commit` and `$rollback` methods
+        return new Proxy(await txClient, {
+          get(target, prop) {
+            if (prop === '$commit') {
+              return () => {
+                commit()
+                return tx
+              }
+            }
+            if (prop === '$rollback') {
+              return () => {
+                rollback()
+                return tx
+              }
+            }
+            return target[prop as keyof typeof target]
+          }
+        }) as FlatTransactionClient
+      }
+
+      throw new Error('Transactions are not supported by this client')
+    },
+    getPaginator: PrismaService.prototype.getPaginator
+  }
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Close #1561 
Backend Unit Test에서 Transaction Rollback을 이용하는 기능을 구현했습니다.  

### Additional context

`prisma.service.ts`에 있는 `PrismaService` Class를 `GroupService`에 주입하는 대신, 새로 만든 `transaction.extension.ts`의 transactionextension을 PrismaClient에 extend하여서, extended된 PrismaClient를 `PrismaService`에 주입했습니다. 이를 이용해 transaction client를 unit test 상에서 구현했습니다.  
`트랜잭션_클라이언트.$commit()`, `트랜잭션_클라이언트.$rollback()`을 통해, Transaction 커밋과 롤백을 이용할 수 있습니다.  

```typescript
beforeEach(async function () {
    this.timeout(0)
    //transaction client
    tx = await prisma.$begin()
    const module: TestingModule = await Test.createTestingModule({
      providers: [
        GroupService,
        { provide: PrismaService, useValue: tx },
        ConfigService,
        {
          provide: CACHE_MANAGER,
          useFactory: () => ({
            set: () => [],
            get: () => []
          })
        }
      ]
    }).compile()
    service = module.get<GroupService>(GroupService)
    cache = module.get<Cache>(CACHE_MANAGER)
  })
```
상기 mocha hook이 local에서는 default timeout setting인 2000ms를 무리 없이 통과하는데요, github action에서는 2000ms 넘겨서 CI 테스트를 통과하지 못했었습니다.  
그래서 `this.timeout(0)`를 넣어서 timeout에 걸리지 않게 했습니다. (`0`으로 설정하면 disable됨)
`tx = await prisma.$begin()` 이 부분때문에 약간의 병목이 생긴 것인지는 확실치 않으나, 나름의 최적화 여지가 있을 것 같습니다.

#1257 PR과 관련이 있습니다.

`transactionExtension`은 <https://github.com/prisma/prisma-client-extensions/pull/47>을 참고하여 작성했습니다.  
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
