### PR TITLE
fix(infra): set aws profile as skkuding

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -70,6 +70,9 @@ then
   echo "source /usr/share/bash-completion/completions/git" >> ~/.bashrc
 fi
 
+# Set aws profile for terraform as skkuding
+echo "export AWS_PROFILE=skkuding" >> ~/.bashrc
+
 # Apply database migration
 for i in {1..5}
 do


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
terraform 설정할때 aws credential 사용하는 문제가 있었습니다.
개인 aws 계정이 default라고 되어있다면 그 계정의 credential을 terraform이 사용하여 Access Denied가 뜹니다.
skkuding aws configure 세팅에서 profile이름을 skkuding으로 하고
환경변수인 AWS_PROFILE을 설정함으로써 이를 막을 수 있습니다.

- bashrc에 AWS_PROFILE 설정하는 부분 추가했어용 ^0^

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
