### PR TITLE
fix(infra): change otel_endpoint env name

### DIFF
--- a/apps/backend/apps/admin/src/main.ts
+++ b/apps/backend/apps/admin/src/main.ts
@@ -9,8 +9,8 @@ const bootstrap = async () => {
   // otel instrumentation
   if (process.env.NODE_ENV == 'production') {
     if (
-      process.env.OTEL_EXPORTER_OTLP_ENDPOINT == undefined ||
-      process.env.OTEL_EXPORTER_OTLP_ENDPOINT == ''
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL == undefined ||
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL == ''
     ) {
       console.log('The exporter url is not defined')
     } else {

--- a/apps/backend/apps/admin/src/metric.ts
+++ b/apps/backend/apps/admin/src/metric.ts
@@ -9,7 +9,8 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 const startMetricsExporter = () => {
   const options = {
-    url: 'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT + '/v1/metrics', // Grafana Agent Metric을 받는 url
+    url:
+      'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL + '/v1/metrics', // Grafana Agent Metric을 받는 url
     headers: {},
     concurrencyLimit: 5
   }

--- a/apps/backend/apps/admin/src/tracer.ts
+++ b/apps/backend/apps/admin/src/tracer.ts
@@ -15,7 +15,7 @@ class Tracer {
 
   // http://localhost:4318/v1/traces
   private exporter = new OTLPTraceExporter({
-    url: 'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT + '/v1/traces'
+    url: 'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL + '/v1/traces'
   })
 
   private provider = new BasicTracerProvider({

--- a/apps/backend/apps/client/src/main.ts
+++ b/apps/backend/apps/client/src/main.ts
@@ -11,8 +11,8 @@ const bootstrap = async () => {
   // otel instrumentation
   if (process.env.NODE_ENV == 'production') {
     if (
-      process.env.OTEL_EXPORTER_OTLP_ENDPOINT == undefined ||
-      process.env.OTEL_EXPORTER_OTLP_ENDPOINT == ''
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL == undefined ||
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL == ''
     ) {
       console.log('The exporter url is not defined')
     } else {

--- a/apps/backend/apps/client/src/metric.ts
+++ b/apps/backend/apps/client/src/metric.ts
@@ -9,7 +9,8 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 const startMetricsExporter = () => {
   const options = {
-    url: 'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT + '/v1/metrics', // Grafana Agent Metric을 받는 url
+    url:
+      'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL + '/v1/metrics', // Grafana Agent Metric을 받는 url
     headers: {},
     concurrencyLimit: 5
   }

--- a/apps/backend/apps/client/src/tracer.ts
+++ b/apps/backend/apps/client/src/tracer.ts
@@ -15,7 +15,7 @@ class Tracer {
 
   // http://localhost:4318/v1/traces
   private exporter = new OTLPTraceExporter({
-    url: 'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT + '/v1/traces'
+    url: 'http://' + process.env.OTEL_EXPORTER_OTLP_ENDPOINT_URL + '/v1/traces'
   })
 
   private provider = new BasicTracerProvider({

--- a/apps/infra/modules/codedang-infra/backend/admin-task-definition.tftpl
+++ b/apps/infra/modules/codedang-infra/backend/admin-task-definition.tftpl
@@ -72,7 +72,7 @@
         "value" : "${media_secret_key}"
       },
       {
-        "name" : "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "name" : "OTEL_EXPORTER_OTLP_ENDPOINT_URL",
         "value" : "${otel_endpoint}"
       }
     ],

--- a/apps/infra/modules/codedang-infra/backend/client-task-definition.tftpl
+++ b/apps/infra/modules/codedang-infra/backend/client-task-definition.tftpl
@@ -92,7 +92,7 @@
         "value": "${kakao_client_secret}"
       },
       {
-        "name" : "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "name" : "OTEL_EXPORTER_OTLP_ENDPOINT_URL",
         "value" : "${otel_endpoint}"
       }
     ],

--- a/apps/infra/modules/codedang-infra/iris/task-definition.tftpl
+++ b/apps/infra/modules/codedang-infra/iris/task-definition.tftpl
@@ -63,7 +63,7 @@
         "value": "${redis_port}"
       },
       {
-        "name" : "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "name" : "OTEL_EXPORTER_OTLP_ENDPOINT_URL",
         "value" : "${otel_endpoint}"
       }
     ],

--- a/apps/iris/main.go
+++ b/apps/iris/main.go
@@ -35,7 +35,7 @@ func main() {
 	ctx := context.Background()
 	cache := cache.NewCache(ctx)
 	if env == "production" {
-		if utils.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "") != "" {
+		if utils.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT_URL", "") != "" {
 			shutdown := observability.InitTracer(ctx)
 			defer shutdown()
 			observability.SetGlobalMeterProvider()
@@ -43,7 +43,7 @@ func main() {
 			observability.GetMemoryMeter(otel.Meter("memory-metrics"))
 			observability.GetCPUMeter(otel.Meter("cpu-metrics"), 15*time.Second)
 		} else {
-			logProvider.Log(logger.INFO, "Cannot find OTEL_EXPORTER_OTLP_ENDPOINT")
+			logProvider.Log(logger.INFO, "Cannot find OTEL_EXPORTER_OTLP_ENDPOINT_URL")
 		}
 	} else {
 		logProvider.Log(logger.INFO, "Running in development mode")

--- a/apps/iris/src/observability/metric.go
+++ b/apps/iris/src/observability/metric.go
@@ -50,7 +50,7 @@ func newMetricResource() (*resource.Resource, error) {
 
 func newMeterProvider(res *resource.Resource, second time.Duration) (*sdkmetric.MeterProvider, error) {
 	// Use OLTP Exporter for Grafana Agent (Recommended)
-	entryPoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	entryPoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT_URL")
 	otlpExporter, err := otlpmetrichttp.New(context.Background(), otlpmetrichttp.WithEndpointURL("http://"+entryPoint+"/v1/metrics"))
 	if err != nil {
 		return nil, err

--- a/apps/iris/src/observability/tracer.go
+++ b/apps/iris/src/observability/tracer.go
@@ -62,7 +62,7 @@ func newResource(ctx context.Context) (*resource.Resource, error) {
 }
 
 func newExporter(ctx context.Context) (*otlptrace.Exporter, error) {
-	oltpEndpoint := utils.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	oltpEndpoint := utils.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT_URL", "")
 	exp, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpoint(oltpEndpoint), otlptracehttp.WithInsecure())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description
Closes #1573 

`OTEL_EXPORTER_OTLP_ENDPOINT` 환경변수를 `localhost:4318`로 전달하는 경우와 `127.0.0.1:4318`로 전달하는 경우의 동작이 다릅니다. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#### `127.0.0.1`일 때 : 오류
```
 sudo -E OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4318 APP_ENV=production go run main.go
2024/03/19 10:20:51 internal_logging.go:57: "msg"="parse url" "error"="parse \"127.0.0.1:4318\": first path segment in URL cannot contain colon" "input"="127.0.0.1:4318"
```

#### `localhost`일 때 : 정상
```
sudo -E OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318 APP_ENV=production go run main.go
{"level":"info","ts":"2024-03-19T10:21:05.466Z","caller":"runtime/proc.go:271","msg":"Server Started"}
```

아마 OTEL에서 `OTEL_EXPORTER_OTLP_ENDPOINT`를 비롯한 몇몇 환경변수들을 지정해 놓았는데,
go에서 이 환경변수들에 대해서 추가적인 확인을 하는 과정에서 발생하는 오류로 보입니다! [참고 - otlptracehttp go](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#WithEndpoint)

---


### Additional context

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
