### PR TITLE
fix(fe): allow ascending and descending order for admin contest list

### DIFF
--- a/apps/frontend/app/admin/contest/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/_components/Columns.tsx
@@ -96,7 +96,7 @@ export const columns: ColumnDef<Contest>[] = [
     enableHiding: false
   },
   {
-    accessorKey: 'period',
+    accessorKey: 'startTime',
     header: ({ column }) => (
       <div className="flex justify-center">
         <DataTableColumnHeader
@@ -113,7 +113,7 @@ export const columns: ColumnDef<Contest>[] = [
     )
   },
   {
-    accessorKey: 'register',
+    accessorKey: 'participants',
     header: ({ column }) => (
       <div className="flex justify-center">
         <DataTableColumnHeader column={column} title="Register" />
@@ -124,7 +124,7 @@ export const columns: ColumnDef<Contest>[] = [
     )
   },
   {
-    accessorKey: 'hidden',
+    accessorKey: 'config.isVisible',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Visible" />
     ),

--- a/apps/frontend/components/DataTableColumnHeader.tsx
+++ b/apps/frontend/components/DataTableColumnHeader.tsx
@@ -51,11 +51,11 @@ export function DataTableColumnHeader<TData, TValue>({
         <DropdownMenuContent align="start">
           <DropdownMenuItem onClick={() => column.toggleSorting(false)}>
             <ArrowUpIcon className="text-muted-foreground/70 mr-2 h-3.5 w-3.5" />
-            Asc
+            {title === 'Visible' ? 'Hidden first' : 'Asc'}
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => column.toggleSorting(true)}>
             <ArrowDownIcon className="text-muted-foreground/70 mr-2 h-3.5 w-3.5" />
-            Desc
+            {title === 'Visible' ? 'Visible first' : 'Desc'}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
### Description

- 기존 admin contest page에서 'Period, Register(participant), Visible'에 대해서 정렬 기능을 추가합니다.
  - Visible은 문구를 'Asc, Desc'가 아닌 'Hidden First, Visible First'로 구현.
 



- <img width="227" alt="스크린샷 2024-03-25 오전 11 29 35" src="https://github.com/skkuding/codedang/assets/59248080/b406dba8-ef14-42a1-a3dd-df6eb8664085">

- <img width="194" alt="스크린샷 2024-03-25 오전 11 29 48" src="https://github.com/skkuding/codedang/assets/59248080/586c4a39-7e52-49ce-b58d-d2fd2bb38ac4">

- <img width="179" alt="스크린샷 2024-03-25 오전 11 30 20" src="https://github.com/skkuding/codedang/assets/59248080/66da67ab-c5c4-4046-b586-31d079d2152a">


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
