### PR TITLE
feat(fe): edit contest buttons and tabs

### DIFF
--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { fetcherWithAuth } from '@/lib/utils'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
@@ -26,14 +27,17 @@ const clickDeregister = async (contestId: string) => {
 export default function RegisterButton({
   id,
   registered,
-  state
+  state,
+  firstProblemId
 }: {
   id: string
   registered: boolean
   state: string
+  firstProblemId?: number
 }) {
   const [isRegistered, setIsRegistered] = useState(registered)
   const buttonColor = isRegistered ? 'bg-secondary' : 'bg-primary'
+  const router = useRouter()
   return (
     <>
       {state === 'Upcoming' ? (
@@ -55,7 +59,7 @@ export default function RegisterButton({
         </Button>
       ) : (
         <>
-          {!isRegistered && (
+          {!isRegistered ? (
             <Button
               className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
               onClick={() => {
@@ -66,6 +70,19 @@ export default function RegisterButton({
             >
               Register
             </Button>
+          ) : (
+            <>
+              {firstProblemId && (
+                <Button
+                  className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+                  onClick={() =>
+                    router.push(`/contest/${id}/problem/${firstProblemId}`)
+                  }
+                >
+                  Go To First Problem!
+                </Button>
+              )}
+            </>
           )}
         </>
       )}

--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button'
 import { fetcherWithAuth } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 const clickRegister = async (contestId: string) => {
@@ -24,20 +24,36 @@ const clickDeregister = async (contestId: string) => {
     .catch((err) => console.log(err))
 }
 
+const getFirstProblemId = async (contestId: string) => {
+  const { problems }: { problems: { id: string }[] } = await fetcherWithAuth
+    .get(`contest/${contestId}/problem`, {
+      searchParams: { take: 1 }
+    })
+    .json()
+  return problems?.at(0)?.id
+}
+
 export default function RegisterButton({
   id,
   registered,
-  state,
-  firstProblemId
+  state
 }: {
   id: string
   registered: boolean
   state: string
-  firstProblemId?: number
 }) {
   const [isRegistered, setIsRegistered] = useState(registered)
+  const [firstProblemId, setFirstProblemId] = useState('')
   const buttonColor = isRegistered ? 'bg-secondary' : 'bg-primary'
   const router = useRouter()
+  useEffect(() => {
+    async function fetchFirstProblemId() {
+      const firstId =
+        isRegistered && state === 'Ongoing' ? await getFirstProblemId(id) : ''
+      firstId && setFirstProblemId(firstId)
+    }
+    fetchFirstProblemId()
+  }, [isRegistered])
   return (
     <>
       {state === 'Upcoming' ? (

--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@/lib/auth'
 import { fetcherWithAuth } from '@/lib/utils'
+import type { ContestProblem } from '@/types/type'
 import { sanitize } from 'isomorphic-dompurify'
 import RegisterButton from './_components/RegisterButton'
 
@@ -22,6 +23,11 @@ export default async function ContestTop({ params }: ContestTopProps) {
   const data: ContestTop = await fetcherWithAuth
     .get(`contest/${contestId}`)
     .json()
+  const { problems }: { problems: ContestProblem[] } = await fetcherWithAuth
+    .get(`contest/${contestId}/problem`, {
+      searchParams: { take: 1 }
+    })
+    .json()
 
   const startTime = new Date(data.startTime)
   const endTime = new Date(data.endTime)
@@ -39,13 +45,13 @@ export default async function ContestTop({ params }: ContestTopProps) {
         className="prose w-full max-w-full border-b-2 border-b-gray-300 p-5 py-12"
         dangerouslySetInnerHTML={{ __html: sanitize(data.description) }}
       />
-
       {session && state !== 'Finished' && (
         <div className="mt-10 flex justify-center">
           <RegisterButton
             id={contestId}
             registered={data.isRegistered}
             state={state}
+            firstProblemId={problems?.at(0)?.id}
           />
         </div>
       )}

--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from '@/lib/auth'
 import { fetcherWithAuth } from '@/lib/utils'
-import type { ContestProblem } from '@/types/type'
 import { sanitize } from 'isomorphic-dompurify'
 import RegisterButton from './_components/RegisterButton'
 
@@ -22,11 +21,6 @@ export default async function ContestTop({ params }: ContestTopProps) {
   const { contestId } = params
   const data: ContestTop = await fetcherWithAuth
     .get(`contest/${contestId}`)
-    .json()
-  const { problems }: { problems: ContestProblem[] } = await fetcherWithAuth
-    .get(`contest/${contestId}/problem`, {
-      searchParams: { take: 1 }
-    })
     .json()
 
   const startTime = new Date(data.startTime)
@@ -51,7 +45,6 @@ export default async function ContestTop({ params }: ContestTopProps) {
             id={contestId}
             registered={data.isRegistered}
             state={state}
-            firstProblemId={problems?.at(0)?.id}
           />
         </div>
       )}

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/[submissionId]/page.tsx
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/[submissionId]/page.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from '@/components/ui/skeleton'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SubmissionDetail from '../_components/SubmissionDetail'
+
+export default async function Page({
+  params
+}: {
+  params: {
+    problemId: number
+    contestId: number
+    submissionId: number
+  }
+}) {
+  const { submissionId, problemId, contestId } = params
+
+  return (
+    <div className="flex flex-col gap-5 overflow-auto p-6">
+      <div className="z-20 flex items-center gap-3">
+        <Link href={`/contest/${contestId}/problem/${problemId}/submission`}>
+          <ArrowLeft className="size-5" />
+        </Link>
+        <h1 className="text-xl font-bold">Submission #{submissionId}</h1>
+      </div>
+      <Suspense
+        fallback={
+          <div className="flex h-fit flex-col gap-4 p-2 text-lg">
+            <Skeleton className="h-20 w-full rounded-lg bg-slate-900" />
+            <Skeleton className="h-8 w-3/12 rounded-lg bg-slate-900" />
+            <Skeleton className="h-32 w-full rounded-lg bg-slate-900" />
+          </div>
+        }
+      >
+        <SubmissionDetail
+          problemId={problemId}
+          contestId={contestId}
+          submissionId={submissionId}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/Columns.tsx
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/Columns.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { dateFormatter } from '@/lib/utils'
+import type { SubmissionItem } from '@/types/type'
+import type { ColumnDef } from '@tanstack/react-table'
+
+export const columns: ColumnDef<SubmissionItem>[] = [
+  {
+    header: '#',
+    accessorKey: 'id',
+    cell: ({ row }) => <p className="text-sm">{row.original.id}</p>
+  },
+  {
+    header: () => 'User ID',
+    accessorKey: 'username',
+    cell: ({ row }) => row.original.user.username
+  },
+  {
+    header: () => 'Result',
+    accessorKey: 'result',
+    cell: ({ row }) => {
+      return row.original.result === 'Accepted' ? (
+        <p className="text-green-500">{row.original.result}</p>
+      ) : row.original.result === 'Judging' ? (
+        <p className="text-gray-300">{row.original.result}</p>
+      ) : (
+        <p className="text-red-500">{row.original.result}</p>
+      )
+    }
+  },
+  {
+    header: () => 'Language',
+    accessorKey: 'language',
+    cell: ({ row }) => row.original.language
+  },
+  {
+    header: () => 'Submission Time',
+    accessorKey: 'createTime',
+    cell: ({ row }) =>
+      dateFormatter(row.original.createTime, 'YYYY-MM-DD HH:mm:ss')
+  },
+  {
+    header: () => 'Code Size',
+    accessorKey: 'codeSize',
+    cell: ({ row }) => {
+      return row.original.codeSize === null ? (
+        <p>N/A</p>
+      ) : (
+        <p>{row.original.codeSize} B</p>
+      )
+    }
+  }
+]

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/DataTable.tsx
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/DataTable.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import type { ColumnDef } from '@tanstack/react-table'
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable
+} from '@tanstack/react-table'
+import type { Route } from 'next'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  headerStyle: {
+    [key: string]: string
+  }
+  problemId: number
+  contestId: number
+}
+
+/**
+ * @param columns
+ * columns to be displayed
+ * @param data
+ * data to be displayed
+ * @param headerStyle
+ * tailwindcss class name for each header
+ * @param name
+ * name of the table, used for routing
+ * @example
+ * ```tsx
+ * // page.tsx
+ * <DataTable data={data} columns={columns} headerStyle={{
+ *  title: 'text-left w-2/4 md:w-4/6',
+ *  createdBy: 'w-1/4 md:w-1/6',
+ *  createTime: 'w-1/4 md:w-1/6'
+ *  }}
+ *  name="notice"
+ * />
+ * ```
+ * ```tsx
+ * // _components/Columns.tsx
+ * import type { Notice } from '@/types/type'
+ * export const columns: ColumnDef<Notice, string>[] = [
+ *  {
+ *    header: 'Title',
+ *    accessorKey: 'title',
+ *    cell: (row) => row.original.title,
+ *  },
+ *  ...
+ * ]
+ * ```
+ */
+
+interface Item {
+  id: number
+}
+
+export default function DataTable<TData extends Item, TValue>({
+  columns,
+  data,
+  headerStyle,
+  problemId,
+  contestId
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel()
+  })
+  const router = useRouter()
+
+  return (
+    <Table className="table-fixed">
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow className="hover:bg-slate-600/50" key={headerGroup.id}>
+            {headerGroup.headers.map((header) => {
+              return (
+                <TableHead
+                  key={header.id}
+                  className={cn(
+                    'border-b border-slate-600 text-center text-xs font-semibold text-white',
+                    headerStyle[header.id]
+                  )}
+                  style={{ padding: 0 }}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </TableHead>
+              )
+            })}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {table.getRowModel().rows?.length ? (
+          table.getRowModel().rows.map((row) => {
+            const href =
+              `/contest/${contestId}/problem/${problemId}/submission/${row.original.id}` as Route
+            return (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && 'selected'}
+                className="cursor-pointer border-t border-slate-600 text-slate-300 hover:bg-slate-600/50 hover:font-semibold"
+                onClick={() => {
+                  router.push(href)
+                }}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell
+                    key={cell.id}
+                    style={{
+                      paddingTop: 10,
+                      paddingBottom: 10,
+                      paddingLeft: 2,
+                      paddingRight: 2
+                    }}
+                  >
+                    <div className="text-center text-xs">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </div>
+                    {/* for prefetch */}
+                    <Link href={href} />
+                  </TableCell>
+                ))}
+              </TableRow>
+            )
+          })
+        ) : (
+          <TableRow className="hover:bg-slate-600/50">
+            <TableCell colSpan={columns.length} className="h-24 text-center">
+              No results.
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  )
+}

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/SubmissionDetail.tsx
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/SubmissionDetail.tsx
@@ -1,0 +1,139 @@
+import CodeEditor from '@/components/CodeEditor'
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+import { dateFormatter, fetcherWithAuth } from '@/lib/utils'
+import type { SubmissionDetail } from '@/types/type'
+import { revalidateTag } from 'next/cache'
+import { IoIosLock } from 'react-icons/io'
+import dataIfError from './dataIfError'
+
+interface Props {
+  problemId: number
+  submissionId: number
+  contestId?: number
+}
+
+export default async function SubmissionDetail({
+  problemId,
+  submissionId
+}: Props) {
+  const res = await fetcherWithAuth(`submission/${submissionId}`, {
+    searchParams: { problemId },
+    next: {
+      tags: [`submission/${submissionId}`]
+    }
+  })
+
+  const submission: SubmissionDetail = res.ok ? await res.json() : dataIfError
+  if (res.status == 403) {
+    return (
+      <div className="flex h-[300px] flex-col items-center justify-center gap-20">
+        <IoIosLock size={100} />
+        <p>
+          Unable to check others&apos; until your correct submission is accepted
+        </p>
+      </div>
+    )
+  }
+
+  if (submission.result == 'Judging') {
+    revalidateTag(`submission/${submissionId}`)
+  }
+
+  return (
+    <>
+      <ScrollArea className="shrink-0 rounded-md">
+        <div className="flex items-center justify-around gap-5 bg-slate-700 p-5 text-sm [&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-1 [&_*]:whitespace-nowrap [&_p]:text-slate-400">
+          <div>
+            <h2>User</h2>
+            <p>{submission.username}</p>
+          </div>
+          <div>
+            <h2>Result</h2>
+            <p
+              className={
+                submission.result === 'Accepted'
+                  ? '!text-green-500'
+                  : '!text-red-500'
+              }
+            >
+              {submission.result}
+            </p>
+          </div>
+          <div>
+            <h2>Language</h2>
+            <p>{submission.language}</p>
+          </div>
+          <div>
+            <h2>Submission Time</h2>
+            <p>{dateFormatter(submission.createTime, 'YYYY-MM-DD HH:mm:ss')}</p>
+          </div>
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+      <div>
+        <h2 className="mb-3 text-lg font-bold">Source Code</h2>
+        <CodeEditor
+          value={submission.code}
+          language={submission.language}
+          readOnly
+          className="max-h-96 min-h-16 w-full"
+        />
+      </div>
+      {submission.testcaseResult.length !== 0 && (
+        <div>
+          <h2 className="text-lg font-bold">Test case</h2>
+          <Table className="[&_*]:text-center [&_*]:text-sm [&_*]:hover:bg-transparent [&_td]:p-2 [&_tr]:border-slate-600">
+            <TableHeader className="[&_*]:text-slate-100">
+              <TableRow>
+                <TableHead>#</TableHead>
+                <TableHead>Result</TableHead>
+                <TableHead>Runtime</TableHead>
+                <TableHead>Memory</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {submission.testcaseResult.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>{item.id}</TableCell>
+                  <TableCell
+                    className={
+                      item.result === 'Accepted'
+                        ? 'text-green-500'
+                        : 'text-red-500'
+                    }
+                  >
+                    {item.result}
+                  </TableCell>
+                  <TableCell>{item.cpuTime} ms</TableCell>
+                  <TableCell>
+                    {(item.memoryUsage / (1024 * 1024)).toFixed(2)} MB
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+      {res.ok ? (
+        <></>
+      ) : (
+        <div className="absolute left-0 top-0 z-10 flex h-full w-full flex-col items-center justify-center gap-1 backdrop-blur">
+          <IoIosLock size={100} />
+          <p className="mt-4 text-xl font-semibold">Access Denied</p>
+          <p className="w-10/12 text-center">
+            {`If you want to check other users' code,
+                please submit a correct answer of your own.`}
+          </p>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/dataIfError.ts
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/_components/dataIfError.ts
@@ -1,0 +1,29 @@
+import type { SubmissionDetail } from '@/types/type'
+
+const dataIfError: SubmissionDetail = {
+  problemId: 0,
+  username: 'skkuding',
+  code: `#include <stdio.h>
+
+int main() {
+char name[20];
+scanf("%s", name);
+printf("Hello, %s!\\n", name);
+return 0;
+}`,
+  language: 'C',
+  createTime: new Date(),
+  result: 'Accepted',
+  testcaseResult: Array.from({ length: 5 }, (_, i) => ({
+    id: i,
+    submissionId: 0,
+    problemTestCaseId: i,
+    result: 'Accepted',
+    cpuTime: '0',
+    memoryUsage: 12345,
+    createTime: new Date(),
+    updateTime: new Date()
+  }))
+}
+
+export default dataIfError

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/loading.tsx
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="flex h-fit flex-col gap-5 p-6 text-lg">
+      <Skeleton className="h-12 w-full rounded-xl bg-slate-900" />
+      <div className="flex flex-col gap-4">
+        {[...Array(5)].map((_, i) => (
+          <Skeleton
+            key={i}
+            className="flex h-8 w-full rounded-xl bg-slate-900"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/page.tsx
+++ b/apps/frontend/app/contest/[contestId]/problem/[problemId]/submission/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Paginator from '@/components/Paginator'
+import { usePagination } from '@/lib/pagination'
+import type { SubmissionItem } from '@/types/type'
+import { columns } from './_components/Columns'
+import DataTable from './_components/DataTable'
+
+export default function Submission({
+  params
+}: {
+  params: { problemId: string; contestId: string }
+}) {
+  const { problemId, contestId } = params
+
+  const { items, paginator } = usePagination<SubmissionItem>(
+    `contest/${contestId}/submission?problemId=${problemId}`,
+    20,
+    5,
+    true
+  )
+
+  return (
+    <>
+      <DataTable
+        data={items ?? []}
+        columns={columns}
+        headerStyle={{
+          id: 'w-[8%]',
+          username: 'w-[15%]',
+          result: 'w-[27%]',
+          language: 'w-[14%]',
+          createTime: 'w-[23%]',
+          codeSize: 'w-[13%]'
+        }}
+        problemId={Number(problemId)}
+        contestId={Number(contestId)}
+      />
+      <Paginator page={paginator.page} slot={paginator.slot} />
+    </>
+  )
+}

--- a/apps/frontend/lib/pagination.ts
+++ b/apps/frontend/lib/pagination.ts
@@ -1,4 +1,4 @@
-import { fetcher } from '@/lib/utils'
+import { fetcher, fetcherWithAuth } from '@/lib/utils'
 import { useEffect, useState, useRef, useCallback } from 'react'
 
 interface Item {
@@ -25,7 +25,8 @@ interface Item {
 export const usePagination = <T extends Item>(
   url: string,
   itemsPerPage = 10,
-  pagesPerSlot = 5
+  pagesPerSlot = 5,
+  withauth = false
 ) => {
   const [items, setItems] = useState<T[]>()
   const slotItems = useRef<T[]>([])
@@ -80,9 +81,13 @@ export const usePagination = <T extends Item>(
   useEffect(() => {
     ;(async () => {
       // TODO: fetcher <-> fetcherWithAuth 중 선택할 수 있도록 수정
-      const res = await fetcher.get(path, {
-        searchParams: query
-      })
+      const res = withauth
+        ? await fetcherWithAuth.get(path, {
+            searchParams: query
+          })
+        : await fetcher.get(path, {
+            searchParams: query
+          })
       console.log(res.status)
       const data: T[] = await res.json()
 


### PR DESCRIPTION
### Description
contest top에서 ongoing일 때 registered상태이면 첫 문제로 가는 버튼 생성
contest editor 페이지의 contest submission tab 구현
pagenation에 withauth 옵션 추가


### Additional context

문제들이 자꾸 사라져서 해결 후에 다시 작업해야 할 것 같습니다
close #1577
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
