### PR TITLE
chore: ignore pem key for safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ terraform.rc
 
 # Go workspace file
 go.work
+
+# PEM-encoded certificate data
+*.pem


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
아까 aws 인스턴스 를 ssh하는 방법을 배웠는데 gitignore에 안적혀있어 무서워서 급하게 이슈없이 올려요

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
작업하다 실수로 pem key 올렸을 경우 대비하기 위함입니다. 위험해요!!!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
