### PR TITLE
fix(fe): hide a standings tab

### DIFF
--- a/apps/frontend/app/(main)/contest/_components/ContestTabs.tsx
+++ b/apps/frontend/app/(main)/contest/_components/ContestTabs.tsx
@@ -43,7 +43,7 @@ export default function ContestTabs({ contestId }: { contestId: string }) {
       >
         Announcement
       </Link>
-      <Link
+      {/* <Link
         href={`/contest/${id}/standings` as Route}
         className={cn(
           'text-lg text-gray-400',
@@ -51,7 +51,7 @@ export default function ContestTabs({ contestId }: { contestId: string }) {
         )}
       >
         Standings
-      </Link>
+      </Link> */}
     </div>
   )
 }


### PR DESCRIPTION
### Description

- contest detail page에서 standings tab 비활성화

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
