### PR TITLE
fix: disable create button while isCreating is true

### DIFF
--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -102,6 +102,7 @@ interface ContestProblem {
 export default function Page() {
   const [problems, setProblems] = useState<ContestProblem[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [isCreating, setIsCreating] = useState<boolean>(false)
 
   const router = useRouter()
 
@@ -154,6 +155,7 @@ export default function Page() {
       return
     }
 
+    setIsCreating(true)
     const { data } = await createContest({
       variables: {
         groupId: 1,
@@ -163,6 +165,7 @@ export default function Page() {
     const contestId = Number(data?.createContest.id)
     if (error) {
       toast.error('Failed to create contest')
+      setIsCreating(false)
       return
     }
     await importProblemsToContest({
@@ -395,7 +398,7 @@ export default function Page() {
           <Button
             type="submit"
             className="flex h-[36px] w-[100px] items-center gap-2 px-0 "
-            disabled={isLoading}
+            disabled={isLoading || isCreating}
           >
             <IoMdCheckmarkCircleOutline fontSize={20} />
             <div className="mb-[2px] text-base">Create</div>

--- a/apps/frontend/app/admin/problem/create/page.tsx
+++ b/apps/frontend/app/admin/problem/create/page.tsx
@@ -129,6 +129,7 @@ export default function Page() {
     tagsData?.getTags.map(({ id, name }) => ({ id: Number(id), name })) ?? []
   const [showHint, setShowHint] = useState(false)
   const [showSource, setShowSource] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
 
   const router = useRouter()
 
@@ -159,6 +160,7 @@ export default function Page() {
 
   const [createProblem, { error }] = useMutation(CREATE_PROBLEM)
   const onSubmit = async (input: CreateProblemInput) => {
+    setIsCreating(true)
     await createProblem({
       variables: {
         groupId: 1,
@@ -167,6 +169,7 @@ export default function Page() {
     })
     if (error) {
       toast.error('Failed to create problem')
+      setIsCreating(false)
       return
     }
     toast.success('Problem created successfully')
@@ -574,6 +577,7 @@ export default function Page() {
           <Button
             type="submit"
             className="flex h-[36px] w-[100px] items-center gap-2 px-0 "
+            disabled={isCreating}
           >
             <IoMdCheckmarkCircleOutline fontSize={20} />
             <div className="mb-[2px] text-base">Create</div>


### PR DESCRIPTION
### Description
contest와 problem 생성 시
create 버튼을 누르면 isCreating이 true로 바꿉니다
(조건이 맞지 않아 생성이 안되는 경우 isCreating을 다시 false로 바꿉니다)

isCreating이 true일 때는 create 버튼이 disabled 됩니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes #1632 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
