### PR TITLE
fix(fe): disable signup button when clicked

### DIFF
--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -38,7 +38,7 @@ export default function HeaderAuthPanel({
     (state) => state
   )
   const { setModalPage } = useSignUpModalStore((state) => state)
-  const [signupActivate, setSignupActivate] = useState(false)
+  const [signupDisabled, setSignupDisabled] = useState(false)
   return (
     <div className="ml-2 flex items-center gap-2">
       {session ? (
@@ -89,13 +89,13 @@ export default function HeaderAuthPanel({
           </DialogTrigger>
           <DialogTrigger asChild>
             <Button
-              disabled={signupActivate}
+              disabled={signupDisabled}
               onClick={() => {
-                setSignupActivate(true)
+                setSignupDisabled(true)
                 showSignUp()
                 setModalPage(0)
                 setTimeout(() => {
-                  setSignupActivate(false)
+                  setSignupDisabled(false)
                 }, 400)
               }}
               variant={variants[group]}

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -16,6 +16,7 @@ import { LogOut, User, UserRoundCog } from 'lucide-react'
 import type { Session } from 'next-auth'
 import { signOut } from 'next-auth/react'
 import Link from 'next/link'
+import { useState } from 'react'
 import { RxHamburgerMenu } from 'react-icons/rx'
 import AuthModal from './AuthModal'
 
@@ -37,6 +38,7 @@ export default function HeaderAuthPanel({
     (state) => state
   )
   const { setModalPage } = useSignUpModalStore((state) => state)
+  const [signupActivate, setSignupActivate] = useState(false)
   return (
     <div className="ml-2 flex items-center gap-2">
       {session ? (
@@ -87,18 +89,36 @@ export default function HeaderAuthPanel({
           </DialogTrigger>
           <DialogTrigger asChild>
             <Button
+              disabled={signupActivate}
+              onClick={() => {
+                setSignupActivate(true)
+                showSignUp()
+                setModalPage(0)
+                setTimeout(() => {
+                  setSignupActivate(false)
+                }, 400)
+              }}
+              variant={variants[group]}
+              className={cn(
+                'hidden px-3 py-1 text-base md:block',
+                group === 'editor' ? 'font-medium' : 'font-bold'
+              )}
+            >
+              Sign Up
+            </Button>
+            {/* <Button
               onClick={() => {
                 showSignUp()
                 setModalPage(0)
               }}
               variant={variants[group]}
               className={cn(
-                'hidden px-3 py-1 text-base md:block ',
+                'hidden px-3 py-1 text-base md:block',
                 group === 'editor' ? 'font-medium' : 'font-bold'
               )}
             >
               Sign Up
-            </Button>
+            </Button> */}
           </DialogTrigger>
           <DialogContent
             onOpenAutoFocus={(e) => {

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -106,19 +106,6 @@ export default function HeaderAuthPanel({
             >
               Sign Up
             </Button>
-            {/* <Button
-              onClick={() => {
-                showSignUp()
-                setModalPage(0)
-              }}
-              variant={variants[group]}
-              className={cn(
-                'hidden px-3 py-1 text-base md:block',
-                group === 'editor' ? 'font-medium' : 'font-bold'
-              )}
-            >
-              Sign Up
-            </Button> */}
           </DialogTrigger>
           <DialogContent
             onOpenAutoFocus={(e) => {


### PR DESCRIPTION
### Description

Signup 버튼 한번 클릭시 연속 클릭 방지 위해서 비활성화 시킴.
setTimeout 이용해서 signup modal이 뜬 이후에 활성화 되도록 했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
