### PR TITLE
feat(fe): show toast when copied

### DIFF
--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -9,6 +9,7 @@ import { tags as t } from '@lezer/highlight'
 import { createTheme } from '@uiw/codemirror-themes'
 import type { ReactCodeMirrorProps } from '@uiw/react-codemirror'
 import ReactCodeMirror, { EditorView } from '@uiw/react-codemirror'
+import { toast } from 'sonner'
 import { ScrollArea, ScrollBar } from './ui/scroll-area'
 
 const editorTheme = createTheme({
@@ -66,16 +67,25 @@ interface Props extends ReactCodeMirrorProps {
   enableCopyPaste?: boolean
 }
 
-const copyPasteHandler = () => {
+const copyPasteHandler = (enableCopyPaste: boolean) => {
   return EditorView.domEventHandlers({
     paste(event) {
-      event.preventDefault()
+      if (!enableCopyPaste) {
+        toast.error('Copying and pasting is not allowed')
+        event.preventDefault()
+      }
     },
     copy(event) {
-      event.preventDefault()
+      if (!enableCopyPaste) {
+        toast.error('Copying and pasting is not allowed')
+        event.preventDefault()
+      }
     },
     cut(event) {
-      event.preventDefault()
+      if (!enableCopyPaste) {
+        toast.error('Copying and pasting is not allowed')
+        event.preventDefault()
+      }
     }
   })
 }
@@ -95,7 +105,7 @@ export default function CodeEditor({
         extensions={[
           fontSize,
           languageParser[language](),
-          enableCopyPaste ? [] : [copyPasteHandler()]
+          copyPasteHandler(enableCopyPaste)
         ]}
         value={value}
         onChange={onChange}

--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -67,25 +67,19 @@ interface Props extends ReactCodeMirrorProps {
   enableCopyPaste?: boolean
 }
 
-const copyPasteHandler = (enableCopyPaste: boolean) => {
+const copyPasteHandler = () => {
   return EditorView.domEventHandlers({
     paste(event) {
-      if (!enableCopyPaste) {
-        toast.error('Copying and pasting is not allowed')
-        event.preventDefault()
-      }
+      toast.error('Copying and pasting is not allowed')
+      event.preventDefault()
     },
     copy(event) {
-      if (!enableCopyPaste) {
-        toast.error('Copying and pasting is not allowed')
-        event.preventDefault()
-      }
+      toast.error('Copying and pasting is not allowed')
+      event.preventDefault()
     },
     cut(event) {
-      if (!enableCopyPaste) {
-        toast.error('Copying and pasting is not allowed')
-        event.preventDefault()
-      }
+      toast.error('Copying and pasting is not allowed')
+      event.preventDefault()
     }
   })
 }
@@ -105,7 +99,7 @@ export default function CodeEditor({
         extensions={[
           fontSize,
           languageParser[language](),
-          copyPasteHandler(enableCopyPaste)
+          enableCopyPaste ? [] : copyPasteHandler()
         ]}
         value={value}
         onChange={onChange}

--- a/apps/frontend/components/EditorDescription.tsx
+++ b/apps/frontend/components/EditorDescription.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { renderKatex } from '@/lib/renderKatex'
 import { convertToLetter } from '@/lib/utils'
+import CopyIcon from '@/public/24_copy.svg'
 import compileIcon from '@/public/compileVersion.svg'
 import copyIcon from '@/public/copy.svg'
 import copyCompleteIcon from '@/public/copyComplete.svg'
@@ -27,6 +28,7 @@ import { FileText } from 'lucide-react'
 import Image from 'next/image'
 import { useState, useEffect, useRef } from 'react'
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard'
+import { toast } from 'sonner'
 import {
   Tooltip,
   TooltipContent,
@@ -158,6 +160,17 @@ export function EditorDescription({
                               <Image
                                 onClick={() => {
                                   copy(input + '\n\n', `input-${id}`) // add newline to the end for easy testing
+                                  toast('Successfully copied', {
+                                    unstyled: true,
+                                    closeButton: false,
+                                    icon: <Image src={CopyIcon} alt="copy" />,
+                                    style: { backgroundColor: '#f0f8ff' },
+                                    classNames: {
+                                      toast:
+                                        'inline-flex items-center py-2 px-3 rounded gap-2',
+                                      title: 'text-primary font-medium'
+                                    }
+                                  })
                                 }}
                                 className="cursor-pointer transition-opacity hover:opacity-60"
                                 src={copyIcon}
@@ -210,6 +223,17 @@ export function EditorDescription({
                               <Image
                                 onClick={() => {
                                   copy(output + '\n\n', `output-${id}`) // add newline to the end for easy testing
+                                  toast('Successfully copied', {
+                                    unstyled: true,
+                                    closeButton: false,
+                                    icon: <Image src={CopyIcon} alt="copy" />,
+                                    style: { backgroundColor: '#f0f8ff' },
+                                    classNames: {
+                                      toast:
+                                        'inline-flex items-center py-2 px-3 rounded gap-2',
+                                      title: 'text-primary font-medium'
+                                    }
+                                  })
                                 }}
                                 className="cursor-pointer transition-opacity hover:opacity-60"
                                 src={copyIcon}

--- a/apps/frontend/public/24_copy.svg
+++ b/apps/frontend/public/24_copy.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5.5 15.5V4.5H13.5V5.5H15V4C15 3.44772 14.5523 3 14 3H5C4.44772 3 4 3.44772 4 4V16C4 16.5523 4.44771 17 5 17H7.5V15.5H5.5Z" fill="#0973DC"/>
+  <mask id="path-2-inside-1_1703_6208" fill="white">
+    <rect x="9" y="7" width="11" height="14" rx="1"/>
+  </mask>
+  <rect x="9" y="7" width="11" height="14" rx="1" stroke="#0973DC" stroke-width="3" mask="url(#path-2-inside-1_1703_6208)"/>
+</svg>


### PR DESCRIPTION
### Description

Problem Description의 Input이나 Output의 복사 버튼을 눌렀을 때 토스트가 뜨도록 하였고, 복붙이 막혀있는 Contest의 대회에서 복사, 붙여넣기, 잘라내기를 했을 때도 토스트가 뜨도록 변경하였습니다..!

closes TAS-538

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
