### PR TITLE
fix(be): change import problem transaction error logic

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.spec.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.spec.ts
@@ -4,7 +4,6 @@ import { ContestProblem, Group, ContestRecord } from '@generated'
 import { Problem } from '@generated'
 import { Contest } from '@generated'
 import { faker } from '@faker-js/faker'
-import { Prisma } from '@prisma/client'
 import type { Cache } from 'cache-manager'
 import { expect } from 'chai'
 import { stub } from 'sinon'
@@ -181,7 +180,8 @@ const db = {
   },
   contestProblem: {
     create: stub().resolves(ContestProblem),
-    findMany: stub().resolves([ContestProblem])
+    findMany: stub().resolves([ContestProblem]),
+    findFirst: stub().resolves(ContestProblem)
   },
   contestRecord: {
     findMany: stub().resolves([ContestRecord]),
@@ -189,6 +189,7 @@ const db = {
   },
   problem: {
     update: stub().resolves(Problem),
+    updateMany: stub().resolves([Problem]),
     findFirstOrThrow: stub().resolves(Problem)
   },
   group: {
@@ -327,6 +328,7 @@ describe('ContestService', () => {
       db.contest.findUnique.resolves(contest)
       db.problem.update.resolves(problem)
       db.contestProblem.create.resolves(contestProblem)
+      db.contestProblem.findFirst.resolves(null)
 
       const res = await Promise.all(
         await service.importProblemsToContest(groupId, contestId, [
@@ -340,12 +342,7 @@ describe('ContestService', () => {
     it('should return an empty array when the problem already exists in contest', async () => {
       db.contest.findUnique.resolves(contest)
       db.problem.update.resolves(problem)
-      db.contestProblem.create.throws(
-        new Prisma.PrismaClientKnownRequestError(
-          'ContestProblem already exists',
-          { code: 'P2002', clientVersion: 'version' }
-        )
-      )
+      db.contestProblem.findFirst.resolves(ContestProblem)
 
       const res = await service.importProblemsToContest(groupId, contestId, [
         problemIdsWithScore

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -359,24 +359,27 @@ export class ContestService {
     const contestProblems: ContestProblem[] = []
 
     for (const { problemId, score } of problemIdsWithScore) {
-      const [contestProblem] = await this.prisma.$transaction([
-        this.prisma.contestProblem.upsert({
+      const isProblemAlreadyImported =
+        await this.prisma.contestProblem.findFirst({
           where: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            contestId_problemId: {
-              contestId,
-              problemId
-            }
-          },
-          create: {
+            contestId,
+            problemId
+          }
+        })
+      if (isProblemAlreadyImported) {
+        continue
+      }
+
+      const [contestProblem] = await this.prisma.$transaction([
+        this.prisma.contestProblem.create({
+          data: {
             // 원래 id: 'temp'이었는데, contestProblem db schema field가 바뀌어서
             // 임시 방편으로 order: 0으로 설정합니다.
             order: 0,
             contestId,
             problemId,
             score
-          },
-          update: {}
+          }
         }),
         this.prisma.problem.updateMany({
           where: {

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -359,48 +359,52 @@ export class ContestService {
     const contestProblems: ContestProblem[] = []
 
     for (const { problemId, score } of problemIdsWithScore) {
-      try {
-        const [contestProblem] = await this.prisma.$transaction([
-          this.prisma.contestProblem.create({
-            data: {
-              // 원래 id: 'temp'이었는데, contestProblem db schema field가 바뀌어서
-              // 임시 방편으로 order: 0으로 설정합니다.
-              order: 0,
+      const [contestProblem] = await this.prisma.$transaction([
+        this.prisma.contestProblem.upsert({
+          where: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            contestId_problemId: {
               contestId,
-              problemId,
-              score
+              problemId
             }
-          }),
-          this.prisma.problem.update({
-            where: {
-              id: problemId,
-              OR: [
-                {
-                  visibleLockTime: {
-                    equals: MIN_DATE
-                  }
-                },
-                {
-                  visibleLockTime: {
-                    equals: MAX_DATE
-                  }
-                },
-                {
-                  visibleLockTime: {
-                    lte: contest.endTime
-                  }
+          },
+          create: {
+            // 원래 id: 'temp'이었는데, contestProblem db schema field가 바뀌어서
+            // 임시 방편으로 order: 0으로 설정합니다.
+            order: 0,
+            contestId,
+            problemId,
+            score
+          },
+          update: {}
+        }),
+        this.prisma.problem.updateMany({
+          where: {
+            id: problemId,
+            OR: [
+              {
+                visibleLockTime: {
+                  equals: MIN_DATE
                 }
-              ]
-            },
-            data: {
-              visibleLockTime: contest.endTime
-            }
-          })
-        ])
-        contestProblems.push(contestProblem)
-      } catch (error) {
-        continue
-      }
+              },
+              {
+                visibleLockTime: {
+                  equals: MAX_DATE
+                }
+              },
+              {
+                visibleLockTime: {
+                  lte: contest.endTime
+                }
+              }
+            ]
+          },
+          data: {
+            visibleLockTime: contest.endTime
+          }
+        })
+      ])
+      contestProblems.push(contestProblem)
     }
 
     return contestProblems
@@ -424,64 +428,60 @@ export class ContestService {
     const contestProblems: ContestProblem[] = []
 
     for (const problemId of problemIds) {
-      try {
-        // 문제가 포함된 대회 중 가장 늦게 끝나는 대회의 종료시각으로 visibleLockTime 설정 (없을시 비공개 전환)
-        let visibleLockTime = MAX_DATE
+      // 문제가 포함된 대회 중 가장 늦게 끝나는 대회의 종료시각으로 visibleLockTime 설정 (없을시 비공개 전환)
+      let visibleLockTime = MAX_DATE
 
-        const contestIds = (
-          await this.prisma.contestProblem.findMany({
-            where: {
+      const contestIds = (
+        await this.prisma.contestProblem.findMany({
+          where: {
+            problemId
+          }
+        })
+      )
+        .filter((contestProblem) => contestProblem.contestId !== contestId)
+        .map((contestProblem) => contestProblem.contestId)
+
+      if (contestIds.length) {
+        const latestContest = await this.prisma.contest.findFirstOrThrow({
+          where: {
+            id: {
+              in: contestIds
+            }
+          },
+          orderBy: {
+            endTime: 'desc'
+          },
+          select: {
+            endTime: true
+          }
+        })
+        visibleLockTime = latestContest.endTime
+      }
+
+      const [, contestProblem] = await this.prisma.$transaction([
+        this.prisma.problem.updateMany({
+          where: {
+            id: problemId,
+            visibleLockTime: {
+              lte: contest.endTime
+            }
+          },
+          data: {
+            visibleLockTime
+          }
+        }),
+        this.prisma.contestProblem.delete({
+          where: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            contestId_problemId: {
+              contestId,
               problemId
             }
-          })
-        )
-          .filter((contestProblem) => contestProblem.contestId !== contestId)
-          .map((contestProblem) => contestProblem.contestId)
+          }
+        })
+      ])
 
-        if (contestIds.length) {
-          const latestContest = await this.prisma.contest.findFirstOrThrow({
-            where: {
-              id: {
-                in: contestIds
-              }
-            },
-            orderBy: {
-              endTime: 'desc'
-            },
-            select: {
-              endTime: true
-            }
-          })
-          visibleLockTime = latestContest.endTime
-        }
-
-        const [, contestProblem] = await this.prisma.$transaction([
-          this.prisma.problem.updateMany({
-            where: {
-              id: problemId,
-              visibleLockTime: {
-                lte: contest.endTime
-              }
-            },
-            data: {
-              visibleLockTime
-            }
-          }),
-          this.prisma.contestProblem.delete({
-            where: {
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              contestId_problemId: {
-                contestId,
-                problemId
-              }
-            }
-          })
-        ])
-
-        contestProblems.push(contestProblem)
-      } catch (error) {
-        continue
-      }
+      contestProblems.push(contestProblem)
     }
 
     return contestProblems


### PR DESCRIPTION
### Description

1. import problem api 에서 이미 contest에 속한 problem을 import하려고 하면, 기존 대회 endTime보다 새로 import할 대회의 endTime이 더 나중일 경우에만 problem의 visibleLockTime update됩니다. 만약 그렇지 않을 경우, problem.update는 에러를 throw합니다. 이렇게 에러를 throw할 경우, contestProblem.create도 transaction으로 묶여있기 때문에 contestProblem.create도 같이 롤백됩니다.
정상적인 로직이라면 problem.update는 실패하더라도 contestProblem.create는 성공해야합니다. 이에 따라, update가 아닌 updateMany를 사용하여 where 조건에 걸리는 record가 하나도 없더라도 에러를 반환하지 않습니다. 

2. 이 문제의 디버깅이 매우 어려웠던 이유는 DB 업데이트에서 오류가 나더라도 에러를 잘 핸들링하는 것이 아니라 `continue` 했기 때문이 큽니다. 에러를 suppress하는 것은 문제를 찾는 데에 큰 어려움을 줍니다. 따라서, contestProblem을 create 하기 전 contestProblem이 이미 있는지 확인하고, update대신 updateMany로 바꿉니다. suppress하기 위해 들어가 있는 try catch문을 없앱니다. 
이 경우 에러가 나지 않고 response로 새로 추가된 contestProblem이 반환되므로, 프론트에서도 정보를 더 잘 활용할 수 있을 것입니다. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
