### PR TITLE
chore: disable vscode extension verifySignature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,10 @@
         "hashicorp.terraform",
         "ms-azuretools.vscode-docker",
         "prisma.prisma"
-      ]
+      ],
+      "settings": {
+        "extensions.verifySignature": false
+      }
     }
   },
   "features": {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
현재 VSCode devcontainer에서 extension을 신규로 설치할 때 Installing 과정에서 더 진행이 되지가 않는 경우가 발생합니다.
(VSCode version > 1.86.2 에서  발생)
원활한 extension 설치를 위해 extension을 설치할 때 verifySignature를 disable합니다. (아래 이슈 참고)
이미 build된 컨테이너에서는 `killall vsce-sign`를 실행해 이 문제를 일시적으로 해결할 수 있습니다. 

https://github.com/microsoft/vscode-remote-release/issues/9628

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
