### PR TITLE
feat(be): calculate score based on latest submission only

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -596,6 +596,9 @@ export class ContestService {
         where: {
           userId,
           contestId
+        },
+        orderBy: {
+          createTime: 'desc'
         }
       }),
       this.prisma.contestRecord.findFirst({
@@ -614,35 +617,36 @@ export class ContestService {
       throw new EntityNotExistException('contestRecord')
     }
 
-    // 하나의 Problem에 대해 여러 개의 Submission이 존재한다면, 더 높은 점수를 갖는 Submission을 반영함
-    const highestScoreSubmissions: {
+    // 하나의 Problem에 대해 여러 개의 Submission이 존재한다면, 마지막에 제출된 Submission만을 점수 계산에 반영함
+    const latestSubmissions: {
       [problemId: string]: {
         result: ResultStatus
-        score: number // Problem에서 획득한 점수
+        score: number // Problem에서 획득한 점수 (maxScore 만점 기준)
+        maxScore: number // Contest에서 Problem이 갖는 배점(만점)
       }
-    } = this.getHighestScoreSubmissions(submissions)
+    } = await this.getlatestSubmissions(submissions)
 
     const problemScores: {
       problemId: number
       score: number
+      maxScore: number
     }[] = []
 
-    for (const problemId in highestScoreSubmissions) {
+    for (const problemId in latestSubmissions) {
       problemScores.push({
         problemId: parseInt(problemId),
-        score: highestScoreSubmissions[problemId].score
+        score: latestSubmissions[problemId].score,
+        maxScore: latestSubmissions[problemId].maxScore
       })
     }
 
-    const userContestScore = await this.calculateUserContestScore(
-      contestId,
-      problemScores
-    )
-
     const scoreSummary = {
-      submittedProblemCount: Object.keys(highestScoreSubmissions).length, // Contest에 존재하는 문제 중 제출된 문제의 개수
+      submittedProblemCount: Object.keys(latestSubmissions).length, // Contest에 존재하는 문제 중 제출된 문제의 개수
       totalProblemCount: contestProblems.length, // Contest에 존재하는 Problem의 총 개수
-      userContestScore, // Contest에서 유저가 받은 점수
+      userContestScore: problemScores.reduce(
+        (total, { score }) => total + score,
+        0
+      ), // Contest에서 유저가 받은 점수
       contestPerfectScore: contestProblems.reduce(
         (total, { score }) => total + score,
         0
@@ -653,69 +657,39 @@ export class ContestService {
     return scoreSummary
   }
 
-  getHighestScoreSubmissions(submissions: Submission[]) {
-    const highestScoreSubmissions: {
+  async getlatestSubmissions(submissions: Submission[]) {
+    const latestSubmissions: {
       [problemId: string]: {
         result: ResultStatus
-        score: number // Problem에서 획득한 점수 (100점 만점 기준)
+        score: number // Problem에서 획득한 점수
+        maxScore: number // Contest에서 Problem이 갖는 배점
       }
     } = {}
 
     for (const submission of submissions) {
       const problemId = submission.problemId
+      if (problemId in latestSubmissions) continue
 
-      if (
-        !(problemId in highestScoreSubmissions) ||
-        (highestScoreSubmissions[problemId].result !== ResultStatus.Accepted &&
-          submission.result === ResultStatus.Accepted)
-      ) {
-        highestScoreSubmissions[problemId] = {
-          result: ResultStatus.Accepted,
-          score: 100
-        }
-      } else {
-        const currentScore = highestScoreSubmissions[problemId].score
-
-        if (submission.score > currentScore) {
-          highestScoreSubmissions[problemId] = {
-            result: submission.result as ResultStatus,
-            score: submission.score
-          }
-        }
-      }
-    }
-
-    return highestScoreSubmissions
-  }
-
-  async calculateUserContestScore(
-    contestId: number,
-    problemScores: {
-      problemId: number
-      score: number
-    }[]
-  ) {
-    let userContestScore = 0
-    for (const problemScore of problemScores) {
-      const contestProblemScore = (
+      const maxScore = (
         await this.prisma.contestProblem.findUniqueOrThrow({
           where: {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             contestId_problemId: {
-              contestId,
-              problemId: problemScore.problemId
+              contestId: submission.contestId!,
+              problemId: submission.problemId
             }
-          },
-          select: {
-            score: true
           }
         })
       ).score
 
-      userContestScore += contestProblemScore * (problemScore.score / 100)
+      latestSubmissions[problemId] = {
+        result: submission.result as ResultStatus,
+        score: (submission.score / 100) * maxScore, // contest에 할당된 Problem의 총점에 맞게 계산
+        maxScore
+      }
     }
 
-    return userContestScore
+    return latestSubmissions
   }
 
   async getContestsByProblemId(problemId: number) {

--- a/apps/backend/apps/admin/src/contest/model/score-summary.ts
+++ b/apps/backend/apps/admin/src/contest/model/score-summary.ts
@@ -1,4 +1,4 @@
-import { Field, Int, ObjectType } from '@nestjs/graphql'
+import { Field, Float, Int, ObjectType } from '@nestjs/graphql'
 
 @ObjectType()
 export class UserContestScoreSummary {
@@ -8,7 +8,7 @@ export class UserContestScoreSummary {
   @Field(() => Int)
   totalProblemCount: number
 
-  @Field(() => Int)
+  @Field(() => Float)
   userContestScore: number
 
   @Field(() => Int)
@@ -23,6 +23,9 @@ class ProblemScore {
   @Field(() => Int)
   problemId: number
 
-  @Field(() => Int)
+  @Field(() => Float)
   score: number
+
+  @Field(() => Int)
+  maxScore: number
 }

--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -16,10 +16,7 @@ import {
   RESULT_QUEUE,
   Status
 } from '@libs/constants'
-import {
-  EntityNotExistException,
-  UnprocessableDataException
-} from '@libs/exception'
+import { UnprocessableDataException } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
 import { JudgerResponse } from './class/judger-response.dto'
 
@@ -219,7 +216,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
     if (submission.userId && submission.contestId)
       await this.calculateSubmissionScore(submission, allAccepted)
 
-    await this.calculateProblemScore(submission.id)
+    await this.updateProblemScore(submission.id)
     await this.updateProblemAccepted(submission.problemId, allAccepted)
   }
 
@@ -290,8 +287,8 @@ export class SubmissionSubscriptionService implements OnModuleInit {
     })
   }
 
-  async calculateProblemScore(id: number) {
-    const submission = await this.prisma.submission.findFirst({
+  async updateProblemScore(id: number) {
+    const submission = await this.prisma.submission.findUniqueOrThrow({
       where: {
         id
       },
@@ -305,14 +302,10 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       }
     })
 
-    if (!submission) {
-      throw new EntityNotExistException('submission')
-    }
-
-    let newScore = 0
+    let score = 0
     submission.submissionResult.map((submissionResult) => {
       if (submissionResult.result === 'Accepted') {
-        newScore += submissionResult.problemTestcase.scoreWeight
+        score += submissionResult.problemTestcase.scoreWeight
       }
     })
 
@@ -321,7 +314,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
         id
       },
       data: {
-        score: newScore
+        score
       }
     })
   }

--- a/apps/backend/apps/client/src/submission/test/submission-sub.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission-sub.service.spec.ts
@@ -340,7 +340,7 @@ describe('SubmissionSubscriptionService', () => {
         .stub(service, 'calculateSubmissionScore')
         .resolves()
       const problemScoreSpy = sandbox
-        .stub(service, 'calculateProblemScore')
+        .stub(service, 'updateProblemScore')
         .resolves()
       const acceptSpy = sandbox
         .stub(service, 'updateProblemAccepted')
@@ -417,7 +417,7 @@ describe('SubmissionSubscriptionService', () => {
         service,
         'calculateSubmissionScore'
       )
-      const problemScoreSpy = sandbox.stub(service, 'calculateProblemScore')
+      const problemScoreSpy = sandbox.stub(service, 'updateProblemScore')
 
       await service.updateSubmissionResult(1)
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
closes TAS-788

같은 문제에 대해 여러번의 submission이 있었을 때, 점수 계산의 기준을 "가장 높은 점수를 획득한 Submission" 에서 "마지막에 제출한 Submission" 으로 변경합니다.

추가로, 점수 계산 시 각 문제의 획득 점수가 무조건 100으로 표시되는 오류를 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
