### PR TITLE
fix(fe): remove isRegistered state and add refreshing

### DIFF
--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { Skeleton } from '@/components/ui/skeleton'
 import { fetcherWithAuth } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
-import { Suspense, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 const getFirstProblemId = async (contestId: string) => {
@@ -61,51 +60,49 @@ export default function RegisterButton({
   }, [registered])
   return (
     <>
-      <Suspense fallback={<Skeleton className="px-12 py-6"></Skeleton>}>
-        {state === 'Upcoming' ? (
-          <Button
-            className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-            onClick={() => {
-              if (registered) {
-                clickDeregister(id)
-                toast.success('Deregistered Upcoming test successfully')
-              } else {
+      {state === 'Upcoming' ? (
+        <Button
+          className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+          onClick={() => {
+            if (registered) {
+              clickDeregister(id)
+              toast.success('Deregistered Upcoming test successfully')
+            } else {
+              clickRegister(id)
+              toast.success('Registered Upcoming test successfully')
+            }
+          }}
+        >
+          {registered ? 'Deregister' : 'Register'}
+        </Button>
+      ) : (
+        <>
+          {!registered ? (
+            <Button
+              className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+              onClick={() => {
                 clickRegister(id)
-                toast.success('Registered Upcoming test successfully')
-              }
-            }}
-          >
-            {registered ? 'Deregister' : 'Register'}
-          </Button>
-        ) : (
-          <>
-            {!registered ? (
-              <Button
-                className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-                onClick={() => {
-                  clickRegister(id)
-                  toast.success('Registered Ongoing test successfully')
-                }}
-              >
-                Register
-              </Button>
-            ) : (
-              <>
-                {firstProblemId && (
-                  <Button
-                    className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-                    onClick={() =>
-                      router.push(`/contest/${id}/problem/${firstProblemId}`)
-                    }
-                  >
-                    Go To First Problem!
-                  </Button>
-                )}
-              </>
-            )}
-          </>
-        )}
-      </Suspense>
+                toast.success('Registered Ongoing test successfully')
+              }}
+            >
+              Register
+            </Button>
+          ) : (
+            <>
+              {firstProblemId && (
+                <Button
+                  className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+                  onClick={() =>
+                    router.push(`/contest/${id}/problem/${firstProblemId}`)
+                  }
+                >
+                  Go To First Problem!
+                </Button>
+              )}
+            </>
+          )}
+        </>
+      )}
     </>
   )
 }

--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
@@ -1,28 +1,11 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { fetcherWithAuth } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-
-const clickRegister = async (contestId: string) => {
-  await fetcherWithAuth
-    .post(`contest/${contestId}/participation`, {
-      searchParams: { groupId: 1 }
-    })
-    .then((res) => res.json())
-    .catch((err) => console.log(err))
-}
-
-const clickDeregister = async (contestId: string) => {
-  await fetcherWithAuth
-    .delete(`contest/${contestId}/participation`, {
-      searchParams: { groupId: 1 }
-    })
-    .then((res) => res.json())
-    .catch((err) => console.log(err))
-}
 
 const getFirstProblemId = async (contestId: string) => {
   const { problems }: { problems: { id: string }[] } = await fetcherWithAuth
@@ -42,66 +25,87 @@ export default function RegisterButton({
   registered: boolean
   state: string
 }) {
-  const [isRegistered, setIsRegistered] = useState(registered)
   const [firstProblemId, setFirstProblemId] = useState('')
-  const buttonColor = isRegistered ? 'bg-secondary' : 'bg-primary'
+  const buttonColor = registered ? 'bg-secondary' : 'bg-primary'
   const router = useRouter()
+  const clickRegister = async (contestId: string) => {
+    await fetcherWithAuth
+      .post(`contest/${contestId}/participation`, {
+        searchParams: { groupId: 1 }
+      })
+      .then((res) => {
+        res.json()
+        router.refresh()
+      })
+      .catch((err) => console.log(err))
+  }
+  const clickDeregister = async (contestId: string) => {
+    await fetcherWithAuth
+      .delete(`contest/${contestId}/participation`, {
+        searchParams: { groupId: 1 }
+      })
+      .then((res) => {
+        res.json()
+        router.refresh()
+      })
+      .catch((err) => console.log(err))
+  }
+
   useEffect(() => {
     async function fetchFirstProblemId() {
       const firstId =
-        isRegistered && state === 'Ongoing' ? await getFirstProblemId(id) : ''
+        registered && state === 'Ongoing' ? await getFirstProblemId(id) : ''
       firstId && setFirstProblemId(firstId)
     }
     fetchFirstProblemId()
-  }, [isRegistered])
+  }, [registered])
   return (
     <>
-      {state === 'Upcoming' ? (
-        <Button
-          className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-          onClick={() => {
-            if (isRegistered) {
-              clickDeregister(id)
-              setIsRegistered(false)
-              toast.success('Deregistered Upcoming test successfully')
-            } else {
-              clickRegister(id)
-              setIsRegistered(true)
-              toast.success('Registered Upcoming test successfully')
-            }
-          }}
-        >
-          {isRegistered ? 'Deregister' : 'Register'}
-        </Button>
-      ) : (
-        <>
-          {!isRegistered ? (
-            <Button
-              className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-              onClick={() => {
+      <Suspense fallback={<Skeleton className="px-12 py-6"></Skeleton>}>
+        {state === 'Upcoming' ? (
+          <Button
+            className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+            onClick={() => {
+              if (registered) {
+                clickDeregister(id)
+                toast.success('Deregistered Upcoming test successfully')
+              } else {
                 clickRegister(id)
-                setIsRegistered(true)
-                toast.success('Registered Ongoing test successfully')
-              }}
-            >
-              Register
-            </Button>
-          ) : (
-            <>
-              {firstProblemId && (
-                <Button
-                  className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-                  onClick={() =>
-                    router.push(`/contest/${id}/problem/${firstProblemId}`)
-                  }
-                >
-                  Go To First Problem!
-                </Button>
-              )}
-            </>
-          )}
-        </>
-      )}
+                toast.success('Registered Upcoming test successfully')
+              }
+            }}
+          >
+            {registered ? 'Deregister' : 'Register'}
+          </Button>
+        ) : (
+          <>
+            {!registered ? (
+              <Button
+                className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+                onClick={() => {
+                  clickRegister(id)
+                  toast.success('Registered Ongoing test successfully')
+                }}
+              >
+                Register
+              </Button>
+            ) : (
+              <>
+                {firstProblemId && (
+                  <Button
+                    className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
+                    onClick={() =>
+                      router.push(`/contest/${id}/problem/${firstProblemId}`)
+                    }
+                  >
+                    Go To First Problem!
+                  </Button>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </Suspense>
     </>
   )
 }


### PR DESCRIPTION
### Description
기존에 contest top에서 registered 버튼을 눌러 참가한 상태에서 다른 탭을 왔다갔다 하면 버튼 상태가 참가 이전 상태로 초기화되었습니다.
또한 뒤로가기 버튼으로 contest page로 이동 시 참가 여부가 업데이트 되지 않는 오류가 있었습니다.
isRegistered state 대신 refresh를 사용하여 contest에 참가하거나 삭제할 시 re-fetching을 통해 isRegistered값을 새로 불러오고 컴포넌트를 재랜더링합니다. 

close #1604

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
