### PR TITLE
chore(be): fix getProblems

### DIFF
--- a/apps/backend/apps/client/src/problem/problem.repository.ts
+++ b/apps/backend/apps/client/src/problem/problem.repository.ts
@@ -109,6 +109,9 @@ export class ProblemRepository {
           // 아니면 텍스트가 많은 field에서는 full-text search를 사용하고, 텍스트가 적은 field에서는 contains를 사용하는 방법도 고려해보자.
           contains: search
         },
+        exposeTime: {
+          lte: new Date()
+        },
         isVisible: true
       },
       select: {

--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -27,11 +27,8 @@ export class ProblemService {
     order?: ProblemOrder
     search?: string
   }) {
-    let unprocessedProblems = await this.problemRepository.getProblems(options)
-
-    unprocessedProblems = unprocessedProblems.filter(
-      (problem) => problem.exposeTime <= new Date()
-    )
+    const unprocessedProblems =
+      await this.problemRepository.getProblems(options)
 
     const uniqueTagIds = new Set(
       unprocessedProblems.flatMap((item) => {


### PR DESCRIPTION
### Description

기존 getProblems service 코드에서는 db에서 정해진 개수의 Problem을 take한 뒤, exposeTime으로 filter했습니다.
이때문에 db에서 가져온 개수와 최종 return되는 problem 개수가 달라졌습니다.
그래서 db에서 problem을 가져올 때 exposeTime을 체크해서 가져올 수 있도록 합니다.

### Additional context



---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
