### PR TITLE
fix(be): return cpu-time and memory-usage null when is-judge-visible is false

### DIFF
--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -487,7 +487,11 @@ export class SubmissionService {
       results.sort((a, b) => a.problemTestcaseId - b.problemTestcaseId)
 
       if (contestId && !isJudgeResultVisible) {
-        results.map((r) => (r.result = 'Blind'))
+        results.map((r) => {
+          r.result = 'Blind'
+          r.cpuTime = null
+          r.memoryUsage = null
+        })
       }
 
       return {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-852

isJudgeVisible == false로 세팅되어있는 대회에서, Result만 가려지고 CpuTime과 Memory Usage를 가리지 않아 결과에 대해 유추할 수 있습니다. 이 문제를 해결합니다.

cpuTime과 memoryUsage는 isJudgeVisible==false인 경우 `null`로 반환됩니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
