### PR TITLE
fix(infra): upgrade instance type of client api

### DIFF
--- a/apps/infra/modules/codedang-infra/ecs-api-asg.tf
+++ b/apps/infra/modules/codedang-infra/ecs-api-asg.tf
@@ -62,7 +62,7 @@ resource "aws_autoscaling_policy" "asp_api" {
 resource "aws_launch_template" "ec2_template_api" {
   name          = "Codedang-LaunchTemplate-Api"
   image_id      = "ami-05db432abf706dc01" # 한국
-  instance_type = "t3a.small"             # 2vCPU, 2GiB Mem
+  instance_type = "t3a.xlarge"            # 4vCPU, 16GiB Mem
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecs_container_instance_role.name


### PR DESCRIPTION
### Description
- 원활한 수업 사용을 위해 api instance type을 t3a.small에서 t3a.xlarge로 임시적으로 바꿉니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
