### PR TITLE
fix(cd): hide minio's id and password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       - 9001:9001
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: skku
-      MINIO_ROOT_PASSWORD: skku1234
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     volumes:
       - codedang-storage:/data
 


### PR DESCRIPTION
기존에는 minIO의 ID와 PW가 파일에 노출되어 있었다.
Github Actions의 secrets를 사용해 해당 값을 환경 변수로 설정해 주어 사용함으로써 노출을 피할 수 있다.

Close #1952
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
