### PR TITLE
feat(fe): show skeleton code on code editor

### DIFF
--- a/apps/frontend/components/EditorHeader.tsx
+++ b/apps/frontend/components/EditorHeader.tsx
@@ -24,12 +24,17 @@ import { auth } from '@/lib/auth'
 import { fetcherWithAuth } from '@/lib/utils'
 import useAuthModalStore from '@/stores/authModal'
 import { CodeContext, useLanguageStore } from '@/stores/editor'
-import type { Language, ProblemDetail, Submission } from '@/types/type'
+import type {
+  Language,
+  ProblemDetail,
+  Submission,
+  Template
+} from '@/types/type'
 import JSConfetti from 'js-confetti'
-import { Trash2Icon } from 'lucide-react'
 import type { Route } from 'next'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect, useState } from 'react'
+import { IoMdRefresh } from 'react-icons/io'
 import { useInterval } from 'react-use'
 import { toast } from 'sonner'
 import { useStore } from 'zustand'
@@ -37,15 +42,21 @@ import { useStore } from 'zustand'
 interface ProblemEditorProps {
   problem: ProblemDetail
   contestId?: number
+  templateString: string
 }
 
-export default function Editor({ problem, contestId }: ProblemEditorProps) {
+export default function Editor({
+  problem,
+  contestId,
+  templateString
+}: ProblemEditorProps) {
   const { language, setLanguage } = useLanguageStore()
   const store = useContext(CodeContext)
   if (!store) throw new Error('CodeContext is not provided')
   const { code, setCode } = useStore(store)
   const [loading, setLoading] = useState(false)
   const [submissionId, setSubmissionId] = useState<number | null>(null)
+  const [templateCode, setTemplateCode] = useState<string | null>(null)
   const router = useRouter()
   const confetti = typeof window !== 'undefined' ? new JSConfetti() : null
   useInterval(
@@ -84,6 +95,15 @@ export default function Editor({ problem, contestId }: ProblemEditorProps) {
       }
     })
   }, [])
+
+  useEffect(() => {
+    const parsedTemplates = JSON.parse(templateString)
+    const filteredTemplate = parsedTemplates.filter(
+      (template: Template) => template.language === language
+    )
+    if (filteredTemplate.length === 0) return
+    setTemplateCode(filteredTemplate[0].code[0].text)
+  }, [language])
 
   const submit = async () => {
     if (code === '') {
@@ -132,21 +152,21 @@ export default function Editor({ problem, contestId }: ProblemEditorProps) {
               size="icon"
               className="size-7 shrink-0 rounded-md bg-slate-600 hover:bg-slate-700"
             >
-              <Trash2Icon className="size-4" />
+              <IoMdRefresh className="size-5" />
             </Button>
           </AlertDialogTrigger>
           <AlertDialogContent className="border border-slate-800 bg-slate-900">
             <AlertDialogHeader>
               <AlertDialogTitle className="text-slate-50">
-                Clear code
+                Reset code
               </AlertDialogTitle>
               <AlertDialogDescription className="text-slate-300">
-                Are you sure you want to clear your code?
+                Are you sure you want to reset to the default code?
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter className="flex gap-2">
-              <AlertDialogAction onClick={() => setCode('')}>
-                Clear
+              <AlertDialogAction onClick={() => setCode(templateCode ?? '')}>
+                Reset
               </AlertDialogAction>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
             </AlertDialogFooter>

--- a/apps/frontend/components/EditorResizablePanel.tsx
+++ b/apps/frontend/components/EditorResizablePanel.tsx
@@ -90,7 +90,11 @@ export default function EditorMainResizablePanel({
       <ResizablePanel defaultSize={65} className="bg-slate-900">
         <div className="grid-rows-editor grid h-full">
           <CodeContext.Provider value={store}>
-            <EditorHeader problem={problem} contestId={contestId} />
+            <EditorHeader
+              problem={problem}
+              contestId={contestId}
+              templateString={problem.template[0]}
+            />
             <CodeEditorInEditorResizablePanel
               templateString={problem.template[0]}
             />

--- a/apps/frontend/components/EditorResizablePanel.tsx
+++ b/apps/frontend/components/EditorResizablePanel.tsx
@@ -9,7 +9,7 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { CodeContext, createCodeStore, useLanguageStore } from '@/stores/editor'
-import type { Language, ProblemDetail } from '@/types/type'
+import type { Language, ProblemDetail, Template } from '@/types/type'
 import type { Route } from 'next'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -91,7 +91,9 @@ export default function EditorMainResizablePanel({
         <div className="grid-rows-editor grid h-full">
           <CodeContext.Provider value={store}>
             <EditorHeader problem={problem} contestId={contestId} />
-            <CodeEditorInEditorResizablePanel />
+            <CodeEditorInEditorResizablePanel
+              templateString={problem.template[0]}
+            />
           </CodeContext.Provider>
         </div>
       </ResizablePanel>
@@ -99,11 +101,29 @@ export default function EditorMainResizablePanel({
   )
 }
 
-function CodeEditorInEditorResizablePanel() {
+interface CodeEditorInEditorResizablePanelProps {
+  templateString: string
+}
+
+function CodeEditorInEditorResizablePanel({
+  templateString
+}: CodeEditorInEditorResizablePanelProps) {
   const { language } = useLanguageStore()
   const store = useContext(CodeContext)
   if (!store) throw new Error('CodeContext is not provided')
   const { code, setCode } = useStore(store)
+
+  useEffect(() => {
+    const parsedTemplates = JSON.parse(templateString)
+    const filteredTemplate = parsedTemplates.filter(
+      (template: Template) => template.language === language
+    )
+    if (!code) {
+      if (filteredTemplate.length === 0) return
+      setCode(filteredTemplate[0].code[0].text)
+    }
+  }, [language])
+
   return (
     <CodeEditor
       value={code}

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -15,6 +15,17 @@ export interface Tag {
   name: string
 }
 
+export interface Snippet {
+  id: number
+  locked: boolean
+  text: string
+}
+
+export interface Template {
+  code: Snippet[]
+  language: Language
+}
+
 export interface Problem {
   id: number
   title: string
@@ -55,6 +66,7 @@ export interface ProblemDetail {
   source: string
   tags: Tag[]
   hint: string
+  template: string[]
 }
 
 // Contest type definition


### PR DESCRIPTION
### Description
store에 저장된 코드가 없다면, 서버에서 받아온 스켈레톤 코드를 store에 저장하도록 했습니다. 

- 언어를 변경할 때마다 해당 스켈레톤 코드가 표시됩니다

https://github.com/skkuding/codedang/assets/97675977/5572ca78-587b-4778-b924-04d7bd39be26

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes #1781 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
