### PR TITLE
fix(be): add user-id condition for get-contest-submissions

### DIFF
--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -665,7 +665,8 @@ export class SubmissionService implements OnModuleInit {
       take,
       where: {
         problemId,
-        contestId
+        contestId,
+        userId
       },
       select: {
         id: true,


### PR DESCRIPTION
### Description

Closes #1601

contest submissions를 불러올 때 자신이 제출한 submissions만을 반환하도록 수정합니다.
대회의 제출 목록에는 자신이 제출한 내역만을 보여야 하기 때문에, userID 조건을 추가해 자신이 생성한 submission만을 가져오도록 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
