### PR TITLE
feat(fe): redesign problemcard component and see-more button

### DIFF
--- a/apps/frontend/app/(main)/_components/ProblemCard.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCard.tsx
@@ -1,7 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import '@/components/ui/card'
 import type { WorkbookProblem } from '@/types/type'
-import { MdOutlineSubdirectoryArrowRight } from 'react-icons/md'
-import Badge from './Badge'
 
 interface Props {
   problem: WorkbookProblem
@@ -9,20 +7,25 @@ interface Props {
 
 export default function ProblemCard({ problem }: Props) {
   return (
-    <Card className="flex w-full flex-col justify-between gap-1 shadow-none transition hover:scale-105 hover:opacity-80">
-      <CardHeader className="pb-0">
-        <Badge
-          type={problem.difficulty}
-        >{`Level ${problem.difficulty[5]}`}</Badge>
-        <CardTitle className="overflow-hidden text-ellipsis whitespace-nowrap text-lg font-semibold">
-          {`#${problem.id} ${problem.title}`}
-        </CardTitle>
-      </CardHeader>
-
-      <CardContent className="flex items-center gap-1 text-xs text-gray-500">
-        <MdOutlineSubdirectoryArrowRight />
-        Solved Rate {(problem.acceptedRate * 100).toFixed(2)}%
-      </CardContent>
-    </Card>
+    <div className="flex w-full flex-col justify-between gap-4 rounded-md border border-gray-200 p-4 shadow-none transition hover:scale-105">
+      <div className="flex flex-col justify-between gap-4 pt-2">
+        <p className="text-sm font-medium text-gray-500">{`Problem #${problem.id}`}</p>
+        <div className="line-clamp-2 whitespace-pre-wrap text-lg font-semibold leading-tight">
+          {`${problem.title}
+          `}
+        </div>
+      </div>
+      <div className="border-t-2"></div>
+      <div className="grid grid-cols-2 text-xs text-gray-500">
+        <div className="flex flex-col items-center gap-2 py-4">
+          <p className="text-sm font-medium">Level</p>
+          <p className="text-2xl font-semibold text-black">{`${problem.difficulty.substring(5)}`}</p>
+        </div>
+        <div className="flex flex-col items-center gap-2 border-l-2 py-4">
+          <p className="text-sm font-medium">Submission</p>
+          <p className="text-2xl font-semibold text-black">{`${problem.submissionCount}`}</p>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/apps/frontend/app/(main)/_components/ProblemCard.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCard.tsx
@@ -11,6 +11,7 @@ export default function ProblemCard({ problem }: Props) {
       <div className="flex flex-col justify-between gap-4 pt-2">
         <p className="text-sm font-medium text-gray-500">{`Problem #${problem.id}`}</p>
         <div className="line-clamp-2 whitespace-pre-wrap text-lg font-semibold leading-tight">
+          {/* code to keep two lines of problem title */}
           {`${problem.title}
           `}
         </div>
@@ -19,11 +20,15 @@ export default function ProblemCard({ problem }: Props) {
       <div className="grid grid-cols-2 text-xs text-gray-500">
         <div className="flex flex-col items-center gap-2 py-4">
           <p className="text-sm font-medium">Level</p>
-          <p className="text-2xl font-semibold text-black">{`${problem.difficulty.substring(5)}`}</p>
+          <p className="text-2xl font-semibold text-black">
+            {problem.difficulty.substring(5)}
+          </p>
         </div>
         <div className="flex flex-col items-center gap-2 border-l-2 py-4">
           <p className="text-sm font-medium">Submission</p>
-          <p className="text-2xl font-semibold text-black">{`${problem.submissionCount}`}</p>
+          <p className="text-2xl font-semibold text-black">
+            {problem.submissionCount}
+          </p>
         </div>
       </div>
     </div>

--- a/apps/frontend/app/(main)/page.tsx
+++ b/apps/frontend/app/(main)/page.tsx
@@ -66,12 +66,12 @@ export default function Home() {
           </Suspense>
         </div>
       </div> */}
-      <div className="flex w-full flex-col gap-3">
+      <div className="flex w-full flex-col gap-6">
         <div className="flex w-full items-center justify-between text-gray-700">
-          <p className="text-xl font-bold">Professor’s Recommendation</p>
+          <p className="text-2xl font-bold">Problem ✨</p>
           <Link href={'/problem' as Route}>
-            <Button variant="outline" className="h-8">
-              More
+            <Button variant="ghost" className="h-8 px-3">
+              See More
             </Button>
           </Link>
         </div>

--- a/apps/frontend/components/ui/button.tsx
+++ b/apps/frontend/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           'bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80',
         ghost:
-          'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-gray-50',
+          'text-gray-500 hover:bg-gray-100 active:bg-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50',
         link: 'text-gray-900 underline-offset-4 hover:underline dark:text-gray-50',
         slate: 'hover:text-primary-light'
       },


### PR DESCRIPTION
### Description

메인 페이지의 ProblemCards를 리디자인하고 See more 버튼의 active시 색상이 변경되도록 수정함
![image](https://github.com/user-attachments/assets/30718e65-f2bc-47ab-be75-8f83a1fa023d)

Closes #1844 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
