### PR TITLE
fix(infra): add profiles for local minio container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     network_mode: host
 
   local-storage:
+    profiles: ['devcontainer']
     container_name: codedang-local-storage
     image: minio/minio
     ports:


### PR DESCRIPTION
### Description
local-storage 컨테이너와 deploy-storage 컨테이너가 CD-stage 과정 중 docker compose 명령어에 의해 충돌이 생겼습니다.
이를 해결하기 위해 local-storage 에 profile 을 추가합니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-721
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
