### PR TITLE
feat(infra): add capacity provider strategy to ecs cluster

### DIFF
--- a/apps/infra/production/codedang/modules/cluster_autoscaling/cluster.tf
+++ b/apps/infra/production/codedang/modules/cluster_autoscaling/cluster.tf
@@ -5,4 +5,10 @@ resource "aws_ecs_cluster" "this" {
 resource "aws_ecs_cluster_capacity_providers" "this" {
   cluster_name       = aws_ecs_cluster.this.name
   capacity_providers = [aws_ecs_capacity_provider.this.name]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.this.name
+    weight            = 100
+    base              = 1
+  }
 }

--- a/apps/infra/production/codedang/modules/cluster_autoscaling/cluster.tf
+++ b/apps/infra/production/codedang/modules/cluster_autoscaling/cluster.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_cluster_capacity_providers" "this" {
 
   default_capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.this.name
-    weight            = 100
+    weight            = 1
     base              = 1
   }
 }


### PR DESCRIPTION
### Description
Closes TAS-789
ECS Cluster Managed Scalingd을 사용하여 ECS 클러스터의 용량을 자동으로 관리하기 위해 capacity provider strategy를 설정합니다.

<각 parameter 설명>
- weight: Capacity Provider가 여러 개 있을 경우, 작업이 이 Provider에 할당될 비율을 지정합니다. 단일 Capacity Provider를 사용할 때는 중요하지 않지만, 여러 Provider를 사용하는 경우 비율을 통해 리소스 할당을 조정할 수 있습니다. 현재 capacity provider가 1개밖에 없기 때문에 최댓값인 100으로 설정했습니다.
- base: 특정 Capacity Provider에서 최소 몇 개의 작업이 실행되어야 하는지를 설정합니다. 이 값을 통해 특정 Provider에서 항상 일정 수 이상의 작업이 실행되도록 보장할 수 있습니다.

ECS Cluster 기본 strategy를 설정하였지만 서비스별로 설정할 수도 있습니다

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
