### PR TITLE
fix(be): resolves bug problems disappear when import problems to contest

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.spec.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.spec.ts
@@ -175,7 +175,8 @@ const db = {
     create: stub().resolves(ContestProblem)
   },
   problem: {
-    update: stub().resolves(Problem)
+    update: stub().resolves(Problem),
+    findFirstOrThrow: stub().resolves(Problem)
   },
   group: {
     findUnique: stub().resolves(Group)


### PR DESCRIPTION
### Description

PR #1584 의 버그 수정
problem의 exposeTime을 업데이트하는 과정에서 exposeTime을 바꾸는 조건이 충족되지 않는 경우 exposeTime 조정 없이 ContestProblem이 생성되어야하는데, transaction에 묶여있어 ContestProblem도 생성되지 않는 문제를 해결합니다.


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
