### PR TITLE
feat(fe): adjust main page card number responsively

### DIFF
--- a/apps/frontend/app/(main)/_components/ContestCard.tsx
+++ b/apps/frontend/app/(main)/_components/ContestCard.tsx
@@ -35,7 +35,7 @@ export default function ContestCard({ contest }: Props) {
   return (
     <div
       className={cn(
-        'flex w-full flex-col justify-between gap-1 rounded-md border border-gray-200 px-3 shadow-none transition hover:scale-105 hover:opacity-80',
+        'flex w-full flex-col justify-between gap-4 rounded-md border border-gray-200 px-3 shadow-none transition hover:scale-105 hover:opacity-80',
         bgVariants[contest.status]
       )}
     >
@@ -46,15 +46,15 @@ export default function ContestCard({ contest }: Props) {
         )}
       >
         <StatusBadge variant={contest.status} />
-        <div className="line-clamp-2 h-14 whitespace-pre-wrap text-lg font-semibold leading-tight text-black">
+        <div className="line-clamp-4 h-24 text-ellipsis whitespace-pre-wrap text-lg font-semibold leading-tight text-black min-[400px]:line-clamp-2 min-[400px]:h-12">
           {contest.title}
         </div>
       </div>
       <div className="mb-4 flex items-center justify-between">
-        <div className="flex flex-col gap-2">
+        <div className="line-clamp-2 flex flex-col gap-2">
           <div className="inline-flex items-center gap-2 whitespace-nowrap text-xs text-gray-800 opacity-80">
             <Image src={CalendarIcon} alt="Calendar" />
-            <p className="overflow-hidden text-ellipsis whitespace-nowrap">
+            <p className="overflow-hidden text-ellipsis whitespace-pre-wrap">
               {startTime} ~ {endTime}
             </p>
           </div>
@@ -66,7 +66,7 @@ export default function ContestCard({ contest }: Props) {
         </div>
         {(contest.status == 'ongoing' ||
           contest.status == 'registeredOngoing') && (
-          <div className="h-12 w-12">
+          <div className="hidden h-12 w-12 min-[400px]:block">
             <CircularProgressbar value={60} text="60%" />
           </div>
         )}

--- a/apps/frontend/app/(main)/_components/ContestCards.tsx
+++ b/apps/frontend/app/(main)/_components/ContestCards.tsx
@@ -42,17 +42,32 @@ export default async function ContestCards() {
 
   return (
     <>
-      {contests.map((contest) => {
-        return (
-          <Link
-            key={contest.id}
-            href={`/contest/${contest.id}` as Route}
-            className="inline-block w-full"
-          >
-            <ContestCard contest={contest} />
-          </Link>
-        )
-      })}
+      <div className="flex justify-between gap-5 lg:hidden">
+        {contests.slice(0, 2).map((contest) => {
+          return (
+            <Link
+              key={contest.id}
+              href={`/contest/${contest.id}` as Route}
+              className="inline-block w-full"
+            >
+              <ContestCard contest={contest} />
+            </Link>
+          )
+        })}
+      </div>
+      <div className="hidden justify-between gap-5 lg:flex">
+        {contests.map((contest) => {
+          return (
+            <Link
+              key={contest.id}
+              href={`/contest/${contest.id}` as Route}
+              className="inline-block w-full"
+            >
+              <ContestCard contest={contest} />
+            </Link>
+          )
+        })}
+      </div>
     </>
   )
 }

--- a/apps/frontend/app/(main)/_components/ContestCards.tsx
+++ b/apps/frontend/app/(main)/_components/ContestCards.tsx
@@ -42,7 +42,7 @@ export default async function ContestCards() {
 
   return (
     <>
-      <div className="flex justify-between gap-5 lg:hidden">
+      <div className="flex justify-between gap-5 xl:hidden">
         {contests.slice(0, 2).map((contest) => {
           return (
             <Link
@@ -55,7 +55,7 @@ export default async function ContestCards() {
           )
         })}
       </div>
-      <div className="hidden justify-between gap-5 lg:flex">
+      <div className="hidden justify-between gap-5 xl:flex">
         {contests.map((contest) => {
           return (
             <Link

--- a/apps/frontend/app/(main)/_components/ProblemCard.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCard.tsx
@@ -15,14 +15,14 @@ export default function ProblemCard({ problem }: Props) {
         </div>
       </div>
       <div className="border-t-2"></div>
-      <div className="grid grid-cols-2 text-xs text-gray-500">
+      <div className="grid grid-cols-1 text-xs text-gray-500 min-[400px]:grid-cols-2">
         <div className="flex flex-col items-center gap-2 py-4">
           <p className="text-sm font-medium">Level</p>
           <p className="text-2xl font-semibold text-black">
             {problem.difficulty.substring(5)}
           </p>
         </div>
-        <div className="flex flex-col items-center gap-2 border-l-2 py-4">
+        <div className="hidden flex-col items-center gap-2 border-l-2 py-4 min-[400px]:flex">
           <p className="text-sm font-medium">Submission</p>
           <p className="text-2xl font-semibold text-black">
             {problem.submissionCount}

--- a/apps/frontend/app/(main)/_components/ProblemCards.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCards.tsx
@@ -40,21 +40,40 @@ export default function ProblemCards() {
 
   return (
     <>
-      {loading
-        ? [...Array(3)].map((_, i) => (
-            <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
-          ))
-        : problems.map((problem) => {
-            return (
-              <Link
-                key={problem.id}
-                href={`/problem/${problem.id}` as Route}
-                className="inline-block w-full"
-              >
-                <ProblemCard problem={problem} />
-              </Link>
-            )
-          })}
+      <div className="flex justify-between gap-5 lg:hidden">
+        {loading
+          ? [...Array(2)].map((_, i) => (
+              <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
+            ))
+          : problems.slice(0, 2).map((problem) => {
+              return (
+                <Link
+                  key={problem.id}
+                  href={`/problem/${problem.id}` as Route}
+                  className="inline-block w-full"
+                >
+                  <ProblemCard problem={problem} />
+                </Link>
+              )
+            })}
+      </div>
+      <div className="hidden justify-between gap-5 lg:flex">
+        {loading
+          ? [...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
+            ))
+          : problems.map((problem) => {
+              return (
+                <Link
+                  key={problem.id}
+                  href={`/problem/${problem.id}` as Route}
+                  className="inline-block w-full"
+                >
+                  <ProblemCard problem={problem} />
+                </Link>
+              )
+            })}
+      </div>
     </>
   )
 }

--- a/apps/frontend/app/(main)/_components/ProblemCards.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCards.tsx
@@ -40,7 +40,7 @@ export default function ProblemCards() {
 
   return (
     <>
-      <div className="flex justify-between gap-5 lg:hidden">
+      <div className="flex justify-between gap-5 xl:hidden">
         {loading
           ? [...Array(2)].map((_, i) => (
               <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
@@ -57,7 +57,7 @@ export default function ProblemCards() {
               )
             })}
       </div>
-      <div className="hidden justify-between gap-5 lg:flex">
+      <div className="hidden justify-between gap-5 xl:flex">
         {loading
           ? [...Array(3)].map((_, i) => (
               <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />

--- a/apps/frontend/app/(main)/page.tsx
+++ b/apps/frontend/app/(main)/page.tsx
@@ -67,7 +67,7 @@ export default function Home() {
             </Button>
           </Link>
         </div>
-        <div className="grid w-full grid-cols-3 gap-5">
+        <div>
           <ContestCards />
         </div>
         <div className="flex w-full items-center justify-between text-gray-700">
@@ -78,7 +78,7 @@ export default function Home() {
             </Button>
           </Link>
         </div>
-        <div className="grid w-full grid-cols-3 gap-5">
+        <div>
           <ProblemCards />
         </div>
       </div>


### PR DESCRIPTION
### Description

메인 페이지의 Contest Card와 Problem Card의 개수와 디자인이 반응형으로 조절되도록 변경했습니다!

일반 노트북:
![image](https://github.com/user-attachments/assets/f23884e6-081e-49ef-89ee-5d66822d4f77)

1024px:
![image](https://github.com/user-attachments/assets/1a102946-3203-42f4-b2aa-6a9f6fc8c3e2)

390px:
![image](https://github.com/user-attachments/assets/a8127c8d-e35c-4dbc-8050-d52bb6881dc4)


### Additional context

Figma와 달리 일단 1024px까지 양 옆의 마진은 고정하지 않고 유동적으로 변하도록 내버려두었습니다..!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
