### PR TITLE
feat(be): allow re-submission when user already passed problem

### DIFF
--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -2,13 +2,7 @@ import { HttpModule } from '@nestjs/axios'
 import { NotFoundException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Test, type TestingModule } from '@nestjs/testing'
-import {
-  Language,
-  ResultStatus,
-  Role,
-  type Contest,
-  type User
-} from '@prisma/client'
+import { Language, Role, type Contest, type User } from '@prisma/client'
 import { expect } from 'chai'
 import { plainToInstance } from 'class-transformer'
 import { TraceService } from 'nestjs-otel'
@@ -274,9 +268,6 @@ describe('SubmissionService', () => {
 
     it('should create submission with contestId', async () => {
       const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      const hasPassedSpy = stub(problemRepository, 'hasPassedProblem').resolves(
-        false
-      )
       db.problem.findUnique.resolves(problems[0])
       db.submission.create.resolves({
         ...submissions[0],
@@ -294,25 +285,6 @@ describe('SubmissionService', () => {
         )
       ).to.be.deep.equal({ ...submissions[0], contestId: CONTEST_ID })
       expect(publishSpy.calledOnce).to.be.true
-      expect(hasPassedSpy.calledOnce).to.be.true
-    })
-
-    it('should throw conflict found exception if user has already gotten AC', async () => {
-      const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      db.problem.findUnique.resolves(problems[0])
-      db.submission.create.resolves(submissions[0])
-      db.submission.findMany.resolves([{ result: ResultStatus.Accepted }])
-
-      await expect(
-        service.createSubmission(
-          submissionDto,
-          problems[0],
-          submissions[0].userId,
-          USERIP,
-          { contestId: CONTEST_ID }
-        )
-      ).to.be.rejectedWith(ConflictFoundException)
-      expect(publishSpy.calledOnce).to.be.false
     })
 
     it('should create submission with workbookId', async () => {
@@ -338,9 +310,6 @@ describe('SubmissionService', () => {
 
     it('should create submission with contestId', async () => {
       const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      const hasPassedSpy = stub(problemRepository, 'hasPassedProblem').resolves(
-        false
-      )
       db.problem.findUnique.resolves(problems[0])
       db.submission.create.resolves({
         ...submissions[0],
@@ -358,25 +327,6 @@ describe('SubmissionService', () => {
         )
       ).to.be.deep.equal({ ...submissions[0], contestId: CONTEST_ID })
       expect(publishSpy.calledOnce).to.be.true
-      expect(hasPassedSpy.calledOnce).to.be.true
-    })
-
-    it('should throw conflict found exception if user has already gotten AC', async () => {
-      const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      db.problem.findUnique.resolves(problems[0])
-      db.submission.create.resolves(submissions[0])
-      db.submission.findMany.resolves([{ result: ResultStatus.Accepted }])
-
-      await expect(
-        service.createSubmission(
-          submissionDto,
-          problems[0],
-          submissions[0].userId,
-          USERIP,
-          { contestId: CONTEST_ID }
-        )
-      ).to.be.rejectedWith(ConflictFoundException)
-      expect(publishSpy.calledOnce).to.be.false
     })
 
     it('should create submission with workbookId', async () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-786

Contest에서 한번 ACCEPTED를 받으면 다시 제출할 수 없도록 되어 있던 로직을 기획 변경에 따라 재제출이 가능하도록 변경합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
