### PR TITLE
feat(infra): add limits for API and Iris in stage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,9 @@ services:
         reservations:
           cpus: 0.58
           memory: 512M
+        limits:
+          cpus: 2.0
+          memory: 2G
 
   backend-admin:
     profiles: ['deploy', 'update-target']
@@ -120,6 +123,9 @@ services:
         reservations:
           cpus: 0.58
           memory: 512M
+        limits:
+          cpus: 2.0
+          memory: 2G
 
   iris:
     profiles: ['deploy', 'update-target']
@@ -131,6 +137,11 @@ services:
         condition: service_completed_successfully
     env_file: .env.development
     network_mode: host
+    deploy:
+      resources:
+        limits:
+          cpus: 0.50
+          memory: 512M
 
   promtail:
     profiles: ['deploy']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,11 @@ services:
       - .env.development
       - .env
     network_mode: host
+    deploy:
+      resources:
+        reservations:
+          cpus: 0.58
+          memory: 512M
 
   backend-admin:
     profiles: ['deploy', 'update-target']
@@ -110,6 +115,11 @@ services:
       - .env.development
       - .env
     network_mode: host
+    deploy:
+      resources:
+        reservations:
+          cpus: 0.58
+          memory: 512M
 
   iris:
     profiles: ['deploy', 'update-target']


### PR DESCRIPTION
### Description
Stage 환경을 Production 환경과 동일시하기 위해 Stage 내 API 서버와 Iris 서버의 메모리, CPU 의 스펙을 제한하였습니다. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
API server hard limit 은 EC2 t3a.small 의 스펙으로 설정하였습니다.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
