### PR TITLE
chore: add resize attribute to text editor

### DIFF
--- a/apps/frontend/components/TextEditor.tsx
+++ b/apps/frontend/components/TextEditor.tsx
@@ -154,7 +154,7 @@ export default function TextEditor({
     editorProps: {
       attributes: {
         class:
-          'rounded-b-md border overflow-y-auto w-full h-[200px] border-input bg-backround px-3 ring-offset-2 disabled:cursur-not-allowed disabled:opacity-50'
+          'rounded-b-md border overflow-y-auto w-full h-[200px] border-input bg-backround px-3 ring-offset-2 disabled:cursur-not-allowed disabled:opacity-50 resize-y'
       }
     },
     onUpdate({ editor }) {


### PR DESCRIPTION
### Description
텍스트 에디터의 창 크기를 조절할 수 있도록
resize-y 속성을 추가했습니다.

https://github.com/skkuding/codedang/assets/97675977/ee430478-e7f1-43b0-b1ad-c1337e8710e3

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
Closes #1703 
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
