### PR TITLE
fix(fe): change management layout

### DIFF
--- a/apps/frontend/app/admin/layout.tsx
+++ b/apps/frontend/app/admin/layout.tsx
@@ -1,8 +1,7 @@
-import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-import type { Route } from 'next'
+import CodedangLogo from '@/public/codedang.svg'
+import Image from 'next/image'
 import Link from 'next/link'
-import { FaArrowRightFromBracket } from 'react-icons/fa6'
 import ClientApolloProvider from './_components/ApolloProvider'
 import SideBar from './_components/SideBar'
 
@@ -13,25 +12,29 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <nav className="flex w-60 flex-col bg-white p-2 pt-8 text-sm font-medium">
           {/* Todo: Group 기능 추가 시, Public Button 대신 GroupSelect 컴포넌트로 변경 */}
           {/* <GroupSelect /> */}
-          <Button
-            variant="ghost"
-            className="h-fit justify-between py-2 text-left text-lg font-bold text-slate-800"
-          >
-            Public
-          </Button>
+
+          <Link href="/">
+            <Image
+              src={CodedangLogo}
+              alt="코드당"
+              width={135.252}
+              height={28}
+            />
+          </Link>
+
           <Separator className="my-4 transition" />
           <SideBar />
-          <Link
+          {/* <Link
             href={'/' as Route}
             className="mt-auto rounded px-4 py-2 text-slate-600 transition hover:bg-slate-100"
           >
             <FaArrowRightFromBracket className="mr-2 inline-block" />
             Quit
-          </Link>
+          </Link> */}
         </nav>
         <Separator orientation="vertical" />
 
-        <div className="w-full overflow-y-auto">{children}</div>
+        <div className="relative w-full overflow-y-auto">{children}</div>
       </div>
     </ClientApolloProvider>
   )

--- a/apps/frontend/app/admin/notice/page.tsx
+++ b/apps/frontend/app/admin/notice/page.tsx
@@ -1,6 +1,6 @@
 export default function Page() {
   return (
-    <main className="grid flex-1 place-items-center">
+    <main className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform">
       <p className="font-medium text-slate-400">TODO: Show notice list</p>
     </main>
   )

--- a/apps/frontend/app/admin/page.tsx
+++ b/apps/frontend/app/admin/page.tsx
@@ -1,6 +1,6 @@
 export default function Page() {
   return (
-    <main className="grid flex-1 place-items-center">
+    <main className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform">
       <p className="font-medium text-slate-400">Welcome to Codedang!</p>
     </main>
   )


### PR DESCRIPTION
### Description
![스크린샷 2024-08-07 오후 3 01 27](https://github.com/user-attachments/assets/46f1734b-9449-473e-864a-420dd202a341)
Management  페이지 좌측 상단 로고 추가 && 하단 quit 버튼 삭제
Dashboard, Notice 문구 중앙정렬

### Additional context

closes TAS-559
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
