### PR TITLE
fix(fe): fix contest card server error

### DIFF
--- a/apps/frontend/app/(main)/_components/ContestCards.tsx
+++ b/apps/frontend/app/(main)/_components/ContestCards.tsx
@@ -16,23 +16,7 @@ const getContests = async () => {
   data.upcoming.forEach((contest) => {
     contest.status = 'upcoming'
   })
-  let contests = data.ongoing.concat(data.upcoming)
-
-  if (contests.length < 3) {
-    const data: {
-      finished: Contest[]
-    } = await fetcher
-      .get('contest/finished', {
-        searchParams: {
-          take: 3
-        }
-      })
-      .json()
-    data.finished.forEach((contest) => {
-      contest.status = 'finished'
-    })
-    contests = contests.concat(data.finished)
-  }
+  const contests = data.ongoing.concat(data.upcoming)
 
   return contests.slice(0, 3)
 }
@@ -42,26 +26,26 @@ export default async function ContestCards() {
 
   return (
     <>
-      <div className="flex justify-between gap-5 xl:hidden">
+      <div className="flex justify-start gap-5 md:hidden">
         {contests.slice(0, 2).map((contest) => {
           return (
             <Link
               key={contest.id}
               href={`/contest/${contest.id}` as Route}
-              className="inline-block w-full"
+              className="inline-block w-1/2"
             >
               <ContestCard contest={contest} />
             </Link>
           )
         })}
       </div>
-      <div className="hidden justify-between gap-5 xl:flex">
+      <div className="hidden justify-start gap-5 md:flex">
         {contests.map((contest) => {
           return (
             <Link
               key={contest.id}
               href={`/contest/${contest.id}` as Route}
-              className="inline-block w-full"
+              className="inline-block w-1/3"
             >
               <ContestCard contest={contest} />
             </Link>

--- a/apps/frontend/app/(main)/_components/ProblemCards.tsx
+++ b/apps/frontend/app/(main)/_components/ProblemCards.tsx
@@ -40,7 +40,7 @@ export default function ProblemCards() {
 
   return (
     <>
-      <div className="flex justify-between gap-5 xl:hidden">
+      <div className="flex justify-start gap-5 md:hidden">
         {loading
           ? [...Array(2)].map((_, i) => (
               <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
@@ -50,14 +50,14 @@ export default function ProblemCards() {
                 <Link
                   key={problem.id}
                   href={`/problem/${problem.id}` as Route}
-                  className="inline-block w-full"
+                  className="inline-block w-1/2"
                 >
                   <ProblemCard problem={problem} />
                 </Link>
               )
             })}
       </div>
-      <div className="hidden justify-between gap-5 xl:flex">
+      <div className="hidden justify-start gap-5 md:flex">
         {loading
           ? [...Array(3)].map((_, i) => (
               <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
@@ -67,7 +67,7 @@ export default function ProblemCards() {
                 <Link
                   key={problem.id}
                   href={`/problem/${problem.id}` as Route}
-                  className="inline-block w-full"
+                  className="inline-block w-1/3"
                 >
                   <ProblemCard problem={problem} />
                 </Link>


### PR DESCRIPTION
### Description

나타나는 Contest Card가 2개이하일때 나타나는 Server Error 해결했습니다.

### Additional context
앞으로 Finished인 Contest는 ContestCard로 나타나지 않습니다.

추가로 ContestCard, ProblemCard가 2개 이하일때 카드 배칙를 바꿨습니다!
- 앞쪽부터 차례대로 정렬되게 바꿨습니다


closes TAS-715
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
