### PR TITLE
feat(be): add username, email, pin for load test

### DIFF
--- a/apps/backend/apps/client/src/user/user.service.ts
+++ b/apps/backend/apps/client/src/user/user.service.ts
@@ -80,6 +80,12 @@ export class UserService {
   }
 
   async sendPinForRegisterNewEmail({ email }: UserEmailDto): Promise<string> {
+    // TODO: load test를 위함, 테스트 후 삭제 예정
+    if (email === this.config.get('EMAIL_FOR_LOAD_TEST')) {
+      this.logger.debug('load test - sendPinForRegisterNewEmail')
+      return this.createPinAndSendEmail(email)
+    }
+
     const duplicatedUser = await this.getUserCredentialByEmail(email)
     if (duplicatedUser) {
       this.logger.debug('email duplicated')
@@ -108,6 +114,12 @@ export class UserService {
   }
 
   async createPinAndSendEmail(email: string): Promise<string> {
+    // TODO: load test를 위함, 테스트 후 삭제 예정
+    if (email === this.config.get('EMAIL_FOR_LOAD_TEST')) {
+      this.logger.debug('load test - createPinAndSendEmail')
+      return 'You entered an email for testing'
+    }
+
     const pin = this.createPinRandomly(6)
 
     await this.emailService.sendEmailAuthenticationPin(email, pin)
@@ -206,6 +218,15 @@ export class UserService {
     pin,
     email
   }: EmailAuthenticationPinDto): Promise<string> {
+    // TODO: load test를 위함, 테스트 후 삭제 예정
+    if (pin === this.config.get('PIN_FOR_LOAD_TEST')) {
+      this.logger.debug('load test - verifyPinAndIssueJwt')
+      const payload: EmailAuthJwtPayload = { email }
+      const token = await this.createJwt(payload)
+
+      return token
+    }
+
     await this.verifyPin(pin, email)
 
     const payload: EmailAuthJwtPayload = { email }
@@ -562,6 +583,12 @@ export class UserService {
   }
 
   async checkDuplicatedUsername(usernameDto: UsernameDto) {
+    // TODO: load test를 위함, 테스트 후 삭제 예정
+    if (usernameDto.username === this.config.get('USERNAME_FOR_LOAD_TEST')) {
+      this.logger.debug('load test - checkDuplicatedUsername')
+      return
+    }
+
     const duplicatedUser = await this.prisma.user.findUnique({
       where: {
         username: usernameDto.username

--- a/apps/backend/libs/logger/src/pino-option.logger.ts
+++ b/apps/backend/libs/logger/src/pino-option.logger.ts
@@ -64,5 +64,6 @@ export const pinoLoggerModuleOption: Params = {
       }
     },
     redact: ['req.body.password']
+    // enabled: !!process.env.NOLOG
   }
 }


### PR DESCRIPTION
### Description

Closes #1674

회원가입 api에 대한 load test용 username, email, pin을 추가하고, 해당 값들이 입력되면 중복 체크 로직 등을 통과하도록 구현합니다.

**테스트하실 때 sign-up api는 브루노의 Script를 주석처리해놓고 호출하셔야 합니다**

### Additional context
같은 테스트용 username과 email을 통해 api를 반복해서 호출하면 unique constraint때문에 db에 유저 정보를 생성할 수 없습니다. 따라서 다음과 같은 과정을 통해 해결합니다.

1. 테스트용 username, email, pin이 입력된 form이 회원가입 api로 제출됨
2. 유저 정보를 db에 생성할 때 username과 email에는 랜덤한 숫자를 붙여서 저장 (두 필드가 unique이기 때문에 무적 username, email을 사용한다고 해도 테스트 중 실제 db에 유저 정보를 생성할 때는 계속 다르게 바꿔서 넣어줘야합니다) - 예를 들어 무적 username이 "load", 무적 이메일이 "load@gmail.com" 이라고 하면 db에 저장할 때마다 "load49439", "load49439@gmail.com" 이런식으로 뒤에 랜덤 숫자 붙여서 저장

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
