### PR TITLE
refactor(fe): separate katex rendering function

### DIFF
--- a/apps/frontend/app/admin/problem/[id]/page.tsx
+++ b/apps/frontend/app/admin/problem/[id]/page.tsx
@@ -5,12 +5,12 @@ import { Button } from '@/components/ui/button'
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { GET_PROBLEM_DETAIL } from '@/graphql/problem/queries'
 import { usePagination } from '@/lib/pagination'
+import { renderKatex } from '@/lib/renderKatex'
 import type { SubmissionItem } from '@/types/type'
 import { useQuery } from '@apollo/client'
 // import { sanitize } from 'isomorphic-dompurify'
-import katex from 'katex'
 import Link from 'next/link'
-import { useEffect, useRef, type RefObject } from 'react'
+import { useEffect, useRef } from 'react'
 import { FaAngleLeft, FaPencil } from 'react-icons/fa6'
 import { columns } from './_components/Columns'
 import DataTable from './_components/DataTable'
@@ -29,26 +29,6 @@ export default function Page({ params }: { params: { id: string } }) {
     `submission?problemId=${id}`,
     20
   )
-
-  const renderKatex = (
-    html: string | undefined,
-    katexRef: RefObject<HTMLDivElement>
-  ) => {
-    if (katexRef.current) {
-      katexRef.current.innerHTML = html ?? ''
-      const div = katexRef.current
-      div.querySelectorAll('math-component').forEach((el) => {
-        const content = el.getAttribute('content') || ''
-        const mathHtml = katex.renderToString(content, {
-          throwOnError: false,
-          strict: false,
-          globalGroup: true,
-          output: 'mathml'
-        })
-        el.outerHTML = mathHtml
-      })
-    }
-  }
 
   const katexRef = useRef<HTMLDivElement>(null)!
   useEffect(() => {

--- a/apps/frontend/components/EditorDescription.tsx
+++ b/apps/frontend/components/EditorDescription.tsx
@@ -7,14 +7,14 @@ import {
   AccordionTrigger
 } from '@/components/ui/accordion'
 import { Badge } from '@/components/ui/badge'
+import { renderKatex } from '@/lib/renderKatex'
 import { convertToLetter } from '@/lib/utils'
 import type { ContestProblem, ProblemDetail } from '@/types/type'
 import { motion } from 'framer-motion'
 import { sanitize } from 'isomorphic-dompurify'
-import katex from 'katex'
 import { CheckCircle, Lightbulb, Tag } from 'lucide-react'
 import { Clipboard } from 'lucide-react'
-import { useState, useEffect, useRef, type RefObject } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard'
 import {
   Tooltip,
@@ -44,23 +44,6 @@ const useCopy = () => {
   return { copiedID, copy }
 }
 
-const renderKatex = (html: string, katexRef: RefObject<HTMLDivElement>) => {
-  if (katexRef.current) {
-    katexRef.current.innerHTML = html
-    const div = katexRef.current
-    div.querySelectorAll('math-component').forEach((el) => {
-      const content = el.getAttribute('content') || ''
-      const mathHtml = katex.renderToString(content, {
-        throwOnError: false,
-        strict: false,
-        globalGroup: true,
-        output: 'mathml'
-      })
-      el.outerHTML = mathHtml
-    })
-  }
-}
-
 export function EditorDescription({
   problem,
   contestProblems
@@ -69,6 +52,7 @@ export function EditorDescription({
   contestProblems?: ContestProblem[]
 }) {
   const { copiedID, copy } = useCopy()
+
   const katexRef = useRef<HTMLDivElement>(null)!
   useEffect(() => {
     renderKatex(problem.description, katexRef)

--- a/apps/frontend/lib/renderKatex.ts
+++ b/apps/frontend/lib/renderKatex.ts
@@ -1,0 +1,22 @@
+import katex from 'katex'
+import type { RefObject } from 'react'
+
+export const renderKatex = (
+  html: string | undefined,
+  katexRef: RefObject<HTMLDivElement>
+) => {
+  if (katexRef.current) {
+    katexRef.current.innerHTML = html ?? ''
+    const div = katexRef.current
+    div.querySelectorAll('math-component').forEach((el) => {
+      const content = el.getAttribute('content') || ''
+      const mathHtml = katex.renderToString(content, {
+        throwOnError: false,
+        strict: false,
+        globalGroup: true,
+        output: 'mathml'
+      })
+      el.outerHTML = mathHtml
+    })
+  }
+}


### PR DESCRIPTION
### Description

katex 를 렌더링하는 함수를 lib에 분리했습니다.

close #1820

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
