### PR TITLE
feat(fe): add DataTable empty message property

### DIFF
--- a/apps/frontend/app/(main)/contest/_components/FinishedContestTable.tsx
+++ b/apps/frontend/app/(main)/contest/_components/FinishedContestTable.tsx
@@ -27,6 +27,7 @@ export default async function FinishedContestTable() {
           status: 'w-1/4 md:w-1/6'
         }}
         linked
+        emptyMessage="No finished contests found."
       />
     </>
   )

--- a/apps/frontend/components/DataTable.tsx
+++ b/apps/frontend/components/DataTable.tsx
@@ -30,6 +30,7 @@ interface DataTableProps<TData, TValue> {
     [key: string]: string
   }
   linked?: boolean
+  emptyMessage?: string
 }
 
 /**
@@ -73,7 +74,8 @@ export default function DataTable<TData extends Item, TValue>({
   columns,
   data,
   headerStyle,
-  linked = false
+  linked = false,
+  emptyMessage = 'No results.'
 }: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
@@ -145,7 +147,7 @@ export default function DataTable<TData extends Item, TValue>({
         ) : (
           <TableRow>
             <TableCell colSpan={columns.length} className="h-24 text-center">
-              No results.
+              {emptyMessage}
             </TableCell>
           </TableRow>
         )}

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -8,8 +8,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    typedRoutes: true,
-    turbo: true
+    typedRoutes: true
   },
   output: 'standalone',
   env: {


### PR DESCRIPTION
### Description

기존에는 데이터가 없으면 No result만 보여줬지만 상황에 따라 다른 메시지도 보여줄 수 있도록 수정
오류를 발생시키던 next.js 설정 빼기

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
