### PR TITLE
fix(be): modify sandbox python version and judge result cpu-time

### DIFF
--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -505,7 +505,7 @@ export class SubmissionService {
           ...result,
           // TODO: 채점 속도가 너무 빠른경우에 대한 수정 필요 (0ms 미만)
           cpuTime:
-            result.cpuTime && result.cpuTime === BigInt(0)
+            result.cpuTime || result.cpuTime === BigInt(0)
               ? result.cpuTime.toString()
               : null
         }

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -503,7 +503,11 @@ export class SubmissionService {
       const results = submission.submissionResult.map((result) => {
         return {
           ...result,
-          cpuTime: result.cpuTime ? result.cpuTime.toString() : null
+          // TODO: 채점 속도가 너무 빠른경우에 대한 수정 필요 (0ms 미만)
+          cpuTime:
+            result.cpuTime && result.cpuTime === BigInt(0)
+              ? result.cpuTime.toString()
+              : null
         }
       })
 

--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -468,7 +468,7 @@ describe('SubmissionService', () => {
         return {
           ...result,
           cpuTime:
-            result.cpuTime && result.cpuTime === BigInt(0)
+            result.cpuTime || result.cpuTime === BigInt(0)
               ? result.cpuTime.toString()
               : null
         }

--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -467,7 +467,10 @@ describe('SubmissionService', () => {
       const testcaseResult = submissionResults.map((result) => {
         return {
           ...result,
-          cpuTime: result.cpuTime ? result.cpuTime.toString() : null
+          cpuTime:
+            result.cpuTime && result.cpuTime === BigInt(0)
+              ? result.cpuTime.toString()
+              : null
         }
       })
 

--- a/apps/iris/Dockerfile
+++ b/apps/iris/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=builder /build/iris .
 
 # Install dependencies
 RUN apt update && apt install -y \
-  curl gcc g++ openjdk-17-jdk python3 \
+  curl gcc g++ openjdk-17-jdk python3.9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install sandbox

--- a/apps/iris/Dockerfile
+++ b/apps/iris/Dockerfile
@@ -12,7 +12,6 @@ RUN go build
 FROM ubuntu:24.04
 ARG app_env
 
-
 ENV APP_ENV=${app_env}
 
 COPY --from=builder /build/iris .
@@ -21,6 +20,10 @@ COPY --from=builder /build/iris .
 RUN apt update && apt install -y \
   curl gcc g++ openjdk-17-jdk python3.9 \
   && rm -rf /var/lib/apt/lists/*
+
+# Set Python 3.9 as the default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1 \
+  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
 # Install sandbox
 RUN mkdir -p /app/sandbox/policy /app/sandbox/results \

--- a/apps/iris/go.mod
+++ b/apps/iris/go.mod
@@ -1,6 +1,6 @@
 module github.com/skkuding/codedang/apps/iris
 
-go 1.21
+go 1.23
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.4

--- a/apps/iris/src/service/sandbox/langConfig.go
+++ b/apps/iris/src/service/sandbox/langConfig.go
@@ -122,9 +122,10 @@ func NewLangConfig(file file.FileManager, javaPolicyPath string) *langConfig {
 	}
 
 	var pyConfig = config{
-		Language:              PYTHON,
-		SrcName:               "solution.py",
-		ExeName:               "__pycache__/solution.cpython-38.pyc", // TODO: 파이썬 버전 확인
+		Language: PYTHON,
+		SrcName:  "solution.py",
+		// [IMPORTANT] 도커 이미지 변경 시 파이썬 버전도 변경 필요함
+		ExeName:               "__pycache__/solution.cpython-39.pyc", // Default Version on Debian 11 (bullseye)
 		MaxCompileCpuTime:     3000,
 		MaxCompileRealTime:    10000,
 		MaxCompileMemory:      128 * 1024 * 1024,


### PR DESCRIPTION
### Description

1. 파이썬 버전 3.9로 통일
현재 devcontainer의 경우 Debian 11(bullseye) 기반 이미지를 사용중이라 3.9 버전을
stage 및 production 서버에 사용되는 iris 이미지의 경우 우분투 24.04 기반 이미지를 사용하고 있어서
개발환경 및 배포환경에서 파이썬 3.9 버전을 사용하도록 강제함

![image](https://github.com/user-attachments/assets/fff36358-ba2d-414e-b915-c3b49f028371)

2. cpuTime 로직 변경
채점 속도가 0ms 보다 빠른경우 null 이 아닌 0을 반환하도록 수정함



Close TAS-759

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
