### PR TITLE
fix(fe): change contest to startTime ascending order

### DIFF
--- a/apps/frontend/app/(main)/contest/_components/ContestCardList.tsx
+++ b/apps/frontend/app/(main)/contest/_components/ContestCardList.tsx
@@ -69,6 +69,8 @@ export default async function Contest({
       contest.status.toLowerCase() === type.toLowerCase()
   )
 
+  data.sort((a, b) => +new Date(a.startTime) - +new Date(b.startTime))
+
   const contestChunks = []
   for (let i = 0; i < data.length; i += 3)
     contestChunks.push(data.slice(i, i + 3))


### PR DESCRIPTION
### Description

Contest page에서 Contest 상태(upgoing/registered/ongoing) 상관없이 Contest Card를 기간순(startTime 순)으로만 정렬

- <img width="1709" alt="스크린샷 2024-04-27 오후 8 48 24" src="https://github.com/skkuding/codedang/assets/59248080/807c9c9e-ff73-4fe2-8b9e-ee7a0f9115e6">

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
