### PR TITLE
feat(fe): add register code field

### DIFF
--- a/apps/frontend/app/admin/contest/[id]/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/page.tsx
@@ -6,6 +6,7 @@ import { DateTimePickerDemo } from '@/components/date-time-picker-demo'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Switch } from '@/components/ui/switch'
 import {
   IMPORT_PROBLEMS_TO_CONTEST,
   UPDATE_CONTEST,
@@ -44,7 +45,8 @@ const schema = z.object({
   isVisible: z.boolean(),
   description: z.string().min(1),
   startTime: z.date(),
-  endTime: z.date()
+  endTime: z.date(),
+  invitationCode: z.string().min(6).max(6).nullish()
 })
 
 interface Problem {
@@ -58,6 +60,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const [prevProblemIds, setPrevProblemIds] = useState<number[]>([])
   const [problems, setProblems] = useState<Problem[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [showInvitationCode, setShowInvitationCode] = useState<boolean>(false)
   const { id } = params
 
   const router = useRouter()
@@ -94,12 +97,17 @@ export default function Page({ params }: { params: { id: string } }) {
           setValue('endTime', new Date(contestFormData.endTime))
         }
         setValue('description', contestFormData.description)
+        setValue('invitationCode', contestFormData.invitationCode)
       } else {
         const data = contestData.getContest
         setValue('title', data.title)
         setValue('description', data.description)
         setValue('startTime', new Date(data.startTime))
         setValue('endTime', new Date(data.endTime))
+        setValue('invitationCode', data.invitationCode)
+      }
+      if (getValues('invitationCode') !== null) {
+        setShowInvitationCode(true)
       }
       setIsLoading(false)
     }
@@ -162,10 +170,6 @@ export default function Page({ params }: { params: { id: string } }) {
     const problemIds = problems.map((problem) => problem.id)
 
     const orderArray = JSON.parse(localStorage.getItem('orderArray') || '[]')
-    if (orderArray.length === 0) {
-      toast.error('Problem order not set')
-      return
-    }
     if (orderArray.length !== problemIds.length) {
       toast.error('Problem order not set')
       return
@@ -336,6 +340,39 @@ export default function Page({ params }: { params: { id: string } }) {
           </div>
 
           <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <Label required={false}>Register Code</Label>
+              <Switch
+                onCheckedChange={() => {
+                  setShowInvitationCode(!showInvitationCode)
+                  setValue('invitationCode', null)
+                }}
+                checked={showInvitationCode}
+                className="data-[state=checked]:bg-black data-[state=unchecked]:bg-gray-300"
+              />
+            </div>
+            {showInvitationCode && (
+              <Input
+                id="invitationCode"
+                placeholder="Enter a Register Code"
+                type="number"
+                className={cn(
+                  inputStyle,
+                  'w-[380px]',
+                  '[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+                )}
+                {...register('invitationCode')}
+              />
+            )}
+            {errors.invitationCode && (
+              <div className="flex items-center gap-1 text-xs text-red-500">
+                <PiWarningBold />
+                {errors.invitationCode.message as string}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
             <div className="flex items-center justify-between">
               <Label>Contest Problem List</Label>
               <Button
@@ -347,7 +384,8 @@ export default function Page({ params }: { params: { id: string } }) {
                     title: getValues('title'),
                     startTime: getValues('startTime'),
                     endTime: getValues('endTime'),
-                    description: getValues('description')
+                    description: getValues('description'),
+                    invitationCode: getValues('invitationCode')
                   }
                   localStorage.setItem(
                     `contestFormData-${id}`,

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -11,6 +11,7 @@ import {
   PopoverTrigger
 } from '@/components/ui/popover'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Switch } from '@/components/ui/switch'
 import {
   CREATE_CONTEST,
   IMPORT_PROBLEMS_TO_CONTEST
@@ -46,7 +47,8 @@ const schema = z.object({
   isVisible: z.boolean().optional(),
   description: z.string().min(1),
   startTime: z.date(),
-  endTime: z.date()
+  endTime: z.date(),
+  invitationCode: z.string().min(6).max(6).nullish()
 })
 
 interface ContestProblem {
@@ -60,6 +62,7 @@ export default function Page() {
   const [problems, setProblems] = useState<ContestProblem[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [isCreating, setIsCreating] = useState<boolean>(false)
+  const [showInvitationCode, setShowInvitationCode] = useState<boolean>(false)
 
   const router = useRouter()
 
@@ -289,6 +292,40 @@ export default function Page() {
               </div>
             )}
           </div>
+
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <Label required={false}>Register Code</Label>
+              <Switch
+                onCheckedChange={() => {
+                  setShowInvitationCode(!showInvitationCode)
+                  setValue('invitationCode', null)
+                }}
+                checked={showInvitationCode}
+                className="data-[state=checked]:bg-black data-[state=unchecked]:bg-gray-300"
+              />
+            </div>
+            {showInvitationCode && (
+              <Input
+                id="invitationCode"
+                placeholder="Enter a Register Code"
+                type="number"
+                className={cn(
+                  inputStyle,
+                  'w-[380px]',
+                  '[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+                )}
+                {...register('invitationCode')}
+              />
+            )}
+            {errors.invitationCode && (
+              <div className="flex items-center gap-1 text-xs text-red-500">
+                <PiWarningBold />
+                {errors.invitationCode.message as string}
+              </div>
+            )}
+          </div>
+
           <div className="flex flex-col gap-1">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/apps/frontend/graphql/contest/mutations.ts
+++ b/apps/frontend/graphql/contest/mutations.ts
@@ -19,6 +19,7 @@ const UPDATE_CONTEST = gql(`
   mutation UpdateContest($groupId: Int!, $input: UpdateContestInput!) {
     updateContest(groupId: $groupId, input: $input) {
       id
+      invitationCode
       isRankVisible
       isVisible
       description

--- a/apps/frontend/graphql/contest/mutations.ts
+++ b/apps/frontend/graphql/contest/mutations.ts
@@ -4,6 +4,7 @@ const CREATE_CONTEST = gql(`
   mutation CreateContest($groupId: Int!, $input: CreateContestInput!) {
     createContest(groupId: $groupId, input: $input) {
       id
+      invitationCode
       isVisible
       isRankVisible
       description

--- a/apps/frontend/graphql/contest/queries.ts
+++ b/apps/frontend/graphql/contest/queries.ts
@@ -4,6 +4,7 @@ const GET_CONTEST = gql(`
   query GetContest($contestId: Int!) {
     getContest(contestId: $contestId) {
       id
+      invitationCode
       description
       endTime
       startTime


### PR DESCRIPTION
### Description
Contest Create/Edit Page에
Register Code 필드를 구현했습니다.
![image](https://github.com/user-attachments/assets/b25cd101-0c66-4263-b3d7-ebb6309e63c3)
- Switch를 토글하면 register code가 null이 됩니다
- Edit 페이지에서는 다른 필드들과 마찬가지로 import problem할 때 localStorage에 저장됩니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes #1814 
### Additional context
zod schema에서 optional 대신 nullish를 사용했습니다.
nullish는 null을 허용하기 때문에 토글 했을 때 빈 스트링이 아니라 null을 넣어줄 수 있습니다
Hint, Source 등과 같이 선택적으로 입력하는 필드들도 같은 방식으로 개선할 수 있을 것 같습니다.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
