### PR TITLE
feat(infra): change api ecs cpu soft limit and delete memory hard limit

### DIFF
--- a/apps/infra/production/codedang/codedang_service_admin.tf
+++ b/apps/infra/production/codedang/codedang_service_admin.tf
@@ -30,7 +30,7 @@ module "admin_api" {
   #TODO
   task_definition = {
     family = "Codedang-Admin-Api"
-    memory = 950
+    # memory = 950
     container_definitions = jsonencode([
       jsondecode(templatefile("container_definitions/admin_api.json", {
         ecr_uri                         = data.aws_ecr_repository.admin_api.repository_url,

--- a/apps/infra/production/codedang/codedang_service_client.tf
+++ b/apps/infra/production/codedang/codedang_service_client.tf
@@ -30,7 +30,7 @@ module "client_api" {
   #TODO
   task_definition = {
     family = "Codedang-Client-Api"
-    memory = 950
+    # memory = 950
 
     container_definitions = jsonencode([
       jsondecode(templatefile("container_definitions/client_api.json", {

--- a/apps/infra/production/codedang/container_definitions/admin_api.json
+++ b/apps/infra/production/codedang/container_definitions/admin_api.json
@@ -1,7 +1,7 @@
 {
   "name": "Codedang-Admin-Api",
   "image": "${ecr_uri}",
-  "cpu": 924,
+  "cpu": 600,
   "memoryReservation": 512,
   "essential": true,
   "portMappings": [

--- a/apps/infra/production/codedang/container_definitions/client_api.json
+++ b/apps/infra/production/codedang/container_definitions/client_api.json
@@ -1,7 +1,7 @@
 {
   "name": "Codedang-Client-Api",
   "image": "${ecr_uri}",
-  "cpu": 924,
+  "cpu": 600,
   "memoryReservation": 512,
   "essential": true,
   "portMappings": [

--- a/apps/infra/production/codedang/modules/service_autoscaling/variables.tf
+++ b/apps/infra/production/codedang/modules/service_autoscaling/variables.tf
@@ -2,7 +2,7 @@ variable "task_definition" {
   type = object({
     family                = string
     cpu                   = optional(number)
-    memory                = number
+    memory                = optional(number)
     container_definitions = any
     execution_role_arn    = string
   })


### PR DESCRIPTION
### Description
- API ECS 설정을 수정하였습니다 (Admin, Client)
- CPU의 Soft limit을 EC2 인스턴스 전체 용량의 30% 수준으로 낮추었습니다 (기존에는 50% 수준)
- Memory의 Hard limit을 삭제하였습니다. 따라서, Soft limit만 존재합니다. Memory의 soft limit은 EC2 인스턴스 전체 용량의 25% 정도로 설정되어있습니다.
Close #1836 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
