### PR TITLE
fix(fe): admin role doesn't have to update studentId and major

### DIFF
--- a/apps/frontend/app/(main)/settings/page.tsx
+++ b/apps/frontend/app/(main)/settings/page.tsx
@@ -134,7 +134,7 @@ export default function Page() {
       currentPassword: '',
       newPassword: '',
       confirmPassword: '',
-      realName: defaultProfileValues.userProfile.realName,
+      realName: defaultProfileValues.userProfile?.realName ?? '',
       studentId: defaultProfileValues.studentId
     }
   })
@@ -217,7 +217,7 @@ export default function Page() {
     try {
       // 필요 없는 필드 제외 (defaultProfileValues와 값이 같은 것들은 제외)
       const updatePayload: UpdatePayload = {}
-      if (data.realName !== defaultProfileValues.userProfile.realName) {
+      if (data.realName !== defaultProfileValues.userProfile?.realName) {
         updatePayload.realName = data.realName
       }
       if (majorValue !== defaultProfileValues.major) {
@@ -252,7 +252,7 @@ export default function Page() {
     return () => {
       // submit 되기위해, watch로 확인되는 값이 default값과 같으면 setValue를 통해서 defaultProfileValues로 변경
       if (realName === '') {
-        setValue('realName', defaultProfileValues.userProfile.realName)
+        setValue('realName', defaultProfileValues.userProfile?.realName)
       }
       if (majorValue === defaultProfileValues.major) {
         setMajorValue(defaultProfileValues.major)
@@ -458,7 +458,9 @@ export default function Page() {
         <label className="-mb-4 text-xs">Name</label>
         <Input
           placeholder={
-            isLoading ? 'Loading...' : defaultProfileValues.userProfile.realName
+            isLoading
+              ? 'Loading...'
+              : defaultProfileValues.userProfile?.realName
           }
           {...register('realName')}
           className={`${realName && (errors.realName ? 'border-red-500' : 'border-primary')} placeholder:text-neutral-300 focus-visible:ring-0`}

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -47,11 +47,11 @@ export default function HeaderAuthPanel({
   useEffect(() => {
     const checkIfNeedsUpdate = async () => {
       const userResponse = await fetcherWithAuth.get('user')
-      const user: { studentId: string; major: string } =
+      const user: { role: string; studentId: string; major: string } =
         await userResponse.json()
       const updateNeeded =
-        user.studentId === '0000000000' ||
-        user.major === 'Department Information Unavailable / 학과 정보 없음'
+        user.role === 'User' &&
+        (user.studentId === '0000000000' || user.major === 'none')
 
       setNeedsUpdate(updateNeeded)
     }


### PR DESCRIPTION
### Description

프로덕션의 Admin role의 유저들은 옛날에 생성되었으므로 studentId, major, realName을 가지지 않습니다.
Admin user는 이런 정보를 가지지 않으므로, update user info modal을 띄우지 않습니다.

settings 페이지에서 userProfile.realName이 없더라도 렌더링 오류가 나지 않도록 변경합니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
