### PR TITLE
chore(fe): change admin user list column header

### DIFF
--- a/apps/frontend/app/admin/user/_components/Columns.tsx
+++ b/apps/frontend/app/admin/user/_components/Columns.tsx
@@ -10,12 +10,12 @@ interface DataTableUser {
 export const columns: ColumnDef<DataTableUser>[] = [
   {
     accessorKey: 'userId',
-    header: 'ID',
+    header: '#',
     cell: ({ row }) => <div>{row.getValue('userId')}</div>
   },
   {
     accessorKey: 'username',
-    header: 'Username',
+    header: 'User ID',
     cell: ({ row }) => <div>{row.getValue('username')}</div>
   },
   {

--- a/apps/frontend/components/DataTablePagination.tsx
+++ b/apps/frontend/components/DataTablePagination.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from '@/lib/utils'
 import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons'
 import type { Table } from '@tanstack/react-table'
+import { usePathname } from 'next/navigation'
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>
@@ -25,8 +26,9 @@ export function DataTablePagination<TData>({
   return (
     <div className="flex items-center justify-between px-2">
       <div className="text-muted-foreground text-xs text-neutral-600">
-        {table.getFilteredSelectedRowModel().rows.length} of{' '}
-        {table.getFilteredRowModel().rows.length} row(s) selected
+        {usePathname().split('/').pop() !== 'user' &&
+          `${table.getFilteredSelectedRowModel().rows.length} of${' '}
+          ${table.getFilteredRowModel().rows.length} row(s) selected`}
       </div>
       <div className="flex gap-5">
         <button

--- a/apps/frontend/components/DataTablePagination.tsx
+++ b/apps/frontend/components/DataTablePagination.tsx
@@ -8,7 +8,6 @@ import {
 import { cn } from '@/lib/utils'
 import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons'
 import type { Table } from '@tanstack/react-table'
-import { usePathname } from 'next/navigation'
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>
@@ -26,7 +25,7 @@ export function DataTablePagination<TData>({
   return (
     <div className="flex items-center justify-between px-2">
       <div className="text-muted-foreground text-xs text-neutral-600">
-        {usePathname().split('/').pop() !== 'user' &&
+        {table.getColumn('select') &&
           `${table.getFilteredSelectedRowModel().rows.length} of${' '}
           ${table.getFilteredRowModel().rows.length} row(s) selected`}
       </div>


### PR DESCRIPTION
### Description

Admin User List의 column header 명칭을 수정하고, checkbox가 없는 관계로 테이블 왼쪽 하단의 ~row selected 문구를 삭제하였습니다!

Before:
![image](https://github.com/user-attachments/assets/926699d9-3811-4d35-91c0-dcb277880c07)

After:
![image](https://github.com/user-attachments/assets/b65cd158-32cf-441c-a3ac-b5bb3dc946fd)


텍스트를 백틱(``)으로 수정한 것은 paginationbar를 가운데 정렬할 때 justify-between 특성상 그냥 빈 div를 넣는 것이 간편할 것이라고 생각했기 때문입니다!

closes TAS-695

### Additional context

검색과 정렬 기능을 추가는 해야 할 것 같은데, 검색을 id, 이름, 이메일 중 무엇으로, 아니면 동시에 여러 개에서 해야 할지 정해야 할 것 같습니다!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
