### PR TITLE
feat(fe): add indent when tab at textarea

### DIFF
--- a/apps/frontend/components/ui/textarea.tsx
+++ b/apps/frontend/components/ui/textarea.tsx
@@ -6,6 +6,21 @@ export interface TextareaProps
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Tab') {
+        event.preventDefault()
+        const target = event.target as HTMLTextAreaElement
+        const start = target.selectionStart
+        const end = target.selectionEnd
+
+        // Insert 2 spaces at the current cursor position
+        target.value =
+          target.value.substring(0, start) + '  ' + target.value.substring(end)
+
+        // Move the cursor 2 characters forward
+        target.selectionStart = target.selectionEnd = start + 2
+      }
+    }
     return (
       <textarea
         className={cn(
@@ -13,6 +28,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           className
         )}
         ref={ref}
+        onKeyDown={handleKeyDown}
         {...props}
       />
     )


### PR DESCRIPTION
### Description
현재 shadcn textarea 컴포넌트에 tab선택시 indent가 적용되지 않는데, 해당 기능이 기본으로 적용되는게 좋겠다고 판단해서 추가합니다.
- 이를 위해서 shadcn컴포넌트를 모아놓은 ui폴더의 textarea컴포넌트를 수정합니다.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
