### PR TITLE
fix(infra): change incorrect argument in private route table

### DIFF
--- a/apps/infra/modules/codedang-infra/network.tf
+++ b/apps/infra/modules/codedang-infra/network.tf
@@ -89,8 +89,8 @@ resource "aws_route_table" "private-ecs" {
   vpc_id = aws_vpc.main.id
 
   route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_nat_gateway.nat.id
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat.id
   }
 
   # route {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
close #1617 

terraform을 실행하면 `aws_route_table.private-ecs`가 상태가 같아도 계속 업데이트 되는 현상이 발생해요.
찾아보니, aws api가 gateway랑 nat이랑 되게 유연하게 받아들여요.
즉, gateway에 nat id를 전달해도 aws에서는 nat으로 인식해서 nat id값을 저장하는데
테라폼에서는 nat id가 아니라 gateway id로 코드에 적혀있으니 실제 값이랑 달라서 계속 업데이트를 하는거죠!
그래서 nat으로 바꾸면 이런 현상이 사라졌어요.

<img width="901" alt="image" src="https://github.com/skkuding/codedang/assets/62930375/6c474455-84a7-4de3-8ca4-de2f8b60385e">

이 브랜치에서 완벽 fix 했습니다 !

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

기능에는 무리 없는 내용인데 계속 plan하면 뜨는게 불편해서 없애버렸습니당.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
