### PR TITLE
chore(fe): disable close when click outside modal

### DIFF
--- a/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
+++ b/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
@@ -80,7 +80,12 @@ export default function UploadDialog({ refetch }: Props) {
           Upload
         </Button>
       </DialogTrigger>
-      <DialogContent className="flex h-[24rem] w-[32rem] flex-col">
+      <DialogContent
+        onInteractOutside={(e) => {
+          e.preventDefault()
+        }}
+        className="flex h-[24rem] w-[32rem] flex-col"
+      >
         <h1 className="my-2 text-2xl font-bold">Upload Problem</h1>
         <p className="text-sm">
           Please upload Excel file containing problem data. If you are looking


### PR DESCRIPTION
### Description

업로드 모달 바깥 클릭시 모달 닫힘 방지

<img width="986" alt="스크린샷 2024-07-08 오후 3 26 23" src="https://github.com/skkuding/codedang/assets/115887872/e4f594ae-5431-43ce-9a04-9f28daf546b0">


### Additional context


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
