### PR TITLE
fix(ci): change pnpm cache logic and check style all files

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -10,26 +10,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v3
-    - uses: actions/setup-node@v4
+    - name: Checkout repository
+      uses: pnpm/action-setup@v4
+      with:
+        run_install: false
+
+    - name: Setup Node.js and pnpm
+      uses: actions/setup-node@v4
       with:
         node-version: 20
-
-    # https://github.com/pnpm/action-setup/tree/v2/?tab=readme-ov-file#use-cache-to-reduce-installation-time
-    - name: Get pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-    - uses: actions/cache@v4
-      name: Setup pnpm cache
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-
+        cache: 'pnpm'
 
     - name: Install dependencies
       if: ${{ inputs.install == 'yes' }}
-      shell: bash
       run: pnpm install

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -23,4 +23,5 @@ runs:
 
     - name: Install dependencies
       if: ${{ inputs.install == 'yes' }}
+      shell: bash
       run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: echo "${{ github.event.pull_request.title }}" | pnpm commitlint --verbose
 
       - name: Check style (Node.js)
-        run: git diff --name-only --diff-filter=ACMRUXB origin/main | xargs -r pnpm prettier -c
+        run: git diff --name-only --diff-filter=ACMRUXB origin/main | xargs -r pnpm prettier -c --ignore-unknown
 
       - name: Check Style (Go)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-pnpm
+        with:
+          install: 'no'
+
+      - name: Install dev dependencies
+        run: pnpm install --dev
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -138,7 +143,7 @@ jobs:
         run: echo "${{ github.event.pull_request.title }}" | pnpm commitlint --verbose
 
       - name: Check style (Node.js)
-        run: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.ts$|.tsx$|.js$|.jsx$)" | xargs -r pnpm prettier -c
+        run: git diff --name-only --diff-filter=ACMRUXB origin/main | xargs -r pnpm prettier -c
 
       - name: Check Style (Go)
         run: |


### PR DESCRIPTION
### Description

- `setup-pnpm action`:  `setup-node`가 지원하는 cache 기능을 사용하는 것으로 변경
- `ci` workflow:
  - dev dependencies만 설치하도록 변경 -> 30초 시간 절약
  - prettier은 json 문법 등 다양한 파일들을 style check 하기 때문에 grep 부분 지움
    - 이렇게 하면 `.prettierignore`과 같은 파일도 prettier가 체크해서 parser 오류가 뜸 -> `--ignore-unknown` 옵션으로 해결


<img width="222" alt="Screenshot 2024-07-23 at 3 06 22 PM" src="https://github.com/user-attachments/assets/3610f915-360b-4bed-a383-8a2c752195d9">

dev dependencies만 설치해서 ci 같은 경우엔 1분에서 30초로 시간 절약

close #1858 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
