### PR TITLE
feat(fe): change main page components design

### DIFF
--- a/apps/frontend/app/(main)/_components/ContestCard.tsx
+++ b/apps/frontend/app/(main)/_components/ContestCard.tsx
@@ -46,7 +46,7 @@ export default function ContestCard({ contest }: Props) {
         )}
       >
         <StatusBadge variant={contest.status} />
-        <div className="line-clamp-4 h-24 text-ellipsis whitespace-pre-wrap text-lg font-semibold leading-tight text-black min-[400px]:line-clamp-2 min-[400px]:h-12">
+        <div className="line-clamp-4 text-ellipsis whitespace-pre-wrap text-lg font-semibold leading-tight text-black min-[400px]:line-clamp-2">
           {contest.title}
         </div>
       </div>

--- a/apps/frontend/app/(main)/_components/Header.tsx
+++ b/apps/frontend/app/(main)/_components/Header.tsx
@@ -8,7 +8,7 @@ import NavLink from './NavLink'
 export default async function Header() {
   const session = await auth()
   return (
-    <header className="fixed left-0 z-40 grid h-16 w-full place-items-center bg-white/80">
+    <header className="fixed left-0 z-40 grid h-14 w-full place-items-center bg-white/80">
       <div className="flex w-full max-w-7xl items-center justify-between gap-5 px-5">
         {/* FIXME: If you uncomment a group tab, you have to remove a pr-20 tailwind class */}
         <div className="flex min-w-fit items-center justify-between gap-8 text-[16px]">

--- a/apps/frontend/app/(main)/contest/_components/ContestCardList.tsx
+++ b/apps/frontend/app/(main)/contest/_components/ContestCardList.tsx
@@ -6,7 +6,7 @@ import {
   CarouselNext,
   CarouselPrevious
 } from '@/components/ui/carousel'
-import { fetcher, fetcherWithAuth } from '@/lib/utils'
+import { cn, fetcher, fetcherWithAuth } from '@/lib/utils'
 import type { Contest } from '@/types/type'
 import type { Route } from 'next'
 import type { Session } from 'next-auth'
@@ -52,6 +52,58 @@ const getRegisteredContests = async () => {
   )
 }
 
+type ItemsPerSlide = 2 | 3
+
+function ContestCardCarousel({
+  itemsPerSlide,
+  title,
+  data
+}: {
+  itemsPerSlide: ItemsPerSlide
+  title: string
+  data: Contest[]
+}) {
+  const chunks = []
+
+  if (itemsPerSlide === 3) {
+    for (let i = 0; i < data.length; i += 3) chunks.push(data.slice(i, i + 3))
+  } else if (itemsPerSlide === 2) {
+    for (let i = 0; i < data.length; i += 2) chunks.push(data.slice(i, i + 2))
+  }
+
+  return (
+    <Carousel
+      className={cn(itemsPerSlide === 3 ? 'max-xl:hidden' : 'xl:hidden')}
+    >
+      <div className="mb-5 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-700">{title}</h1>
+        <div className="flex items-center justify-end gap-2">
+          <CarouselPrevious />
+          <CarouselNext />
+        </div>
+      </div>
+      <CarouselContent className="p-1">
+        {chunks.map((chunk) => (
+          <CarouselItem key={chunk[0].id} className="flex w-full gap-3">
+            {chunk.map((contest) => (
+              <Link
+                key={contest.id}
+                href={`/contest/${contest.id}` as Route}
+                className={cn(
+                  'block overflow-hidden p-2',
+                  itemsPerSlide === 3 ? 'w-1/3' : 'w-1/2'
+                )}
+              >
+                <ContestCard contest={contest} />
+              </Link>
+            ))}
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+    </Carousel>
+  )
+}
+
 export default async function Contest({
   title,
   type,
@@ -71,36 +123,12 @@ export default async function Contest({
 
   data.sort((a, b) => +new Date(a.startTime) - +new Date(b.startTime))
 
-  const contestChunks = []
-  for (let i = 0; i < data.length; i += 3)
-    contestChunks.push(data.slice(i, i + 3))
-
   return data.length === 0 ? (
     <></>
   ) : (
-    <Carousel>
-      <div className="mb-5 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-700">{title}</h1>
-        <div className="flex items-center justify-end gap-2">
-          <CarouselPrevious />
-          <CarouselNext />
-        </div>
-      </div>
-      <CarouselContent className="p-1">
-        {contestChunks.map((contestChunk) => (
-          <CarouselItem key={contestChunk[0].id} className="flex w-full gap-3">
-            {contestChunk.map((contest) => (
-              <Link
-                key={contest.id}
-                href={`/contest/${contest.id}` as Route}
-                className="block w-1/3 overflow-hidden p-2"
-              >
-                <ContestCard contest={contest} />
-              </Link>
-            ))}
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-    </Carousel>
+    <>
+      <ContestCardCarousel itemsPerSlide={3} title={title} data={data} />
+      <ContestCardCarousel itemsPerSlide={2} title={title} data={data} />
+    </>
   )
 }

--- a/apps/frontend/app/(main)/contest/layout.tsx
+++ b/apps/frontend/app/(main)/contest/layout.tsx
@@ -4,7 +4,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Cover title="CONTEST" description="Contests of CODEDANG" />
-      <div className="flex w-full max-w-5xl flex-col gap-5 p-5 py-8">
+      <div className="flex w-full max-w-7xl flex-col gap-5 p-5 py-8">
         {children}
       </div>
     </>

--- a/apps/frontend/app/(main)/layout.tsx
+++ b/apps/frontend/app/(main)/layout.tsx
@@ -9,7 +9,7 @@ export default function MainLayout({
   return (
     <div className="flex min-h-dvh w-screen flex-col items-center overflow-x-hidden">
       <Header />
-      <main className="mt-16 flex w-full max-w-7xl flex-1 flex-col items-center px-5">
+      <main className="mt-14 flex w-full max-w-7xl flex-1 flex-col items-center px-5">
         {children}
       </main>
       <Footer />

--- a/apps/frontend/app/(main)/notice/layout.tsx
+++ b/apps/frontend/app/(main)/notice/layout.tsx
@@ -7,7 +7,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         title="NOTICE"
         description="Events and announcements of CODEDANG"
       />
-      <div className="flex w-full max-w-5xl flex-col gap-5 p-5 py-8">
+      <div className="flex w-full max-w-7xl flex-col gap-5 p-5 py-8">
         {children}
       </div>
     </>

--- a/apps/frontend/app/(main)/page.tsx
+++ b/apps/frontend/app/(main)/page.tsx
@@ -37,7 +37,7 @@ const slides = [
 
 export default function Home() {
   return (
-    <div className="flex w-full flex-col gap-12 lg:items-center">
+    <div className="flex w-full flex-col gap-16 lg:items-center">
       <Carousel slides={slides} />
       {/* <div className="flex w-full flex-col gap-3">
         <div className="flex w-full items-center justify-between text-gray-700">
@@ -58,8 +58,9 @@ export default function Home() {
           </Suspense>
         </div>
       </div> */}
+
       <div className="flex w-full flex-col gap-6">
-        <div className="flex w-full items-center justify-between text-gray-700">
+        <div className="flex items-center justify-between text-gray-700">
           <p className="text-2xl font-bold">Contest 🏆</p>
           <Link href={'/contest' as Route}>
             <Button variant="ghost" className="h-8 px-3">
@@ -67,10 +68,11 @@ export default function Home() {
             </Button>
           </Link>
         </div>
-        <div>
-          <ContestCards />
-        </div>
-        <div className="flex w-full items-center justify-between text-gray-700">
+        <ContestCards />
+      </div>
+
+      <div className="flex w-full flex-col gap-6">
+        <div className="flex items-center justify-between text-gray-700">
           <p className="text-2xl font-bold">Problem ✨</p>
           <Link href={'/problem' as Route}>
             <Button variant="ghost" className="h-8 px-3">
@@ -78,9 +80,7 @@ export default function Home() {
             </Button>
           </Link>
         </div>
-        <div>
-          <ProblemCards />
-        </div>
+        <ProblemCards />
       </div>
     </div>
   )

--- a/apps/frontend/app/(main)/problem/layout.tsx
+++ b/apps/frontend/app/(main)/problem/layout.tsx
@@ -4,7 +4,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Cover title="PROBLEM" description="All the problems of CODEDANG" />
-      <div className="flex w-full max-w-5xl flex-col gap-5 p-5 py-8">
+      <div className="flex w-full max-w-7xl flex-col gap-5 p-5 py-8">
         {children}
       </div>
     </>

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -42,13 +42,13 @@ export default function HeaderAuthPanel({
         <DropdownMenu>
           <DropdownMenuTrigger
             className={cn(
-              'hidden gap-2 rounded-md px-4 py-1 md:flex',
+              'hidden items-center gap-2 rounded-md px-4 py-1 md:flex',
               group === 'editor' ? null : 'bg-primary text-white'
             )}
           >
             <BiSolidUser
               className={cn(
-                'h-6 w-6',
+                'h-4 w-4',
                 group === 'editor' ? 'text-gray-300' : 'text-white'
               )}
             />
@@ -88,7 +88,7 @@ export default function HeaderAuthPanel({
               onClick={() => showSignIn()}
               variant={'outline'}
               className={cn(
-                'mr-3 hidden px-3 py-1 text-base md:block',
+                'mr-3 hidden rounded-lg px-4 py-1 text-sm md:block',
                 group === 'editor' ? 'font-medium' : 'font-semibold'
               )}
             >
@@ -101,7 +101,7 @@ export default function HeaderAuthPanel({
                 showSignUp()
               }}
               className={cn(
-                'hidden px-3 py-1 text-base md:block',
+                'hidden rounded-lg px-4 py-1 text-sm md:block',
                 group === 'editor' ? 'font-medium' : 'font-bold'
               )}
             >


### PR DESCRIPTION
### Description
1. Main 페이지에서 Contest 카드랑 Problem 카드 사이 여백 늘림
2. Contest 페이지 캐러셀 모바일에서는 2개 되도록 수정
3. line-clamp로 ... 이 되어도 뒤에 문자가 살짝 보이는 버그 (height 지워서 해결)
4. 로그인 완료 후 헤더에 유저 아이콘 크기 변경
5. 헤더 사이즈 변경

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-710
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
