### PR TITLE
fix(infra): inject minIO info from env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -39,6 +39,9 @@ MEDIA_SECRET_KEY=skku1234
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6380
 
+MINIO_ROOT_USER=skku
+MINIO_ROOT_PASSWORD=skku1234
+
 DATABASE_URL=postgresql://postgres:1234@127.0.0.1:5433/skkuding?schema=public
 TEST_DATABASE_URL=postgresql://postgres:1234@127.0.0.1:5434/skkuding?schema=public
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
     command: server /data --console-address ":9001"
     environment:
       MINIO_BROWSER_REDIRECT_URL: https://stage.codedang.com/console
-      MINIO_ROOT_USER: skku
-      MINIO_ROOT_PASSWORD: skku1234
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     volumes:
       - codedang-storage:/data
 


### PR DESCRIPTION
### Description

이전 PR에서 minIO username / password를 변수를 통해 inject하도록 변경한다는 PR을 올렸는데,
deploy storage에는 적용하지 않았길래 적용했습니다.

또한 local storage의 username/password를 환경변수에서 inject하도록 변경하였는데 
env.development에 해당 환경변수가 추가되어 있지 않아 로컬에서 setup.sh이 정상적으로 작동하지 않아 이 부분을 수정합니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
