### PR TITLE
fix(fe): prevent unnecessary rerenders in editor page

### DIFF
--- a/apps/frontend/components/EditorResizablePanel.tsx
+++ b/apps/frontend/components/EditorResizablePanel.tsx
@@ -29,24 +29,8 @@ export default function EditorMainResizablePanel({
   contestId,
   children
 }: ProblemEditorProps) {
-  // get programming language from localStorage for default value
-  const { value } = useStorage<Language>(
-    'programming_lang',
-    problem.languages[0]
-  )
-  const { code, setCode, setLanguage, language } = useEditorStore()
   const pathname = usePathname()
   const base = contestId ? `/contest/${contestId}` : ''
-
-  useEffect(() => {
-    if (!language) {
-      setLanguage(value ?? problem.languages[0])
-    } else if (language && !problem.languages.includes(language)) {
-      // if value in storage is not in languages, set value to the first language
-      setLanguage(problem.languages[0])
-    }
-  }, [problem.languages, value, setLanguage, language])
-
   return (
     <ResizablePanelGroup
       direction="horizontal"
@@ -99,15 +83,40 @@ export default function EditorMainResizablePanel({
       <ResizablePanel defaultSize={65} className="bg-slate-900">
         <div className="grid-rows-editor grid h-full">
           <EditorHeader problem={problem} contestId={contestId} />
-          <CodeEditor
-            value={code}
-            language={language as Language}
-            onChange={setCode}
-            height="100%"
-            className="h-full"
-          />
+          <CodeEditorInEditorResizablePanel problem={problem} />
         </div>
       </ResizablePanel>
     </ResizablePanelGroup>
+  )
+}
+
+function CodeEditorInEditorResizablePanel({
+  problem
+}: {
+  problem: ProblemDetail
+}) {
+  // get programming language from localStorage for default value
+  const { value } = useStorage<Language>(
+    'programming_lang',
+    problem.languages[0]
+  )
+  const { code, setCode, setLanguage, language } = useEditorStore()
+
+  useEffect(() => {
+    if (!language) {
+      setLanguage(value ?? problem.languages[0])
+    } else if (language && !problem.languages.includes(language)) {
+      // if value in storage is not in languages, set value to the first language
+      setLanguage(problem.languages[0])
+    }
+  }, [problem.languages, value, setLanguage, language])
+  return (
+    <CodeEditor
+      value={code}
+      language={language as Language}
+      onChange={setCode}
+      height="100%"
+      className="h-full"
+    />
   )
 }


### PR DESCRIPTION
### Description

- code editor에 입력시 Resizable panel이 전부 rerender되는 이슈가 있었음
- store을 분리시켜서 해결
- profiler 기준 render 수행시간 `7.9ms` -> `4.1ms`로 감소
  -  문자 하나를 입력 했을 때 기준

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
