### PR TITLE
feat(ci): run ci depending on code change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,14 @@ jobs:
               - 'apps/backend/apps/admin/**'
 
       - uses: ./.github/actions/setup-pnpm
-        if: steps.filter.outputs.${{ matrix.target }} == 'true'
+        if: ${{ steps.filter.outputs[matrix.target] == 'true' }}
 
       - name: Generate Prisma Client
-        if: steps.filter.outputs.${{ matrix.target }} == 'true'
+        if: ${{ steps.filter.outputs[matrix.target] == 'true' }}
         run: pnpm --filter="@codedang/backend" exec prisma generate
 
       - name: Build
-        if: steps.filter.outputs.${{ matrix.target }} == 'true'
+        if: ${{ steps.filter.outputs[matrix.target] == 'true' }}
         run: pnpm --filter="@codedang/backend" build ${{ matrix.target }}
 
   build-frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,67 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  build:
-    name: Build
+  build-backend:
+    name: Build Backend
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        target: [frontend, backend, backend-admin]
+        target: [client, admin]
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check if source code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared: &shared
+              - 'apps/backend/libs/**'
+              - 'apps/backend/prisma/**'
+              - 'apps/backend/*.json'
+              - 'pnpm-lock.yaml'
+            client:
+              - *shared
+              - 'apps/backend/apps/client/**'
+            admin:
+              - *shared
+              - 'apps/backend/apps/admin/**'
+
       - uses: ./.github/actions/setup-pnpm
+        if: steps.filter.outputs.${{ matrix.target }} == 'true'
 
       - name: Generate Prisma Client
-        if: ${{ matrix.target == 'backend' || matrix.target == 'backend-admin' }}
+        if: steps.filter.outputs.${{ matrix.target }} == 'true'
         run: pnpm --filter="@codedang/backend" exec prisma generate
 
+      - name: Build
+        if: steps.filter.outputs.${{ matrix.target }} == 'true'
+        run: pnpm --filter="@codedang/backend" build ${{ matrix.target }}
+
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if source code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'apps/frontend/**'
+              - 'pnpm-lock.yaml'
+
+      - uses: ./.github/actions/setup-pnpm
+        if: steps.filter.outputs.frontend == 'true'
+
       - name: Setup Next.js build cache
-        if: ${{ matrix.target == 'frontend' }}
         uses: actions/cache@v4
+        if: steps.filter.outputs.frontend == 'true'
         with:
           path: apps/frontend/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
@@ -33,18 +75,15 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Load Next.js environment
-        if: ${{ matrix.target == 'frontend' }}
+        if: steps.filter.outputs.frontend == 'true'
         run: |
           echo "NEXT_PUBLIC_BASEURL=https://stage.codedang.com/api" >> apps/frontend/.env
           echo "NEXT_PUBLIC_GQL_BASEURL=https://stage.codedang.com/graphql" >> apps/frontend/.env
           echo "NEXT_URL=https://stage.codedang.com" >> apps/frontend/.env
 
-      - name: Build (backend admin)
-        if: ${{ matrix.target == 'backend-admin' }}
-        run: pnpm --filter="@codedang/backend" build admin
       - name: Build
-        if: ${{ matrix.target != 'backend-admin' }}
-        run: pnpm --filter="apps/${{ matrix.target }}" build
+        if: steps.filter.outputs.frontend == 'true'
+        run: pnpm --filter="@codedang/frontend" build
 
   typecheck:
     name: Typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check if source code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'apps/backend/**'
+
       - uses: ./.github/actions/setup-pnpm
+        if: steps.filter.outputs.backend == 'true'
 
       - name: Generate Prisma Client
+        if: steps.filter.outputs.backend == 'true'
         run: pnpm --filter="@codedang/backend" exec prisma generate
 
       - name: Check types (backend) # For spec files
+        if: steps.filter.outputs.backend == 'true'
         run: pnpm --filter="@codedang/backend" exec tsc --noEmit
 
       # Typecheck is not performed for frontend intentionally.
@@ -137,8 +149,8 @@ jobs:
       - name: Lint (Node.js)
         run: pnpm lint
 
-  test:
-    name: Test
+  test-backend:
+    name: Test Backend
     runs-on: ubuntu-latest
 
     env:
@@ -157,9 +169,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check if source code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'apps/backend/**'
+              - 'pnpm-lock.yaml'
+
       - uses: ./.github/actions/setup-pnpm
+        if: steps.filter.outputs.backend == 'true'
 
       - name: Check Prisma Migration
+        if: steps.filter.outputs.backend == 'true'
         run: |
           pnpm --filter="@codedang/backend" exec prisma migrate diff \
             --from-migrations ./prisma/migrations \
@@ -170,7 +194,9 @@ jobs:
           "Please run 'pnpm prisma migrate dev' locally and commit the changes." && exit 1)
 
       - name: Migrate Prisma
+        if: steps.filter.outputs.backend == 'true'
         run: pnpm --filter="@codedang/backend" exec prisma migrate reset --force
 
       - name: Test
-        run: pnpm -r test
+        if: steps.filter.outputs.backend == 'true'
+        run: pnpm --filter="@codedang/backend" test


### PR DESCRIPTION
### Description

Close #1696 

Backend(client / admin), Frontend 코드 변경이 있을 때에만 CI job을 실행시켜요.
[dorny/paths-filter](https://github.com/dorny/paths-filter) job을 활용했어요.

Branch protection rule을 적용하기 위해, 코드 변경이 없어도 job은 실행되게 했어요.
코드 변경이 없으면 job만 실행되고 build는 하지 않습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
