### PR TITLE
feat(fe): implement indent extension

### DIFF
--- a/apps/frontend/app/admin/problem/[id]/edit/page.tsx
+++ b/apps/frontend/app/admin/problem/[id]/edit/page.tsx
@@ -99,7 +99,6 @@ export default function Page({ params }: { params: { id: string } }) {
   const { id } = params
   const [showHint, setShowHint] = useState(true)
   const [showSource, setShowSource] = useState(true)
-
   const { data: tagsData } = useQuery(GET_TAGS)
   const tags =
     tagsData?.getTags.map(({ id, name }) => ({ id: +id, name })) ?? []
@@ -402,17 +401,23 @@ export default function Page({ params }: { params: { id: string } }) {
               </div>
             )}
           </div>
-
           <div className="flex flex-col gap-1">
             <div className="flex justify-between">
-              <div className="flex flex-col gap-1">
+              <div className="flex w-[360px] flex-col gap-1">
                 <Label>Input Description</Label>
-                <Textarea
-                  id="inputDescription"
-                  placeholder="Enter a description..."
-                  className="min-h-[120px] w-[360px] bg-white"
-                  {...register('inputDescription')}
-                />
+                {getValues('inputDescription') && (
+                  <Controller
+                    render={({ field }) => (
+                      <TextEditor
+                        placeholder="Enter a description..."
+                        onChange={field.onChange}
+                        defaultValue={field.value as string}
+                      />
+                    )}
+                    name="inputDescription"
+                    control={control}
+                  />
+                )}
                 {errors.inputDescription && (
                   <div className="flex items-center gap-1 text-xs text-red-500">
                     <PiWarningBold />
@@ -420,14 +425,22 @@ export default function Page({ params }: { params: { id: string } }) {
                   </div>
                 )}
               </div>
-              <div className="flex flex-col gap-1">
+              <div className="flex w-[360px] flex-col gap-1">
                 <Label>Output Description</Label>
-                <Textarea
-                  id="outputDescription"
-                  placeholder="Enter a description..."
-                  className="min-h-[120px] w-[360px] bg-white"
-                  {...register('outputDescription')}
-                />
+                {getValues('outputDescription') && (
+                  <Controller
+                    render={({ field }) => (
+                      <TextEditor
+                        placeholder="Enter a description..."
+                        onChange={field.onChange}
+                        defaultValue={field.value as string}
+                      />
+                    )}
+                    name="outputDescription"
+                    control={control}
+                  />
+                )}
+
                 {errors.outputDescription && (
                   <div className="flex items-center gap-1 text-xs text-red-500">
                     <PiWarningBold />

--- a/apps/frontend/components/TextEditor.tsx
+++ b/apps/frontend/components/TextEditor.tsx
@@ -14,7 +14,7 @@ import { DialogClose } from '@radix-ui/react-dialog'
 import { mergeAttributes, Node } from '@tiptap/core'
 import Link from '@tiptap/extension-link'
 import Placeholder from '@tiptap/extension-placeholder'
-import type { Extension } from '@tiptap/react'
+import { Extension } from '@tiptap/react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import type { NodeViewWrapperProps } from '@tiptap/react'
@@ -84,6 +84,25 @@ function MathPreview(props: NodeViewWrapperProps) {
   )
 }
 
+export const Indentation = Extension.create({
+  name: 'indentation',
+  addKeyboardShortcuts() {
+    return {
+      Tab: ({ editor }) => {
+        const { state, dispatch } = editor.view
+        const { selection } = state
+        const transaction = state.tr.insertText(
+          '  ',
+          selection.from,
+          selection.to
+        ) // Insert two spaces
+        dispatch(transaction)
+        return true
+      }
+    }
+  }
+})
+
 export const MathExtension = Node.create({
   name: 'mathComponent',
   group: 'inline math',
@@ -149,7 +168,8 @@ export default function TextEditor({
         emptyEditorClass:
           'before:absolute before:text-gray-300 before:float-left before:content-[attr(data-placeholder)] before:pointer-events-none'
       }),
-      Link
+      Link,
+      Indentation
     ],
     editorProps: {
       attributes: {


### PR DESCRIPTION
### Description

admin의 problem editor description에서 tab 키 입력 시 indent가 되지 않는 오류를 해결했습니다. 

Texteditor로 통일 완료했습니다.

### Additional context

<del><img width="839" alt="image" src="https://github.com/skkuding/codedang/assets/113789141/ec85e4b9-8bfc-404b-b383-1fd06d7ac708">
-edit problem
<img width="845" alt="image" src="https://github.com/skkuding/codedang/assets/113789141/02a10bf0-a0df-4d66-b4be-bbe9d8a39082">
-create problem
다음과 같이 edit problem 창이랑 create problem 창을 비교했을 때 둘의 input, output description 컴포넌트가 다른 이유가 무엇인가요? Textarea와 Texteditor 를 각각 사용하고 있습니다. 
</del>



### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

close #1750 
