### PR TITLE
chore(fe): prevent signup modal reset

### DIFF
--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import useAuthModalStore from '@/stores/authModal'
-import useSignUpModalStore from '@/stores/signUpModal'
 import { LogOut, User, UserRoundCog } from 'lucide-react'
 import type { Session } from 'next-auth'
 import { signOut } from 'next-auth/react'
@@ -36,7 +35,6 @@ export default function HeaderAuthPanel({
   const { currentModal, hideModal, showSignIn, showSignUp } = useAuthModalStore(
     (state) => state
   )
-  const { setModalPage } = useSignUpModalStore((state) => state)
   return (
     <div className="ml-2 flex items-center gap-2">
       {session ? (
@@ -89,7 +87,6 @@ export default function HeaderAuthPanel({
             <Button
               onClick={() => {
                 showSignUp()
-                setModalPage(0)
               }}
               variant={variants[group]}
               className={cn(
@@ -191,7 +188,6 @@ export default function HeaderAuthPanel({
               className="flex cursor-pointer items-center gap-1 font-semibold"
               onClick={() => {
                 showSignUp()
-                setModalPage(0)
               }}
             >
               Sign Up

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -101,6 +101,9 @@ export default function HeaderAuthPanel({
             onOpenAutoFocus={(e) => {
               e.preventDefault()
             }}
+            onInteractOutside={(e) => {
+              e.preventDefault()
+            }}
             className="min-h-[30rem] max-w-[20.5rem]"
           >
             <AuthModal />


### PR DESCRIPTION
### Description

Signup 모달 입력 도중에 나갔을 때 다시 Signup을 누르면 모달이 초기화되어 최초 화면부터 뜨는 문제를 수정

### Additional context

email verification code를 보낸 후 나갔다 Signup을 누르면 다시 이메일을 입력하는 화면부터 뜨는데 인증 번호를 입력하는 화면이 떠야 하는지에 대해서는 추후 논의 
Closes #1754 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
