### PR TITLE
feat(infra): increase api asg desired capacity and ecs client service desired count

### DIFF
--- a/apps/infra/production/codedang/codedang_api.tf
+++ b/apps/infra/production/codedang/codedang_api.tf
@@ -9,8 +9,8 @@ module "codedang_api" {
   }
 
   autoscaling_group = {
-    name     = "Codedang-AutoScalingGroup-Api"
-    max_size = 10
+    name             = "Codedang-AutoScalingGroup-Api"
+    max_size         = 10
     desired_capacity = 2
   }
 

--- a/apps/infra/production/codedang/codedang_api.tf
+++ b/apps/infra/production/codedang/codedang_api.tf
@@ -11,6 +11,7 @@ module "codedang_api" {
   autoscaling_group = {
     name     = "Codedang-AutoScalingGroup-Api"
     max_size = 10
+    desired_capacity = 2
   }
 
   autoscaling_policy = {

--- a/apps/infra/production/codedang/codedang_iris.tf
+++ b/apps/infra/production/codedang/codedang_iris.tf
@@ -10,8 +10,9 @@ module "codedang_iris" {
   }
 
   autoscaling_group = {
-    name     = "Codedang-AutoScalingGroup-Iris"
-    max_size = 4
+    name             = "Codedang-AutoScalingGroup-Iris"
+    max_size         = 4
+    desired_capacity = 1
   }
 
   autoscaling_policy = {

--- a/apps/infra/production/codedang/codedang_service_client.tf
+++ b/apps/infra/production/codedang/codedang_service_client.tf
@@ -85,7 +85,7 @@ module "client_api" {
   ecs_service = {
     name          = "Codedang-Client-Api-Service"
     cluster_arn   = module.codedang_api.ecs_cluster.arn
-    desired_count = 1
+    desired_count = 2
     load_balancer = {
       container_name   = "Codedang-Client-Api"
       container_port   = 4000

--- a/apps/infra/production/codedang/codedang_service_client.tf
+++ b/apps/infra/production/codedang/codedang_service_client.tf
@@ -94,7 +94,7 @@ module "client_api" {
   }
 
   appautoscaling_target = {
-    min_capacity = 1
+    min_capacity = 2
     max_capacity = 8
     resource_id = {
       cluster_name = module.codedang_api.ecs_cluster.name

--- a/apps/infra/production/codedang/modules/cluster_autoscaling/autoscaling.tf
+++ b/apps/infra/production/codedang/modules/cluster_autoscaling/autoscaling.tf
@@ -28,7 +28,7 @@ resource "aws_autoscaling_group" "this" {
   name                = var.autoscaling_group.name
   vpc_zone_identifier = [for key in keys(var.subnets) : aws_subnet.this[key].id]
 
-  desired_capacity = 1
+  desired_capacity = var.autoscaling_group.desired_capacity
   min_size         = 1
   max_size         = var.autoscaling_group.max_size
 

--- a/apps/infra/production/codedang/modules/cluster_autoscaling/variables.tf
+++ b/apps/infra/production/codedang/modules/cluster_autoscaling/variables.tf
@@ -11,8 +11,8 @@ variable "launch_template" {
 
 variable "autoscaling_group" {
   type = object({
-    name     = string
-    max_size = number
+    name             = string
+    max_size         = number
     desired_capacity = number
   })
   description = "The autoscaling group. e.g. {name='codedang-asg', max_size=7}"

--- a/apps/infra/production/codedang/modules/cluster_autoscaling/variables.tf
+++ b/apps/infra/production/codedang/modules/cluster_autoscaling/variables.tf
@@ -13,6 +13,7 @@ variable "autoscaling_group" {
   type = object({
     name     = string
     max_size = number
+    desired_capacity = number
   })
   description = "The autoscaling group. e.g. {name='codedang-asg', max_size=7}"
 }


### PR DESCRIPTION
### Description
- 배포 안정화 작업이 완벽하지 않아, 즉 Scale Up/Down에 대한 확신이 없어 API Auto Scaling Group만 desired capacity를 2개로 올립니다. 즉 API의 경우 기본 인스턴스 개수가 2개입니다.
- ECS Service 중 Client의 경우 트래픽 분산을 위해 배포 시 컨테이너 기본 개수를 2개로 설정합니다.

Closes TAS-828
<!-- Please insert your description ere and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
