### PR TITLE
feat(infra): apply minio web conolse on stage server

### DIFF
--- a/apps/infra/stage/Caddyfile
+++ b/apps/infra/stage/Caddyfile
@@ -18,7 +18,6 @@
 		respond "" 204
 	}
 
-
 	# 2. Actual request
 	# Matcher: If Origin header equals to the argument
 	# Handler: Set CORS headers
@@ -65,6 +64,11 @@ stage.codedang.com {
 			Set-Cookie (.*) "$1; SameSite=None; Secure"
 			defer
 		}
+	}
+
+	handle /bucket* {
+		uri strip_prefix /bucket
+		reverse_proxy 127.0.0.1:9001
 	}
 
 	handle /logs* {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - 9001:9001
     command: server /data --console-address ":9001"
     environment:
+      MINIO_BROWSER_REDIRECT_URL: https://stage.codedang.com/bucket
       MINIO_ROOT_USER: skku
       MINIO_ROOT_PASSWORD: skku1234
     volumes:


### PR DESCRIPTION
closes #1824 
### Description
Stage서버의 Minio (오브젝트 저장소 S3대체) 의 웹 콘솔을 접속할 수 있게 추가하였습니다. 
stage.codedang.com/bucket/ 으로 접속하시고, 아이디비밀번호는 따로 공유드립니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
