### PR TITLE
chore(infra): set exchange as durable

### DIFF
--- a/apps/infra/modules/codedang-infra/rabbitmq.tf
+++ b/apps/infra/modules/codedang-infra/rabbitmq.tf
@@ -57,7 +57,7 @@ resource "rabbitmq_exchange" "exchange" {
 
   settings {
     type    = "direct"
-    durable = false
+    durable = true
   }
 }
 


### PR DESCRIPTION
### Description
Close #1645 

MQ의 Exchange가 durable 설정이 되어있지 않으면 broker 가 재실행될 때 마다 exchange가 사라집니다. 
AWS RabbitMQ의 life cycle이나 restart 되는 시점에 대해서는 조금 더 찾아보고 정리해볼게요! 
(이따 스터디 때 공유하는 게 목표! ㅎㅎ)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
