### PR TITLE
fix(fe): change email logo

### DIFF
--- a/apps/backend/apps/client/src/email/templates/email-auth.hbs
+++ b/apps/backend/apps/client/src/email/templates/email-auth.hbs
@@ -64,7 +64,7 @@
           <td>
             {{!-- Logo file is uploaded in https://github.com/skkuding/codedang/issues/1066 --}}
             <img
-              src="https://github.com/user-attachments/assets/6c8d7d43-d581-4007-9608-c1186424f6a8"
+              src="https://github.com/user-attachments/assets/09d0e23b-8ce6-4b42-b7af-7b3e120327a0"
               height="72"
               alt="Codedang"
               id="logo"


### PR DESCRIPTION
### Description

이메일 인증 코드당 로고 재수정합니다.
- 기존 SVG형식이 gmail에서 인식이 되지않음.

### Additional context



---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
