### PR TITLE
feat(fe): implement a admin user page

### DIFF
--- a/apps/frontend/app/admin/user/_components/Columns.tsx
+++ b/apps/frontend/app/admin/user/_components/Columns.tsx
@@ -1,0 +1,33 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+interface DataTableUser {
+  username: string
+  userId: number
+  name: string
+  email: string
+}
+
+export const columns: ColumnDef<DataTableUser>[] = [
+  {
+    accessorKey: 'userId',
+    header: 'ID',
+    cell: ({ row }) => <div>{row.getValue('userId')}</div>
+  },
+  {
+    accessorKey: 'username',
+    header: 'Username',
+    cell: ({ row }) => <div>{row.getValue('username')}</div>
+  },
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    cell: ({ row }) => {
+      return <div>{row.getValue('name') || '-'}</div>
+    }
+  },
+  {
+    accessorKey: 'email',
+    header: 'Email',
+    cell: ({ row }) => <div>{row.getValue('email')}</div>
+  }
+]

--- a/apps/frontend/app/admin/user/page.tsx
+++ b/apps/frontend/app/admin/user/page.tsx
@@ -1,7 +1,74 @@
-export default function Page() {
+'use client'
+
+import { gql } from '@generated'
+import { DataTableAdmin } from '@/components/DataTableAdmin'
+import { ScrollBar } from '@/components/ui/scroll-area'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useQuery } from '@apollo/client'
+import { ScrollArea } from '@radix-ui/react-scroll-area'
+import { columns } from './_components/Columns'
+
+const GET_GROUP_MEMBERS = gql(`
+  query GetGroupMembers($groupId: Int!, $cursor: Int, $take: Int!, $leaderOnly: Boolean!) {
+    getGroupMembers(groupId: $groupId, cursor: $cursor, take: $take, leaderOnly: $leaderOnly) {
+      username
+      userId
+      name
+      email
+    }
+  }
+`)
+
+export default function User() {
+  const { data, loading } = useQuery(GET_GROUP_MEMBERS, {
+    variables: {
+      groupId: 1,
+      cursor: 1,
+      take: 1000,
+      leaderOnly: false
+    }
+  })
   return (
-    <main className="grid flex-1 place-items-center">
-      <p className="font-medium text-slate-400">TODO: Show user list</p>
-    </main>
+    <ScrollArea className="shrink-0">
+      <div className="container mx-auto space-y-5 py-10">
+        <div className="flex justify-between">
+          <h1 className="text-4xl font-bold">User List</h1>
+        </div>
+        {loading ? (
+          <>
+            <div className="mb-16 flex gap-4">
+              <span className="w-2/12">
+                <Skeleton className="h-10 w-full" />
+              </span>
+              <span className="w-1/12">
+                <Skeleton className="h-10 w-full" />
+              </span>
+              <span className="w-1/12">
+                <Skeleton className="h-10 w-full" />
+              </span>
+            </div>
+            {[...Array(10)].map((_, i) => (
+              <Skeleton key={i} className="my-2 flex h-12 w-full rounded-xl" />
+            ))}
+          </>
+        ) : (
+          <DataTableAdmin
+            columns={columns}
+            data={
+              data?.getGroupMembers.map((member) => {
+                return {
+                  username: member.username,
+                  userId: member.userId,
+                  name: member.name,
+                  email: member.email
+                }
+              }) ?? []
+            }
+            enablePagination
+          />
+        )}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
   )
 }


### PR DESCRIPTION
### Description

<img width="1050" alt="Screenshot 2024-03-20 at 8 39 45 PM" src="https://github.com/skkuding/codedang/assets/50468628/c8d58e20-5348-46ec-a73d-6fcdb74eaa8a">

- 당장 가입된 유저들을 확인할 정도로만 구현했습니다.
- 구현 과정에서 admin page의 페이지 및 컴포넌트들을 봤는데 중복된 코드들이 너무 많은 것 같아요! 일단 layout 통합해서 page들간 중복 코드 제거 할 필요가 있어 보입니다!
  - 이는 현재 이슈들 해결 한 후 개선해봅시다!

close #1575 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
