### PR TITLE
fix(be): inject user role in groud-member-guard

### DIFF
--- a/apps/backend/libs/auth/src/roles/group-member.guard.ts
+++ b/apps/backend/libs/auth/src/roles/group-member.guard.ts
@@ -31,7 +31,7 @@ export class GroupMemberGuard implements CanActivate {
           : parseInt(request.query.groupId as string)
     }
 
-    if (groupId === OPEN_SPACE_ID) {
+    if (!request.user && groupId === OPEN_SPACE_ID) {
       return true
     }
 
@@ -40,7 +40,7 @@ export class GroupMemberGuard implements CanActivate {
       const userRole = (await this.service.getUserRole(user.id)).role
       user.role = userRole
     }
-    if (user.isAdmin() || user.isSuperAdmin()) {
+    if (user.isAdmin() || user.isSuperAdmin() || groupId === OPEN_SPACE_ID) {
       return true
     }
 


### PR DESCRIPTION

### Description

Closes #1721

GroupMemberGuard에서 group이 OPEN_SPACE_ID이면 로그인 상태여도 user role이 주입되지 않는 문제를 해결합니다.


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
