### PR TITLE
feat(be): return is-registered field together when get-finished-contests api is called

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.controller.ts
+++ b/apps/backend/apps/client/src/contest/contest.controller.ts
@@ -66,8 +66,9 @@ export class ContestController {
   }
 
   @Get('finished')
-  @AuthNotNeededIfOpenSpace()
+  @UserNullWhenAuthFailedIfOpenSpace()
   async getFinishedContests(
+    @Req() req: AuthenticatedRequest,
     @Query('groupId', GroupIDPipe) groupId: number,
     @Query('cursor', CursorValidationPipe) cursor: number | null,
     @Query('take', new DefaultValuePipe(10), new RequiredIntPipe('take'))
@@ -76,6 +77,7 @@ export class ContestController {
   ) {
     try {
       return await this.contestService.getFinishedContestsByGroupId(
+        req.user?.id,
         cursor,
         take,
         groupId,

--- a/apps/backend/apps/client/src/contest/contest.service.spec.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.spec.ts
@@ -302,6 +302,7 @@ describe('ContestService', () => {
     it('should return finished contests', async () => {
       const contests = await service.getFinishedContestsByGroupId(
         null,
+        null,
         10,
         groupId
       )

--- a/collection/client/Contest/Get finished contests/Succeed.bru
+++ b/collection/client/Contest/Get finished contests/Succeed.bru
@@ -10,7 +10,7 @@ get {
   auth: none
 }
 
-query {
+params:query {
   ~take: 10
   ~cursor: 1
   ~groupId: 1
@@ -34,6 +34,8 @@ docs {
   종료된 대회들을 가져옵니다.
   
   pagination이 가능하며, 제목 검색 기능을 포함합니다.
+  
+  각 대회에 유저가 등록되어있는지를 표시하는 `isRegisterd` 필드가 함께 반환합니다. (로그인되어있지 않은 경우 모두 false)
   
   ### Query
   


### PR DESCRIPTION
### Description

closes TAS-685

get finished contests API 호출 시 유저가 해당 대회에 등록되었는지를 표시하는 `isRegistered` 필드를 포함해 반환합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
