### PR TITLE
fix(fe): fix Vercel problemCard server component error

### DIFF
--- a/apps/frontend/app/(main)/_components/ProblemCards.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCards.tsx
@@ -10,7 +10,7 @@ interface ProblemCardsProps {
 }
 
 const getProblems = async () => {
-  const problems: ProblemCardsProps = await fetcher
+  const res: ProblemCardsProps = await fetcher
     .get('problem', {
       searchParams: {
         take: 3
@@ -19,8 +19,8 @@ const getProblems = async () => {
     })
     .json()
 
-  problems.data ?? console.error('4.getProblem', problems)
-  return problems.data ?? problems
+  res.data ?? console.error('4.getProblem', res)
+  return res.data ?? res
 }
 
 export default async function ProblemCards() {

--- a/apps/frontend/app/(main)/_components/ProblemCards.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCards.tsx
@@ -10,7 +10,7 @@ interface ProblemCardsProps {
 }
 
 const getProblems = async () => {
-  const res: ProblemCardsProps = await fetcher
+  const problemRes: ProblemCardsProps = await fetcher
     .get('problem', {
       searchParams: {
         take: 3
@@ -19,8 +19,8 @@ const getProblems = async () => {
     })
     .json()
 
-  res.data ?? console.error('4.getProblem', res)
-  return res.data ?? res
+  problemRes.data ?? console.error('4.getProblem', problemRes)
+  return problemRes.data ?? problemRes
 }
 
 export default async function ProblemCards() {

--- a/apps/frontend/app/(main)/notice/_components/NoticeTable.tsx
+++ b/apps/frontend/app/(main)/notice/_components/NoticeTable.tsx
@@ -13,7 +13,7 @@ interface NoticeProps {
 }
 
 const getFixedNotices = async () => {
-  const notices: NoticeProps = await fetcher
+  const fixedNoticesRes: NoticeProps = await fetcher
     .get('notice', {
       searchParams: {
         fixed: 'true',
@@ -21,12 +21,12 @@ const getFixedNotices = async () => {
       }
     })
     .json()
-  console.log('1. getFixedNotices', notices)
-  return notices.data ?? notices
+  console.log('1. getFixedNotices', fixedNoticesRes)
+  return fixedNoticesRes.data ?? fixedNoticesRes
 }
 
 const getNotices = async (search: string) => {
-  const notices: NoticeProps = await fetcher
+  const noticesRes: NoticeProps = await fetcher
     .get('notice', {
       searchParams: {
         search,
@@ -34,8 +34,8 @@ const getNotices = async (search: string) => {
       }
     })
     .json()
-  console.log('2. getNotices', notices)
-  return notices.data ?? notices
+  console.log('2. getNotices', noticesRes)
+  return noticesRes.data ?? noticesRes
 }
 
 export default async function NoticeTable({ search }: Props) {


### PR DESCRIPTION
### Description

여전히 Vercel에서 problemCards를 렌더링하는 도중 에러가 발생하여, data fetching할 때 사용하는 변수 이름을 렌더링 할 때 쓰는 변수와 다르게 지정합니다. 기존에도 두 변수는 스코프가 분리되어 있으므로 문제가 없음이 보장되어야 하지만, Vercel 로그를 확인해보니 두 변수가 혼동되어 사용되고 있음을 알 수 있었습니다. 
이미지 확인하시면 problems response는 data와 total로 구성되어 있어야 하지만, 무슨 이유에서인지 problem response 안에 problems과 total이 들어있음을 확인할 수 있습니다.

이에 따라 같은 이유로 NoticeTable 부분도 변경합니다. 

![image](https://github.com/skkuding/codedang/assets/73051219/299bf0f2-c3b0-4127-add1-d076d46ef34f)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
