### PR TITLE
fix(be): get testcase-ids from postgresql not s3 when create submission

### DIFF
--- a/apps/backend/apps/client/src/submission/interface/testcase.dto.ts
+++ b/apps/backend/apps/client/src/submission/interface/testcase.dto.ts
@@ -1,5 +1,0 @@
-export interface TestcaseDTO {
-  id: string
-  input: string
-  output: string
-}


### PR DESCRIPTION
### Description

submission 생성시 testcaseId를 s3에 있는 json 파일이 아닌 problemTestcase DB 테이블에서 받아오도록 수정

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
