### PR TITLE
fix(infra): add tag name into aws eip

### DIFF
--- a/apps/infra/modules/codedang-infra/network.tf
+++ b/apps/infra/modules/codedang-infra/network.tf
@@ -25,6 +25,10 @@ resource "aws_eip" "nat_eip" {
   }
 
   depends_on = [aws_internet_gateway.main]
+
+  tags = {
+    Name = "Codedang-NatEIP"
+  }
 }
 
 resource "aws_subnet" "public_subnet1" {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
테라폼 프로젝트를 분리하는 과정에서 `aws_eip.nat_eip`를 data로 import해야하는 상황이 생겼는데, 
기존에 tag가 없어서 불러오기가 까다로워, 해당 값을 추가했습니다. 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
