### PR TITLE
feat(fe): add register code dialog, split register logic based on invitationCodeExists

### DIFF
--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
@@ -1,10 +1,29 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { fetcherWithAuth } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { cn, fetcherWithAuth } from '@/lib/utils'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
+import { z } from 'zod'
+
+interface RegisterCodeInput {
+  invitationCode: string
+}
+
+const schema = z.object({
+  invitationCode: z.string().length(6)
+})
 
 const getFirstProblemId = async (contestId: string) => {
   const { problems }: { problems: { id: string }[] } = await fetcherWithAuth
@@ -18,90 +37,168 @@ const getFirstProblemId = async (contestId: string) => {
 export default function RegisterButton({
   id,
   registered,
-  state
+  state,
+  title,
+  invitationCodeExists
 }: {
   id: string
   registered: boolean
   state: string
+  title: string
+  invitationCodeExists: boolean
 }) {
   const [firstProblemId, setFirstProblemId] = useState('')
-  const buttonColor = registered ? 'bg-secondary' : 'bg-primary'
+  // const buttonColor = registered ? 'bg-secondary' : 'bg-primary'
   const router = useRouter()
   const clickRegister = async (contestId: string) => {
     await fetcherWithAuth
       .post(`contest/${contestId}/participation`, {
-        searchParams: { groupId: 1 }
+        searchParams: invitationCodeExists
+          ? {
+              groupId: 1,
+              invitationCode: getValues('invitationCode')
+            }
+          : { groupId: 1 }
       })
       .then((res) => {
-        res.json()
+        if (!res.ok) {
+          toast.error(
+            invitationCodeExists ? 'Invalid code' : 'Failed to register'
+          )
+        } else {
+          toast.success(`Registered ${state} test successfully`)
+        }
         router.refresh()
       })
       .catch((err) => console.log(err))
   }
-  const clickDeregister = async (contestId: string) => {
-    await fetcherWithAuth
-      .delete(`contest/${contestId}/participation`, {
-        searchParams: { groupId: 1 }
-      })
-      .then((res) => {
-        res.json()
-        router.refresh()
-      })
-      .catch((err) => console.log(err))
-  }
+  // const clickDeregister = async (contestId: string) => {
+  //   await fetcherWithAuth
+  //     .delete(`contest/${contestId}/participation`, {
+  //       searchParams: { groupId: 1 }
+  //     })
+  //     .then((res) => {
+  //       res.json()
+  //       router.refresh()
+  //     })
+  //     .catch((err) => console.log(err))
+  // }
 
   useEffect(() => {
     async function fetchFirstProblemId() {
-      const firstId =
-        registered && state === 'Ongoing' ? await getFirstProblemId(id) : ''
-      firstId && setFirstProblemId(firstId)
+      if (registered && state === 'Ongoing') {
+        const firstId = await getFirstProblemId(id)
+        setFirstProblemId(firstId ?? '')
+      } else {
+        setFirstProblemId('')
+      }
     }
     fetchFirstProblemId()
-  }, [registered])
+  }, [registered, state, id])
+
+  const {
+    handleSubmit,
+    register,
+    trigger,
+    getValues,
+    formState: { errors }
+  } = useForm<RegisterCodeInput>({
+    resolver: zodResolver(schema)
+  })
+
+  const onSubmit = async () => {
+    clickRegister(id)
+  }
+
   return (
     <>
-      {state === 'Upcoming' ? (
-        <Button
-          className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-          onClick={() => {
-            if (registered) {
-              clickDeregister(id)
-              toast.success('Deregistered Upcoming test successfully')
-            } else {
-              clickRegister(id)
-              toast.success('Registered Upcoming test successfully')
-            }
-          }}
-        >
-          {registered ? 'Deregister' : 'Register'}
-        </Button>
-      ) : (
+      {registered ? (
+        // Case 1) User registered for the contest
         <>
-          {!registered ? (
+          {/* {state === 'Upcoming' ? (
             <Button
               className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
               onClick={() => {
-                clickRegister(id)
-                toast.success('Registered Ongoing test successfully')
+                clickDeregister(id)
+                toast.success('Deregistered Upcoming test successfully')
               }}
             >
-              Register
+              Deregister
             </Button>
           ) : (
-            <>
-              {firstProblemId && (
-                <Button
-                  className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-                  onClick={() =>
-                    router.push(`/contest/${id}/problem/${firstProblemId}`)
-                  }
-                >
-                  Go To First Problem!
-                </Button>
-              )}
-            </>
+            <> */}
+          {firstProblemId && (
+            <Button
+              className="px-12 py-6 text-lg font-light"
+              onClick={() =>
+                router.push(`/contest/${id}/problem/${firstProblemId}`)
+              }
+            >
+              Go To First Problem!
+            </Button>
           )}
+          {/* </>
+          )} */}
         </>
+      ) : !invitationCodeExists ? (
+        // Case 2) User not registered and no invitation code required
+        <Button
+          className="px-12 py-6 text-lg disabled:bg-gray-300 disabled:text-gray-600"
+          disabled={state === 'Upcoming'}
+          onClick={() => {
+            clickRegister(id)
+          }}
+        >
+          Register Now
+        </Button>
+      ) : (
+        // Case 3) User not registered and invitation code required
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button
+              className="px-12 py-6 text-lg disabled:bg-gray-300 disabled:text-gray-600"
+              disabled={state === 'Upcoming'}
+            >
+              Register Now
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="flex w-[416px] flex-col gap-6 p-10">
+            <DialogHeader>
+              <DialogTitle className="line-clamp-2 text-xl">
+                {title}
+              </DialogTitle>
+            </DialogHeader>
+            <form
+              onSubmit={handleSubmit(onSubmit)}
+              className="flex flex-col gap-6"
+            >
+              <div className="flex flex-col gap-1">
+                <Input
+                  placeholder="Register Code"
+                  {...register('invitationCode', {
+                    onChange: () => trigger('invitationCode')
+                  })}
+                  type="number"
+                  className={cn(
+                    'h-12 w-full [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+                    errors.invitationCode &&
+                      'border-red-500 focus-visible:ring-red-500'
+                  )}
+                />
+                {errors.invitationCode && (
+                  <p className="text-xs text-red-500">
+                    Register Code must be a 6-digit number
+                  </p>
+                )}
+              </div>
+              <div className="flex justify-center">
+                <Button type="submit" className="w-24">
+                  Register
+                </Button>
+              </div>
+            </form>
+          </DialogContent>
+        </Dialog>
       )}
     </>
   )

--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
@@ -4,10 +4,12 @@ import { sanitize } from 'isomorphic-dompurify'
 import RegisterButton from './_components/RegisterButton'
 
 interface ContestTop {
+  title: string
   description: string
   startTime: string
   endTime: string
   isRegistered: boolean
+  invitationCodeExists: boolean
 }
 
 interface ContestTopProps {
@@ -45,6 +47,8 @@ export default async function ContestTop({ params }: ContestTopProps) {
             id={contestId}
             registered={data.isRegistered}
             state={state}
+            title={data.title}
+            invitationCodeExists={data.invitationCodeExists}
           />
         </div>
       )}


### PR DESCRIPTION
### Description
Deregister 로직을 주석처리하고, 초대 코드 입력 모달을 구현했습니다.

https://github.com/user-attachments/assets/387d8f9f-03c6-4185-8da4-7b26507a7f8f
### 1. Upcoming Contest
Register Now 버튼이 비활성화됩니다.
### 2. 초대코드가 없는 Ongoing Contest
Register Now 버튼을 통해 바로 등록 가능합니다.
### 3. 초대코드가 있는 Ongoing Contest
Register Now 버튼을 통해 초대코드 입력 모달을 열고
모달에 올바른 초대코드를 입력하는 것으로 대회에 등록합니다.

### 참고사항
모달에 초대코드 입력할 때 경고 문구를
'Register Code must be a 6-digit number'로 설정했습니다.
피그마의 경우 'Incorrect'로 되어 있으나, 
초대코드의 형식과 값 중 어느 것이 틀린 것인지 혼동 될 걸 우려해 수정했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes #1811 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
