### PR TITLE
fix(fe): change settings page for update now

### DIFF
--- a/apps/frontend/app/(main)/settings/page.tsx
+++ b/apps/frontend/app/(main)/settings/page.tsx
@@ -25,7 +25,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import type { Route } from 'next'
 import type { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useEffect } from 'react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -58,33 +58,28 @@ type UpdatePayload = Partial<{
   major: string
 }>
 
-// const schemaUpdate = z.object({
-//   studentId: z.string().optional(),
-//   password: z.string().optional(),
-//   newPassword: z.string().optional(),
-//   realName: z.string().optional(),
-//   major: z.string().optional()
-// })
-
-const schemaSettings = z.object({
-  currentPassword: z.string().min(1, { message: 'Required' }).optional(),
-  newPassword: z
-    .string()
-    .min(1)
-    .min(8)
-    .max(20)
-    .refine((data) => {
-      const invalidPassword = /^([a-z]*|[A-Z]*|[0-9]*|[^a-zA-Z0-9]*)$/
-      return !invalidPassword.test(data)
-    })
-    .optional(),
-  confirmPassword: z.string().optional(),
-  realName: z
-    .string()
-    .regex(/^[a-zA-Z\s]+$/, { message: 'Only English Allowed' })
-    .optional(),
-  studentId: z.string().optional()
-})
+const schemaSettings = (updateNow: boolean) =>
+  z.object({
+    currentPassword: z.string().min(1, { message: 'Required' }).optional(),
+    newPassword: z
+      .string()
+      .min(1)
+      .min(8)
+      .max(20)
+      .refine((data) => {
+        const invalidPassword = /^([a-z]*|[A-Z]*|[0-9]*|[^a-zA-Z0-9]*)$/
+        return !invalidPassword.test(data)
+      })
+      .optional(),
+    confirmPassword: z.string().optional(),
+    realName: z
+      .string()
+      .regex(/^[a-zA-Z\s]+$/, { message: 'Only English Allowed' })
+      .optional(),
+    studentId: updateNow
+      ? z.string().regex(/^\d{10}$/, { message: 'Only 10 numbers' })
+      : z.string().optional()
+  })
 
 function requiredMessage(message?: string) {
   return (
@@ -95,6 +90,9 @@ function requiredMessage(message?: string) {
 }
 
 export default function Page() {
+  const searchParams = useSearchParams()
+  const updateNow = searchParams.get('updateNow')
+
   const [defaultProfileValues, setdefaultProfileValues] = useState<getProfile>({
     username: '',
     userProfile: {
@@ -128,7 +126,7 @@ export default function Page() {
     watch,
     formState: { errors, isDirty }
   } = useForm<SettingsFormat>({
-    resolver: zodResolver(schemaSettings),
+    resolver: zodResolver(schemaSettings(updateNow === 'true')),
     mode: 'onChange',
     defaultValues: {
       currentPassword: '',
@@ -162,7 +160,6 @@ export default function Page() {
         const isConfirmed = window.confirm(
           'Are you sure you want to leave?\nYour changes have not been saved.\nIf you leave this page, all changes will be lost.\nDo you still want to proceed?'
         )
-        // Error occurs if I just put 'href' without 'href === ...' code..
         if (isConfirmed) {
           originalPush(href as Route, options)
         }
@@ -181,7 +178,8 @@ export default function Page() {
   const [isCheckButtonClicked, setIsCheckButtonClicked] =
     useState<boolean>(false)
   const [isPasswordCorrect, setIsPasswordCorrect] = useState<boolean>(false)
-  const [newPasswordAble, setNewPasswordAble] = useState<boolean>(false)
+  const [newPasswordAbleToWrite, setNewPasswordAbleToWrite] =
+    useState<boolean>(false)
   const [passwordShow, setPasswordShow] = useState<boolean>(false)
   const [newPasswordShow, setNewPasswordShow] = useState<boolean>(false)
   const [confirmPasswordShow, setConfirmPasswordShow] = useState<boolean>(false)
@@ -191,19 +189,27 @@ export default function Page() {
   const newPassword = watch('newPassword')
   const confirmPassword = watch('confirmPassword')
   const realName = watch('realName')
+  const studentId = watch('studentId')
   const isPasswordsMatch = newPassword === confirmPassword && newPassword !== ''
   const [isLoading, setIsLoading] = useState<boolean>(true)
-  // saveAble1, saveAble2 둘 중 하나라도 true 면 Save 버튼 활성화
+
   const saveAblePassword: boolean =
     !!currentPassword &&
     !!newPassword &&
     !!confirmPassword &&
     isPasswordCorrect &&
-    newPasswordAble &&
+    !errors.newPassword &&
     isPasswordsMatch
   const saveAbleOthers: boolean =
-    !!realName || !!(majorValue !== defaultProfileValues.major)
-  const saveAble = isPasswordsMatch && (saveAblePassword || saveAbleOthers)
+    (!!realName && !errors.realName) ||
+    !!(majorValue !== defaultProfileValues.major)
+  const saveAble =
+    (saveAblePassword && saveAbleOthers) ||
+    (saveAbleOthers && !newPassword && !confirmPassword) ||
+    (saveAblePassword && !realName && majorValue === defaultProfileValues.major)
+
+  const saveAbleUpdateNow =
+    !!studentId && majorValue !== 'none' && !errors.studentId
 
   // New Password Input 창과 Re-enter Password Input 창의 border 색상을, 일치하는지 여부에 따라 바꿈
   useEffect(() => {
@@ -228,6 +234,9 @@ export default function Page() {
       }
       if (data.newPassword !== 'tmppassword1') {
         updatePayload.newPassword = data.newPassword
+      }
+      if (updateNow && data.studentId !== '0000000000') {
+        updatePayload.studentId = data.studentId
       }
 
       const response = await safeFetcherWithAuth.patch('user', {
@@ -281,7 +290,7 @@ export default function Page() {
 
       if (response.status === 201) {
         setIsPasswordCorrect(true)
-        setNewPasswordAble(true)
+        setNewPasswordAbleToWrite(true)
       }
     } catch {
       console.error('Failed to check password')
@@ -312,7 +321,9 @@ export default function Page() {
       >
         <h1 className="-mb-1 text-center text-2xl font-bold">Settings</h1>
         <p className="text-center text-sm text-neutral-500">
-          You can change your information
+          {updateNow
+            ? 'You must update your information'
+            : 'You can change your information'}
         </p>
 
         {/* ID */}
@@ -331,8 +342,10 @@ export default function Page() {
               type={passwordShow ? 'text' : 'password'}
               placeholder="Current password"
               {...register('currentPassword')}
-              disabled={isCheckButtonClicked && isPasswordCorrect}
-              className={`flex justify-stretch text-neutral-600 placeholder:text-neutral-300 disabled:text-neutral-400 ${errors.currentPassword && 'border-red-500'} ${isCheckButtonClicked ? (isPasswordCorrect ? 'border-primary' : 'border-red-500') : ''} ring-0 focus-visible:ring-0`}
+              disabled={
+                updateNow ? true : isCheckButtonClicked && isPasswordCorrect
+              }
+              className={`flex justify-stretch text-neutral-600 placeholder:text-neutral-400 disabled:bg-neutral-200 disabled:text-neutral-400 ${errors.currentPassword && 'border-red-500'} ${isCheckButtonClicked ? (isPasswordCorrect ? 'border-primary' : 'border-red-500') : ''} ring-0 focus-visible:ring-0`}
             />
             <span
               className="absolute right-0 top-0 flex h-full items-center p-3"
@@ -374,7 +387,7 @@ export default function Page() {
             <Input
               type={newPasswordShow ? 'text' : 'password'}
               placeholder="New password"
-              disabled={!newPasswordAble}
+              disabled={updateNow ? true : !newPasswordAbleToWrite}
               {...register('newPassword')}
               className={`flex justify-stretch border-neutral-300 ring-0 placeholder:text-neutral-400 focus-visible:ring-0 disabled:bg-neutral-200 ${
                 isPasswordsMatch
@@ -395,7 +408,7 @@ export default function Page() {
             </span>
           </div>
         </div>
-        {errors.newPassword && (
+        {errors.newPassword && newPasswordAbleToWrite && (
           <div
             className={`-mt-3 inline-flex items-center text-xs ${newPassword && 'text-red-500'}`}
           >
@@ -415,7 +428,7 @@ export default function Page() {
             <Input
               type={confirmPasswordShow ? 'text' : 'password'}
               placeholder="Re-enter new password"
-              disabled={!newPasswordAble}
+              disabled={updateNow ? true : !newPasswordAbleToWrite}
               {...register('confirmPassword', {
                 validate: (val: string) => {
                   if (watch('newPassword') != val) {
@@ -460,8 +473,9 @@ export default function Page() {
           placeholder={
             isLoading ? 'Loading...' : defaultProfileValues.userProfile.realName
           }
+          disabled={updateNow ? true : false}
           {...register('realName')}
-          className={`${realName && (errors.realName ? 'border-red-500' : 'border-primary')} placeholder:text-neutral-300 focus-visible:ring-0`}
+          className={`${realName && (errors.realName ? 'border-red-500' : 'border-primary')} placeholder:text-neutral-400 focus-visible:ring-0 disabled:bg-neutral-200`}
         />
         {realName &&
           errors.realName &&
@@ -471,12 +485,17 @@ export default function Page() {
         <label className="-mb-4 mt-2 text-xs">Student ID</label>
         <Input
           placeholder={
-            isLoading ? 'Loading...' : defaultProfileValues.studentId
+            updateNow
+              ? '2024123456'
+              : isLoading
+                ? 'Loading...'
+                : defaultProfileValues.studentId
           }
-          disabled={true}
+          disabled={updateNow ? false : true}
           {...register('studentId')}
-          className="border-neutral-300 text-neutral-600 placeholder:text-neutral-400 disabled:bg-neutral-200"
+          className={`placeholder:text-neutral-400 focus-visible:ring-0 ${updateNow ? `${errors.studentId || !studentId ? 'border-red-500' : 'border-primary'} text-neutral-600` : 'border-neutral-300 text-neutral-600 disabled:bg-neutral-200'}`}
         />
+        {errors.studentId && requiredMessage(errors.studentId.message)}
 
         {/* First Major */}
         <label className="-mb-4 mt-2 text-xs">First Major</label>
@@ -489,16 +508,22 @@ export default function Page() {
                 role="combobox"
                 className={cn(
                   'justify-between border-gray-200 font-normal text-neutral-600 hover:bg-white',
-                  majorValue === defaultProfileValues.major
-                    ? 'text-neutral-300'
-                    : 'border-primary'
+                  updateNow
+                    ? `${majorValue === 'none' || isLoading ? 'border-red-500 text-neutral-400' : 'border-primary'}`
+                    : majorValue === defaultProfileValues.major
+                      ? 'text-neutral-400'
+                      : 'border-primary'
                 )}
               >
                 {isLoading
                   ? 'Loading...'
-                  : !majorValue
-                    ? defaultProfileValues.major
-                    : majorValue}
+                  : updateNow
+                    ? majorValue === 'none'
+                      ? 'Department Information Unavailable / 학과 정보 없음'
+                      : majorValue
+                    : !majorValue
+                      ? defaultProfileValues.major
+                      : majorValue}
                 <FaChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
@@ -538,7 +563,7 @@ export default function Page() {
         {/* Save Button */}
         <div className="mt-2 text-end">
           <Button
-            disabled={!saveAble}
+            disabled={updateNow ? !saveAbleUpdateNow : !saveAble}
             type="submit"
             className="font-semibold disabled:bg-neutral-300 disabled:text-neutral-500"
             onClick={onSubmitClick()}

--- a/apps/frontend/app/(main)/settings/page.tsx
+++ b/apps/frontend/app/(main)/settings/page.tsx
@@ -203,7 +203,7 @@ export default function Page() {
     isPasswordsMatch
   const saveAbleOthers: boolean =
     !!realName || !!(majorValue !== defaultProfileValues.major)
-  const saveAble = saveAblePassword || saveAbleOthers
+  const saveAble = isPasswordsMatch && (saveAblePassword || saveAbleOthers)
 
   // New Password Input 창과 Re-enter Password Input 창의 border 색상을, 일치하는지 여부에 따라 바꿈
   useEffect(() => {

--- a/apps/frontend/app/(main)/settings/page.tsx
+++ b/apps/frontend/app/(main)/settings/page.tsx
@@ -308,7 +308,7 @@ export default function Page() {
 
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="flex h-svh max-h-[846px] w-full flex-col justify-between gap-4 px-4"
+        className="flex max-h-[846px] w-full flex-col justify-between gap-4 px-4"
       >
         <h1 className="-mb-1 text-center text-2xl font-bold">Settings</h1>
         <p className="text-center text-sm text-neutral-500">
@@ -481,7 +481,7 @@ export default function Page() {
         {/* First Major */}
         <label className="-mb-4 mt-2 text-xs">First Major</label>
         <div className="flex flex-col gap-1">
-          <Popover open={majorOpen} onOpenChange={setMajorOpen} modal={true}>
+          <Popover open={majorOpen} onOpenChange={setMajorOpen}>
             <PopoverTrigger asChild>
               <Button
                 aria-expanded={majorOpen}

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -226,6 +226,18 @@ export default function HeaderAuthPanel({
                 </DropdownMenuItem>
               </Link>
             )}
+            <Link href="/settings">
+              <DropdownMenuItem
+                className={cn(
+                  'flex cursor-pointer items-center gap-1',
+                  isEditor
+                    ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
+                    : 'font-semibold'
+                )}
+              >
+                <UserRoundCog className="size-4" /> Settings
+              </DropdownMenuItem>
+            </Link>
             <DropdownMenuItem
               className="flex cursor-pointer items-center gap-1 font-semibold"
               onClick={() => {

--- a/apps/frontend/components/auth/UpdateInformation.tsx
+++ b/apps/frontend/components/auth/UpdateInformation.tsx
@@ -2,12 +2,14 @@
 
 import { Button } from '@/components/ui/button'
 import CodedangLogo from '@/public/codedang.svg'
+import type { Route } from 'next'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { IoWarningOutline } from 'react-icons/io5'
 
 export default function UpdateInformation() {
   const router = useRouter()
+
   return (
     <div className="flex w-full flex-col items-center gap-1">
       <div className="flex justify-center pt-4">
@@ -38,7 +40,13 @@ export default function UpdateInformation() {
       </ul>
       <Button
         className="mt-10 w-full bg-red-500 font-semibold hover:bg-red-600"
-        onClick={() => router.push('/settings')}
+        onClick={() => {
+          router.push(
+            ('/settings' +
+              '?' +
+              new URLSearchParams({ updateNow: 'true' })) as Route
+          )
+        }}
       >
         Update Now
       </Button>

--- a/apps/frontend/lib/constants.ts
+++ b/apps/frontend/lib/constants.ts
@@ -51,7 +51,6 @@ export const levels = [
  * @constant
  */
 export const majors = [
-  '학과 정보 없음',
   '자유전공계열',
   '인문과학계열',
   '유학·동양학과',


### PR DESCRIPTION
### Description

학번, 학과 필수로 바꿔야하는 유저들을 위한 Settings페이지 만들었습니다.
추가로
- '현 비밀번호 Incorrect & 새 비밀번호 생성 조건 동시 노출' 오류, 
- 학과 혹은 이름 입력 돼있는 상태에서 re-enter password은 입력하지 않고 new password 만 입력된 상태에서 save 버튼이 활성화되는 문제 해결했습니다

closes TAS-783
closes TAS-785


### Additional context


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
