### PR TITLE
fix(fe): handle null user in submission

### DIFF
--- a/apps/frontend/app/problem/[problemId]/submission/_components/Columns.tsx
+++ b/apps/frontend/app/problem/[problemId]/submission/_components/Columns.tsx
@@ -13,7 +13,7 @@ export const columns: ColumnDef<SubmissionItem>[] = [
   {
     header: () => 'User ID',
     accessorKey: 'username',
-    cell: ({ row }) => row.original.user.username
+    cell: ({ row }) => row.original.user?.username ?? 'Unknown User'
   },
   {
     header: () => 'Result',


### PR DESCRIPTION
### Description

problem의 submission 페이지에서 username이 null인 user가 있으면 런타임 에러가 나는 오류가 존재함. 그럴 경우 username을 'Unknown User'라고 표기해 버그 해결

### Additional context

앞으로 username이 null인 경우는 절대 발생하지 않을 것이므로 지금처럼 'Unknown User'라고 표기할지, 아예 제출 내역을 숨길지는 추후 결정

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
