### PR TITLE
fix(fe): fix Sample input output scroll design

### DIFF
--- a/apps/frontend/components/EditorDescription.tsx
+++ b/apps/frontend/components/EditorDescription.tsx
@@ -21,7 +21,7 @@ import compileIcon from '@/public/compileVersion.svg'
 import copyIcon from '@/public/copy.svg'
 import copyCompleteIcon from '@/public/copyComplete.svg'
 import type { ContestProblem, ProblemDetail } from '@/types/type'
-import { Level } from '@/types/type'
+import type { Level } from '@/types/type'
 import { motion } from 'framer-motion'
 import { sanitize } from 'isomorphic-dompurify'
 import { FileText } from 'lucide-react'
@@ -133,7 +133,7 @@ export function EditorDescription({
               <h2 className="mb-2 font-bold">Sample</h2>
 
               <div className="flex space-x-2 text-base">
-                <div className="w-full space-y-2">
+                <div className="w-1/2 space-y-2">
                   <div className="flex items-center space-x-3">
                     <h3 className="select-none text-sm font-semibold">
                       Input {index + 1}
@@ -186,7 +186,7 @@ export function EditorDescription({
                       </Tooltip>
                     </TooltipProvider>
                   </div>
-                  <div className="bg-[#222939 w-full rounded-md border border-[#555C66]">
+                  <div className="rounded-md border border-[#555C66]">
                     <pre
                       className="h-24 w-full select-none overflow-auto px-4 py-2 font-mono text-sm"
                       dangerouslySetInnerHTML={{
@@ -196,7 +196,7 @@ export function EditorDescription({
                   </div>
                 </div>
 
-                <div className="w-full space-y-2">
+                <div className="w-1/2 space-y-2">
                   <div className="flex items-center space-x-3">
                     <h3 className="select-none text-sm font-semibold">
                       Output {index + 1}
@@ -249,7 +249,7 @@ export function EditorDescription({
                       </Tooltip>
                     </TooltipProvider>
                   </div>
-                  <div className="bg-[#222939 w-full rounded-md border-[1px] border-[#555C66]">
+                  <div className="rounded-md border-[1px] border-[#555C66]">
                     <pre
                       className="h-24 w-full select-none overflow-auto px-4 py-2 font-mono text-sm"
                       dangerouslySetInnerHTML={{

--- a/apps/frontend/components/EditorResizablePanel.tsx
+++ b/apps/frontend/components/EditorResizablePanel.tsx
@@ -47,7 +47,7 @@ export default function EditorMainResizablePanel({
     >
       <ResizablePanel
         defaultSize={35}
-        style={{ minWidth: '600px' }}
+        style={{ minWidth: '500px' }}
         minSize={20}
       >
         <div className="grid-rows-editor grid h-full grid-cols-1">

--- a/apps/frontend/components/EditorResizablePanel.tsx
+++ b/apps/frontend/components/EditorResizablePanel.tsx
@@ -47,7 +47,7 @@ export default function EditorMainResizablePanel({
     >
       <ResizablePanel
         defaultSize={35}
-        style={{ minWidth: '400px' }}
+        style={{ minWidth: '600px' }}
         minSize={20}
       >
         <div className="grid-rows-editor grid h-full grid-cols-1">


### PR DESCRIPTION
### Description

- Problem Editor Sample Input Output의 길이가 길고, 줄바꿈없이 띄어쓰기만 있을시에 Output이 잘려서 보이는 현상 밑에와 같이 해결했습니다!
- 
<img width="1727" alt="스크린샷 2024-08-30 오전 12 48 55" src="https://github.com/user-attachments/assets/3aac67eb-f6d7-4481-8824-0cef5a0af491">

<img width="1725" alt="스크린샷 2024-08-30 오전 12 41 53" src="https://github.com/user-attachments/assets/228f5929-4185-4ae1-820c-f4ca47115f79">

<img width="1725" alt="스크린샷 2024-08-30 오전 12 42 10" src="https://github.com/user-attachments/assets/0b3a6eef-6506-4c3d-ba5a-ae093a98a838">

closes TAS-775

### Additional context



---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
