### PR TITLE
feat(fe): improve datatableadmin click

### DIFF
--- a/apps/frontend/app/admin/contest/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/_components/Columns.tsx
@@ -34,6 +34,7 @@ function VisibleCell({ row }: { row: Row<DataTableContest> }) {
   return (
     <div className="flex space-x-2">
       <Switch
+        onClick={(e) => e.stopPropagation()}
         id="hidden-mode"
         checked={row.original.isVisible}
         onCheckedChange={() => {
@@ -72,7 +73,7 @@ function VisibleCell({ row }: { row: Row<DataTableContest> }) {
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <button>
+                <button onClick={(e) => e.stopPropagation()}>
                   {row.original.isVisible ? (
                     <FiEye className="text-primary h-[14px] w-[14px]" />
                   ) : (
@@ -112,6 +113,7 @@ export const columns: ColumnDef<DataTableContest>[] = [
     id: 'select',
     header: ({ table }) => (
       <Checkbox
+        onClick={(e) => e.stopPropagation()}
         checked={
           table.getIsAllPageRowsSelected() ||
           (table.getIsSomePageRowsSelected() && 'indeterminate')

--- a/apps/frontend/app/admin/problem/_components/Columns.tsx
+++ b/apps/frontend/app/admin/problem/_components/Columns.tsx
@@ -32,6 +32,7 @@ function VisibleCell({ row }: { row: Row<DataTableProblem> }) {
     <div className="ml-8 flex space-x-2">
       <Switch
         id="hidden-mode"
+        onClick={(e) => e.stopPropagation()}
         checked={row.original.isVisible}
         onCheckedChange={() => {
           row.original.isVisible = !row.original.isVisible
@@ -47,7 +48,10 @@ function VisibleCell({ row }: { row: Row<DataTableProblem> }) {
         }}
       />
       {!row.original.isVisible && (
-        <button className="justify-centert flex items-center">
+        <button
+          className="justify-centert flex items-center"
+          onClick={(e) => e.stopPropagation()}
+        >
           <TbFileInfo className="h-5 w-5 text-black" />
         </button>
       )}
@@ -68,6 +72,7 @@ export const columns: ColumnDef<DataTableProblem>[] = [
     ),
     cell: ({ row }) => (
       <Checkbox
+        onClick={(e) => e.stopPropagation()}
         checked={row.getIsSelected()}
         onCheckedChange={(value) => row.toggleSelected(!!value)}
         aria-label="Select row"

--- a/apps/frontend/components/DataTableAdmin.tsx
+++ b/apps/frontend/components/DataTableAdmin.tsx
@@ -355,11 +355,7 @@ export function DataTableAdmin<TData, TValue>({
                       <TableCell
                         key={cell.id}
                         className="text-center md:p-4"
-                        onClick={
-                          cell.column.id === 'title'
-                            ? () => router.push(href)
-                            : undefined
-                        }
+                        onClick={() => router.push(href)}
                       >
                         {flexRender(
                           cell.column.columnDef.cell,


### PR DESCRIPTION
### Description

Admin의 Problem List와 Contest List에서 title을 제외한 부분을 클릭했을 시 링크 연결이 되지 않는 문제를 수정했습니다! 이제 가장 왼쪽의 Checkbox, Visible의 토글과 아이콘을 제외하고 어느 부분을 클릭해도 제대로 연결됩니다!

closes TAS-705
closes TAS-706

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
