### PR TITLE
feat(infra): add image upload proxy

### DIFF
--- a/apps/infra/stage/Caddyfile
+++ b/apps/infra/stage/Caddyfile
@@ -68,8 +68,14 @@ stage.codedang.com {
 
 	handle /bucket* {
 		uri strip_prefix /bucket
+		reverse_proxy 127.0.0.1:9000
+	}
+
+	handle /console* {
+		uri strip_prefix /console
 		reverse_proxy 127.0.0.1:9001
 	}
+
 
 	handle /logs* {
 		reverse_proxy 127.0.0.1:9999

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - 9001:9001
     command: server /data --console-address ":9001"
     environment:
-      MINIO_BROWSER_REDIRECT_URL: https://stage.codedang.com/bucket
+      MINIO_BROWSER_REDIRECT_URL: https://stage.codedang.com/console
       MINIO_ROOT_USER: skku
       MINIO_ROOT_PASSWORD: skku1234
     volumes:


### PR DESCRIPTION
### Description
closes #1828 
Image Upload 를 위한 프록시 설정을 추가하였습니다.
기존의 Minio Console의 URI를 /bucket으로 설정하였지만,
해당 URI를 실제 Object Resource에 접근하기 위한 URI로 변경하였고,
Web Console은 그 의미에 맞추어 /console로 설정하였습니다.

따라서, Web Console접근은 https://stage.codedang.com/console/  로 접근하시면 되고('/' 잊지 말아주세요)
resource 접근은 https://stage.codedang.com/bucket/{bucket_name}/{resource_name}
으로 가져오시면 됩니다.
**127.0.0.1로 가져오시면 안됩니다.**


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
