### PR TITLE
chore(fe): make safeFetcher that throws http error

### DIFF
--- a/apps/frontend/lib/auth/authorize.ts
+++ b/apps/frontend/lib/auth/authorize.ts
@@ -1,5 +1,5 @@
 import type { User } from 'next-auth'
-import { fetcher } from '../utils'
+import { safeFetcher } from '../utils'
 import { getJWTFromResponse } from './getJWTFromResponse'
 
 /**
@@ -13,7 +13,7 @@ export const authorize = async <C extends Record<string, string>>(
   // Try to login with the credential.
   try {
     // Login with the credential and get JWT from the response.
-    const loginResponse = await fetcher.post('auth/login', {
+    const loginResponse = await safeFetcher.post('auth/login', {
       json: {
         username: credential?.username,
         password: credential?.password
@@ -27,7 +27,7 @@ export const authorize = async <C extends Record<string, string>>(
     } = getJWTFromResponse(loginResponse)
 
     // Get user data for getting user role.
-    const userResponse = await fetcher.get('user', {
+    const userResponse = await safeFetcher.get('user', {
       headers: {
         Authorization: accessToken
       }

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -56,48 +56,12 @@ export const fetcherWithAuth = fetcher.extend({
 })
 
 // difference with fetcher: "throws" http error (must handle error when using)
-export const safeFetcher = ky.create({
-  prefixUrl: baseUrl,
-  retry: 0,
-  timeout: 5000,
-  hooks: {
-    beforeError: [
-      (error) => {
-        if (error instanceof TimeoutError) {
-          toast.error('Request timed out. Please try again later.')
-        }
-        return error
-      }
-    ]
-  }
+export const safeFetcher = fetcher.extend({
+  throwHttpErrors: true
 })
 
-export const safeFetcherWithAuth = safeFetcher.extend({
-  hooks: {
-    beforeRequest: [
-      async (request) => {
-        // Add access token to request header if user is logged in.
-        const session = await auth()
-        if (session)
-          request.headers.set('Authorization', session.token.accessToken)
-      }
-    ],
-    afterResponse: [
-      // Retry option is not working, so we use this workaround.
-      async (request, options, response) => {
-        if (response.status === 401) {
-          const session = await auth()
-          if (session) {
-            request.headers.set('Authorization', session.token.accessToken)
-            fetcher(request, {
-              ...options,
-              hooks: {} // Remove hooks to prevent infinite loop.
-            })
-          }
-        }
-      }
-    ]
-  }
+export const safeFetcherWithAuth = fetcherWithAuth.extend({
+  throwHttpErrors: true
 })
 
 export const convertToLetter = (n: number) => {

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -14,6 +14,7 @@ export const fetcher = ky.create({
   prefixUrl: baseUrl,
   retry: 0,
   timeout: 5000,
+  throwHttpErrors: false,
   hooks: {
     beforeError: [
       (error) => {
@@ -27,6 +28,51 @@ export const fetcher = ky.create({
 })
 
 export const fetcherWithAuth = fetcher.extend({
+  hooks: {
+    beforeRequest: [
+      async (request) => {
+        // Add access token to request header if user is logged in.
+        const session = await auth()
+        if (session)
+          request.headers.set('Authorization', session.token.accessToken)
+      }
+    ],
+    afterResponse: [
+      // Retry option is not working, so we use this workaround.
+      async (request, options, response) => {
+        if (response.status === 401) {
+          const session = await auth()
+          if (session) {
+            request.headers.set('Authorization', session.token.accessToken)
+            fetcher(request, {
+              ...options,
+              hooks: {} // Remove hooks to prevent infinite loop.
+            })
+          }
+        }
+      }
+    ]
+  }
+})
+
+// difference with fetcher: "throws" http error (must handle error when using)
+export const safeFetcher = ky.create({
+  prefixUrl: baseUrl,
+  retry: 0,
+  timeout: 5000,
+  hooks: {
+    beforeError: [
+      (error) => {
+        if (error instanceof TimeoutError) {
+          toast.error('Request timed out. Please try again later.')
+        }
+        return error
+      }
+    ]
+  }
+})
+
+export const safeFetcherWithAuth = safeFetcher.extend({
   hooks: {
     beforeRequest: [
       async (request) => {


### PR DESCRIPTION
### Description

API Fetch 중 에러가 발생할 경우 res를 반환하지 않고 http error를 throw하는 safeFetcher를 구현합니다.
기존 fetcher는 `!res.ok`일 경우 에러 핸들링을 했지만, 
safeFetcher는 try catch나 error.tsx등을 통해서 에러 핸들링을 하도록 개선합니다.
점진적으로 기존 fetcher를 safeFetcher로 개선합니다. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
