### PR TITLE
fix(fe): fix admin contest invitation code

### DIFF
--- a/apps/frontend/app/admin/_components/SwitchField.tsx
+++ b/apps/frontend/app/admin/_components/SwitchField.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { inputStyle } from '../utils'
+import ErrorMessage from './ErrorMessage'
 import Label from './Label'
 
 interface SwitchFieldProps {
@@ -25,7 +26,12 @@ export default function SwitchField({
   hasValue = false
 }: SwitchFieldProps) {
   const [isEnabled, setIsEnabled] = useState(false)
-  const { register, setValue } = useFormContext()
+  const {
+    register,
+    setValue,
+    trigger,
+    formState: { errors }
+  } = useFormContext()
 
   useEffect(() => {
     setIsEnabled(hasValue)
@@ -55,7 +61,9 @@ export default function SwitchField({
               'h-[36px] w-[380px]',
               '[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
             )}
-            {...register(name)}
+            {...register(name, {
+              onChange: () => trigger(name)
+            })}
           />
         ) : (
           <Textarea
@@ -65,6 +73,9 @@ export default function SwitchField({
             {...register(name)}
           />
         ))}
+      {isEnabled && errors['invitationCode'] && (
+        <ErrorMessage message="The invitation code must be a 6-digit number" />
+      )}
     </div>
   )
 }

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -198,16 +198,14 @@ export default function Page() {
                 <DescriptionForm name="description" />
               )}
             </FormSection>
-            {getValues('invitationCode') && (
-              <SwitchField
-                name="invitationCode"
-                title="Invitation Code"
-                type="number"
-                isInput={true}
-                placeholder="Enter a invitation code"
-                hasValue={showInvitationCode}
-              />
-            )}
+            <SwitchField
+              name="invitationCode"
+              title="Invitation Code"
+              type="number"
+              isInput={true}
+              placeholder="Enter a invitation code"
+              hasValue={showInvitationCode}
+            />
 
             <div className="flex flex-col gap-1">
               <div className="flex items-center justify-between">


### PR DESCRIPTION
### Description
1. Contest Create에서 invitation code 필드가 안 보였던 버그 해결
2. invitation code에 입력된 내용이 숫자 6자가 아닐 때 에러 메시지 상시 표시
![image](https://github.com/user-attachments/assets/541f71a6-e008-493e-a8cc-c2bfb9ccf846)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-568
Closes TAS-737
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
