### PR TITLE
fix(fe): remove link from participant score table

### DIFF
--- a/apps/frontend/app/admin/contest/[id]/participant/[userId]/_components/SubmissionColumns.tsx
+++ b/apps/frontend/app/admin/contest/[id]/participant/[userId]/_components/SubmissionColumns.tsx
@@ -68,7 +68,7 @@ export const submissionColumns: ColumnDef<UserSubmission>[] = [
     header: () => <p className="font-mono text-sm">IP</p>,
     cell: ({ row }) => (
       <div className="whitespace-nowrap text-center text-xs">
-        {row.getValue('ip')}
+        {row.getValue('ip') ?? 'Unknown'}
       </div>
     )
   }

--- a/apps/frontend/components/DataTableAdmin.tsx
+++ b/apps/frontend/components/DataTableAdmin.tsx
@@ -443,7 +443,7 @@ export function DataTableAdmin<TData, TValue>({
                     }
                     return `/contest/${pathname.split('/')[3]}/problem/${submission.problemId}/submission/${submission.id}` as Route
                   }
-                  if (pathname.includes('participant')) {
+                  if (pathname.includes('participant') && enableProblemFilter) {
                     const submission = row.original as {
                       contestId: number
                       problemId: number


### PR DESCRIPTION
### Description

participant 페이지의 score 테이블 행을 누르면 에러가 생기는 현상을 이동하지 않게 함으로써 해결하였고, 추가로 ip가 null일 때 빈칸으로 보이는 걸 'Unknown'으로 수정하였습니다!

![image](https://github.com/user-attachments/assets/9caeddc5-5b8c-4765-b1a5-4ada567d4b89)

close TAS-816

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
