### PR TITLE
feat(be): implement getContestScoreSummaries api

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest.resolver.ts
@@ -30,7 +30,10 @@ import { DuplicatedContestResponse } from './model/duplicated-contest-response.o
 import { ProblemScoreInput } from './model/problem-score.input'
 import { PublicizingRequest } from './model/publicizing-request.model'
 import { PublicizingResponse } from './model/publicizing-response.output'
-import { UserContestScoreSummary } from './model/score-summary'
+import {
+  UserContestScoreSummary,
+  UserContestScoreSummaryWithUserInfo
+} from './model/score-summary'
 
 @Resolver(() => Contest)
 export class ContestResolver {
@@ -300,7 +303,7 @@ export class ContestResolver {
     }
   }
 
-  @Query(() => [UserContestScoreSummary])
+  @Query(() => [UserContestScoreSummaryWithUserInfo])
   async getContestScoreSummaries(
     @Args('take', { type: () => Int, defaultValue: 10 }) take: number,
     @Args('contestId', { type: () => Int }) contestId: number,

--- a/apps/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest.resolver.ts
@@ -300,6 +300,27 @@ export class ContestResolver {
     }
   }
 
+  @Query(() => [UserContestScoreSummary])
+  async getContestScoreSummaries(
+    @Args('take', { type: () => Int, defaultValue: 10 }) take: number,
+    @Args('contestId', { type: () => Int }) contestId: number,
+    @Args('cursor', { type: () => Int, nullable: true }) cursor: number | null
+  ) {
+    try {
+      return await this.contestService.getContestScoreSummaries(
+        take,
+        contestId,
+        cursor
+      )
+    } catch (error) {
+      if (error instanceof EntityNotExistException) {
+        throw error.convert2HTTPException()
+      }
+      this.logger.error(error)
+      throw new InternalServerErrorException()
+    }
+  }
+
   @Query(() => ContestsGroupedByStatus)
   async getContestsByProblemId(
     @Args('problemId', { type: () => Int }) problemId: number

--- a/apps/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest.resolver.ts
@@ -288,7 +288,7 @@ export class ContestResolver {
   }
 
   @Query(() => UserContestScoreSummary)
-  async getScoreSummaries(
+  async getContestScoreSummary(
     @Args('userId', { type: () => Int }) userId: number,
     @Args('contestId', { type: () => Int }) contestId: number
   ) {

--- a/apps/backend/apps/admin/src/contest/model/score-summary.ts
+++ b/apps/backend/apps/admin/src/contest/model/score-summary.ts
@@ -19,6 +19,33 @@ export class UserContestScoreSummary {
 }
 
 @ObjectType()
+export class UserContestScoreSummaryWithUserInfo {
+  @Field(() => String)
+  username: string
+
+  @Field(() => String)
+  studentId: string
+
+  @Field(() => String, { nullable: true })
+  realName: string
+
+  @Field(() => Int)
+  submittedProblemCount: number
+
+  @Field(() => Int)
+  totalProblemCount: number
+
+  @Field(() => Float)
+  userContestScore: number
+
+  @Field(() => Int)
+  contestPerfectScore: number
+
+  @Field(() => [ProblemScore])
+  problemScores: ProblemScore[]
+}
+
+@ObjectType()
 class ProblemScore {
   @Field(() => Int)
   problemId: number

--- a/collection/admin/Contest/Get Contest Score Summaries /Succeed.bru
+++ b/collection/admin/Contest/Get Contest Score Summaries /Succeed.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Succeed
+  type: graphql
+  seq: 1
+}
+
+post {
+  url: {{gqlUrl}}
+  body: graphql
+  auth: none
+}
+
+body:graphql {
+  query GetContestScoreSummaries($contestId: Int!, $take: Int!) {
+    getContestScoreSummaries(
+      contestId: $contestId,
+      take: $take
+    ) {
+      submittedProblemCount
+  		totalProblemCount
+      userContestScore
+      contestPerfectScore
+      problemScores {
+        problemId
+        score
+      }
+    }
+  }
+
+}
+
+body:graphql:vars {
+  {
+    "contestId": 1,
+    "take": 10
+  }
+}
+
+docs {
+  ## Get Contest Score Summaries of User
+  유저의 특정 Contest에 대한 점수 요약 List를 반환합니다.
+
+  - username
+    - 유저의 이름
+  - studentId
+    - 유저의 학번
+  - realName
+    - 유저의 실명
+  - submittedProblemCount
+    - 제출된 문제의 개수(정답 여부와 관계 없음)
+  - totalProblemCount
+    - 전체 문제의 개수
+  - userContestScore
+    - 해당 Contest에서 User가 획득한 총 점수
+  - contestPerfectScore
+    - Contest의 만점
+  - problemScores
+    - 각 문제에서 획득한 점수를 담고 있는 배열 (100점 만점 기준)
+    - 속성
+      - problemId
+      - score
+}

--- a/collection/admin/Contest/Get Contest Score Summary of User/Succeed.bru
+++ b/collection/admin/Contest/Get Contest Score Summary of User/Succeed.bru
@@ -11,8 +11,8 @@ post {
 }
 
 body:graphql {
-  query GetScoreSummaries($userId: Int!, $contestId: Int!) {
-    getScoreSummaries(
+  query GetContestScoreSummary($userId: Int!, $contestId: Int!) {
+    getContestScoreSummary(
       userId: $userId,
       contestId:$contestId
     ) {
@@ -26,7 +26,7 @@ body:graphql {
       }
     }
   }
-  
+
 }
 
 body:graphql:vars {
@@ -39,7 +39,7 @@ body:graphql:vars {
 docs {
   ## Get Contest Score Summary of User
   유저의 특정 Contest에 대한 점수 요약을 반환합니다.
-  
+
   - submittedProblemCount
     - 제출된 문제의 개수(정답 여부와 관계 없음)
   - totalProblemCount


### PR DESCRIPTION
### Description

Closes TAS-460

getContestScoreSummaries API를 생성합니다.
기획과는 다르게 Sort는 자동으로 StudentId기준으로 되도록 하였고,
Search 기능은 구현하지 않았습니다.
다른 우선순위 높은 task부터 진행하고, 구현할게여

GetScoreSummaries API 는 실제로 한 유저의 Summary만 가져오므로, GetContestScoreSummary 로 rename합니다.
GetContestScoreSummaries 와 GetContestScoreSummary 의 일관성을 위해서 이렇게 네이밍 했습니다. 

<img width="823" alt="image" src="https://github.com/user-attachments/assets/db49fbd5-e985-4709-b1f6-59e89ad41cf1">

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
