### PR TITLE
feat(cd): edit iris dockerfile to run sh to get containerId

### DIFF
--- a/apps/iris/Dockerfile
+++ b/apps/iris/Dockerfile
@@ -6,10 +6,9 @@ WORKDIR /build
 
 RUN go build
 
-### PRODUCTION ###
+### SERVER ###
 FROM ubuntu:24.04
 
-ENV APP_ENV=production
 COPY --from=builder /build/iris .
 
 # Install dependencies
@@ -29,4 +28,6 @@ RUN architecture=$(dpkg --print-architecture) && if [ "$architecture" = "arm64" 
   fi
 RUN chmod 750 /app/sandbox/libjudger.so
 
-ENTRYPOINT ["./iris"]
+COPY ./entrypoint.sh .
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/apps/iris/entrypoint.sh
+++ b/apps/iris/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [[ -n "$APP_ENV" && $APP_ENV = "production" ]]
+    then ECS_CONTAINER_ID=$(head -1 /proc/self/cgroup | cut -d/ -f4)
+    ./iris $ECS_CONTAINER_ID
+else
+    ./iris
+fi

--- a/apps/iris/src/observability/metric.go
+++ b/apps/iris/src/observability/metric.go
@@ -21,9 +21,9 @@ import (
 
 const defaultMetricDuration time.Duration = 3 * time.Second
 
-func SetGlobalMeterProvider() {
+func SetGlobalMeterProvider(containerId string) {
 	// Create resource.
-	res, err := newMetricResource()
+	res, err := newMetricResource(containerId)
 	if err != nil {
 		reportErr(err, "failed to create metric resource")
 	}
@@ -44,12 +44,13 @@ func SetGlobalMeterProvider() {
 	otel.SetMeterProvider(meterProvider)
 }
 
-func newMetricResource() (*resource.Resource, error) {
+func newMetricResource(containerId string) (*resource.Resource, error) {
 	return resource.Merge(resource.Default(),
 		resource.NewWithAttributes(semconv.SchemaURL,
 			semconv.ServiceName("iris-metric"),
 			semconv.ServiceVersion("0.1.0"),
 			semconv.ServiceInstanceID(getInstanceId()),
+			semconv.ContainerID(containerId),
 		))
 }
 


### PR DESCRIPTION
1. APP_ENV값 dockerfile에서 삭제했습니다.
APP_ENV에서 production으로 박아버려서 stage환경에서도 production의 APP_ENV값을 사용하고 있습니다. 어차피 production환경에서 taskdefinition에 APP_ENV값을 production으로 설정하니, 생략하였습니다.

2. iris dockerfile이 shell script를 기본적으로 실행하게 바뀌었습니다.
shell script에서는 APP_ENV값(production 유무) 에 따라, iris 실행시 container id를 받아오는 command를 실행하고, 해당 값을 main.go함수의 인자로 넘겨서 그 값으로 metric config를 시행합니다.

3. main.go 함수 실행시 (`./iris` 커맨드 실행시) prod 환경에서 container ID를 인자로 넘겨서, 이를 metric provider의 containerID로 설정하는 과정을 추가하였습니다. 이것보다 깔끔한 로직을 찾기가 힘들었습니다 !

추가로, dockerfile에서 entrypoint는, **기본적으로 컨테이너가 생성된 후** 에 시행되는 것으로 확인하였습니다. (직접 검증하였습니다)