### PR TITLE
feat(fe): improve datatableadmin order

### DIFF
--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/problem/page.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/problem/page.tsx
@@ -16,7 +16,7 @@ export default async function ContestProblem({ params }: ContestProblemProps) {
   const { contestId } = params
   const res = await fetcherWithAuth.get(`contest/${contestId}/problem`, {
     searchParams: {
-      take: 10
+      take: 20
     }
   })
 

--- a/apps/frontend/app/admin/contest/[id]/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/[id]/_components/Columns.tsx
@@ -5,6 +5,7 @@ import OptionSelect from '@/components/OptionSelect'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
+import { cn } from '@/lib/utils'
 import type { Level } from '@/types/type'
 import { useQuery } from '@apollo/client'
 import type { ColumnDef, Row } from '@tanstack/react-table'
@@ -71,7 +72,12 @@ export const columns = (
       <div className="flex justify-center">
         <Input
           defaultValue={row.getValue('score')}
-          className="w-[70px] focus-visible:ring-0"
+          className={cn(
+            'w-[70px] focus-visible:ring-0',
+            '[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+          )}
+          type="number"
+          min={0}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault()

--- a/apps/frontend/app/admin/contest/[id]/edit/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/edit/page.tsx
@@ -244,10 +244,12 @@ export default function Page({ params }: { params: { id: string } }) {
                   <AlertDialogTrigger asChild>
                     <Button
                       type="button"
-                      className="flex h-[36px] w-36 items-center gap-2 px-0"
+                      className="flex h-[36px] w-48 items-center gap-2 px-0"
                     >
                       <PlusCircleIcon className="h-4 w-4" />
-                      <div className="mb-[2px] text-sm">Import Problem</div>
+                      <div className="mb-[2px] text-sm">
+                        Import · Edit problem
+                      </div>
                     </Button>
                   </AlertDialogTrigger>
                   <AlertDialogContent className="p-8">
@@ -300,6 +302,7 @@ export default function Page({ params }: { params: { id: string } }) {
                 data={problems as ContestProblem[]}
                 defaultSortColumn={{ id: 'order', desc: false }}
                 enableFooter={true}
+                defaultPageSize={20}
               />
             </div>
             <Button

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -95,6 +95,7 @@ export default function ImportProblemTable({
             })
             onSelectedExport(problemsWithOrder)
           }}
+          defaultPageSize={5}
         />
       )}
     </>

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
@@ -27,7 +27,7 @@ export const columns: ColumnDef<DataTableProblem>[] = [
             row.getIsSelected()
           ).length
           table.getSelectedRowModel().rows.length - currentSelectedCount > 15
-            ? toast.error('Maximum number of problems is 20.')
+            ? toast.error('You can only import up to 20 problems in a contest')
             : table.toggleAllPageRowsSelected(!!value)
         }}
         aria-label="Select all"

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import type { Level } from '@/types/type'
 import type { ColumnDef } from '@tanstack/react-table'
+import { toast } from 'sonner'
 
 interface DataTableProblem {
   id: number
@@ -16,25 +17,39 @@ interface DataTableProblem {
 
 export const columns: ColumnDef<DataTableProblem>[] = [
   {
-    id: 'select',
+    accessorKey: 'select',
     header: ({ table }) => (
       <Checkbox
         checked={table.getIsAllPageRowsSelected()}
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        onCheckedChange={(value) => {
+          const currentPageRows = table.getRowModel().rows
+          const currentSelectedCount = currentPageRows.filter((row) =>
+            row.getIsSelected()
+          ).length
+          table.getSelectedRowModel().rows.length - currentSelectedCount > 15
+            ? toast.error('Maximum number of problems is 20.')
+            : table.toggleAllPageRowsSelected(!!value)
+        }}
         aria-label="Select all"
         className="translate-y-[2px]"
       />
     ),
     cell: ({ row }) => (
       <Checkbox
-        onClick={(e) => e.stopPropagation()}
         checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
         aria-label="Select row"
         className="translate-y-[2px]"
       />
     ),
-    enableSorting: false,
+    sortingFn: (rowA, rowB) => {
+      const aSelected = rowA.getIsSelected()
+      const bSelected = rowB.getIsSelected()
+
+      if (aSelected === bSelected) {
+        return 0
+      }
+      return aSelected ? 1 : -1
+    },
     enableHiding: false
   },
   {
@@ -49,7 +64,6 @@ export const columns: ColumnDef<DataTableProblem>[] = [
         </div>
       )
     },
-    enableSorting: false,
     enableHiding: false
   },
   {

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -188,10 +188,12 @@ export default function Page() {
                   <AlertDialogTrigger asChild>
                     <Button
                       type="button"
-                      className="flex h-[36px] w-36 items-center gap-2 px-0"
+                      className="flex h-[36px] w-48 items-center gap-2 px-0"
                     >
                       <PlusCircleIcon className="h-4 w-4" />
-                      <div className="mb-[2px] text-sm">Import Problem</div>
+                      <div className="mb-[2px] text-sm">
+                        Import · Edit problem
+                      </div>
                     </Button>
                   </AlertDialogTrigger>
                   <AlertDialogContent className="p-8">
@@ -244,6 +246,7 @@ export default function Page() {
                 data={problems as ContestProblem[]}
                 defaultSortColumn={{ id: 'order', desc: false }}
                 enableFooter={true}
+                defaultPageSize={20}
               />
             </div>
             <Button

--- a/apps/frontend/app/admin/contest/page.tsx
+++ b/apps/frontend/app/admin/contest/page.tsx
@@ -69,6 +69,7 @@ export default function Page() {
               isVisible: 'px-0 w-1/12'
             }}
             enableDuplicate={true}
+            defaultSortColumn={{ id: 'startTime', desc: true }}
           />
         )}
       </div>

--- a/apps/frontend/app/admin/problem/create/page.tsx
+++ b/apps/frontend/app/admin/problem/create/page.tsx
@@ -180,7 +180,7 @@ export default function Page() {
             <AlertDialog open={showCreateModal}>
               <AlertDialogContent className="p-8">
                 <AlertDialogHeader className="gap-2">
-                  <AlertDialogTitle>Create Contest?</AlertDialogTitle>
+                  <AlertDialogTitle>Create Problem?</AlertDialogTitle>
                   <AlertDialogDescription>
                     Once user submit any coding, the testcases{' '}
                     <span className="underline">cannot</span> be modified.

--- a/apps/frontend/app/admin/problem/page.tsx
+++ b/apps/frontend/app/admin/problem/page.tsx
@@ -133,6 +133,7 @@ export default function Page({
             enableFilter={true}
             enableDelete={true}
             enablePagination={true}
+            defaultSortColumn={{ id: 'createTime', desc: true }}
           />
         )}
       </div>

--- a/apps/frontend/components/DataTableAdmin.tsx
+++ b/apps/frontend/components/DataTableAdmin.tsx
@@ -475,7 +475,9 @@ export function DataTableAdmin<TData, TValue>({
                             if (selectedRowCount < 20 || row.getIsSelected()) {
                               row.toggleSelected(!row.getIsSelected())
                             } else {
-                              toast.error('Maximum number of problems is 20.')
+                              toast.error(
+                                'You can only import up to 20 problems in a contest'
+                              )
                             }
                           } else {
                             href && router.push(href)

--- a/apps/frontend/components/DataTableAdmin.tsx
+++ b/apps/frontend/components/DataTableAdmin.tsx
@@ -43,7 +43,7 @@ import {
   getSortedRowModel,
   useReactTable
 } from '@tanstack/react-table'
-import { CopyIcon, PlusCircleIcon } from 'lucide-react'
+import { CopyIcon } from 'lucide-react'
 import type { Route } from 'next'
 import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState, Suspense } from 'react'
@@ -75,6 +75,7 @@ interface DataTableProps<TData, TValue> {
   onSelectedExport?: (selectedRows: ContestProblem[]) => void
   defaultSortColumn?: { id: string; desc: boolean }
   enableFooter?: boolean
+  defaultPageSize?: number
 }
 
 interface ContestProblem {
@@ -110,10 +111,17 @@ export function DataTableAdmin<TData, TValue>({
   enableDuplicate = false,
   onSelectedExport = () => {},
   defaultSortColumn = { id: '', desc: false },
-  enableFooter = false
+  enableFooter = false,
+  defaultPageSize = 10
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = useState({})
   const [sorting, setSorting] = useState<SortingState>([])
+  const [defaultSortExists, setDefaultExists] = useState(defaultSortColumn.id)
+  useEffect(() => {
+    if (defaultSortExists)
+      setSorting([{ id: defaultSortColumn.id, desc: defaultSortColumn.desc }])
+    setDefaultExists('')
+  }, [defaultSortExists, defaultSortColumn])
   const pathname = usePathname()
   const page = pathname.split('/').pop()
   const router = useRouter()
@@ -127,8 +135,8 @@ export function DataTableAdmin<TData, TValue>({
       maxSize: Number.MAX_SAFE_INTEGER
     },
     state: {
-      sorting: defaultSortColumn.id
-        ? [{ id: defaultSortColumn.id, desc: defaultSortColumn.desc }]
+      sorting: enableImport
+        ? [{ id: 'select', desc: true }, ...sorting]
         : sorting,
       rowSelection,
       columnVisibility: { languages: false }
@@ -146,10 +154,8 @@ export function DataTableAdmin<TData, TValue>({
   })
 
   useEffect(() => {
-    if (enableImport) {
-      table.setPageSize(5)
-    }
-  }, [enableImport, table])
+    table.setPageSize(defaultPageSize)
+  }, [defaultPageSize, table])
 
   let deletingObject
   if (pathname === '/admin/contest') {
@@ -317,8 +323,7 @@ export function DataTableAdmin<TData, TValue>({
           <div className="flex gap-2">
             {enableImport ? (
               <Button onClick={() => handleImportProblems()}>
-                <PlusCircleIcon className="mr-2 h-4 w-4" />
-                Import
+                Import / Edit
               </Button>
             ) : null}
             {enableDuplicate ? (
@@ -464,9 +469,17 @@ export function DataTableAdmin<TData, TValue>({
                         key={cell.id}
                         className="text-center md:p-4"
                         onClick={() => {
-                          enableImport
-                            ? row.toggleSelected(!row.getIsSelected())
-                            : href && router.push(href)
+                          if (enableImport) {
+                            const selectedRowCount =
+                              table.getSelectedRowModel().rows.length
+                            if (selectedRowCount < 20 || row.getIsSelected()) {
+                              row.toggleSelected(!row.getIsSelected())
+                            } else {
+                              toast.error('Maximum number of problems is 20.')
+                            }
+                          } else {
+                            href && router.push(href)
+                          }
                         }}
                       >
                         {flexRender(

--- a/apps/frontend/components/DataTableProblemFilter.tsx
+++ b/apps/frontend/components/DataTableProblemFilter.tsx
@@ -26,7 +26,9 @@ export default function DataTableLevelFilter<TData, TValue>({
   column
 }: DataTableProblemFilterProps<TData, TValue>) {
   const { id } = useParams()
-  const selectedValue = column?.getFilterValue() as string | undefined
+  const [selectedValue, setSelectedValue] = useState<string | undefined>(
+    undefined
+  )
   const [problemFilterOpen, setProblemFilterOpen] = useState(false)
   const [problems, setProblems] = useState<string[]>([])
 
@@ -72,8 +74,9 @@ export default function DataTableLevelFilter<TData, TValue>({
                   onSelect={() => {
                     option === 'All Problems'
                       ? column?.setFilterValue(null)
-                      : column?.setFilterValue(option)
+                      : column?.setFilterValue(option.slice(3))
                     setProblemFilterOpen(false)
+                    setSelectedValue(option)
                   }}
                 >
                   <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">

--- a/apps/frontend/components/DataTableProblemFilter.tsx
+++ b/apps/frontend/components/DataTableProblemFilter.tsx
@@ -47,18 +47,20 @@ export default function DataTableLevelFilter<TData, TValue>({
 
   return (
     <Popover open={problemFilterOpen} onOpenChange={setProblemFilterOpen}>
-      <PopoverTrigger className="w-44 p-0" asChild>
+      <PopoverTrigger className="w-[250px] p-0" asChild>
         <Button
           variant="outline"
           size={'sm'}
           className="flex h-10 justify-between border px-4 hover:bg-gray-50"
         >
-          <p className="font-bold">{selectedValue ?? 'All Problems'}</p>
+          <p className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
+            {selectedValue ?? 'All Problems'}
+          </p>
           <FaChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-44 p-0" align="start">
+      <PopoverContent className="w-[250px] p-0" align="start">
         <Command>
           <CommandList>
             <CommandGroup>
@@ -66,7 +68,7 @@ export default function DataTableLevelFilter<TData, TValue>({
                 <CommandItem
                   key={option}
                   value={option}
-                  className="flex justify-between text-xs"
+                  className="flex items-center justify-between"
                   onSelect={() => {
                     option === 'All Problems'
                       ? column?.setFilterValue(null)
@@ -74,10 +76,12 @@ export default function DataTableLevelFilter<TData, TValue>({
                     setProblemFilterOpen(false)
                   }}
                 >
-                  {option}
+                  <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">
+                    {option}
+                  </p>
                   <FaCheck
                     className={cn(
-                      'h-4 w-4',
+                      'h-4 w-4 flex-shrink-0',
                       selectedValue === option ||
                         (!selectedValue && option == 'All Problems')
                         ? 'opacity-100'

--- a/apps/frontend/components/EditorLayout.tsx
+++ b/apps/frontend/components/EditorLayout.tsx
@@ -38,7 +38,9 @@ export default async function EditorLayout({
 
   if (contestId) {
     // for getting contest info and problems list
-    problems = await fetcherWithAuth.get(`contest/${contestId}/problem`).json()
+    problems = await fetcherWithAuth
+      .get(`contest/${contestId}/problem?take=20`)
+      .json()
     const ContestProblem: { problem: ProblemDetail } = await fetcherWithAuth
       .get(`contest/${contestId}/problem/${problemId}`)
       .json()

--- a/apps/frontend/components/OptionSelect.tsx
+++ b/apps/frontend/components/OptionSelect.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
+import { ScrollArea } from './ui/scroll-area'
 
 interface OptionSelectProps {
   options: string[] | readonly string[]
@@ -34,17 +35,19 @@ export default function OptionSelect({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent className="w-[115px] bg-white">
-        <SelectGroup>
-          {options.map((option) => (
-            <SelectItem
-              key={option}
-              value={option}
-              className="cursor-pointer hover:bg-gray-100/80"
-            >
-              {option}
-            </SelectItem>
-          ))}
-        </SelectGroup>
+        <ScrollArea>
+          <SelectGroup className="max-h-40">
+            {options.map((option) => (
+              <SelectItem
+                key={option}
+                value={option}
+                className="cursor-pointer hover:bg-gray-100/80"
+              >
+                {option}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </ScrollArea>
       </SelectContent>
     </Select>
   )

--- a/apps/frontend/components/OptionSelect.tsx
+++ b/apps/frontend/components/OptionSelect.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
   SelectContent,
@@ -7,7 +8,6 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
-import { ScrollArea } from './ui/scroll-area'
 
 interface OptionSelectProps {
   options: string[] | readonly string[]


### PR DESCRIPTION
### Description

**주의: 한 PR에 너무 많은 태스크를 해결하였습니다... 죄송합니다..!**

1. admin problem list는 Update 내림차순으로, admin contest list는 Period 내림차순으로 디폴트 정렬을 설정하였습니다. initialState와 state를 동시에 이용하는 건 불가능하다길래 state의 초깃값을 설정하는 방식으로 변경하였습니다.

2. import 모달 테이블에서 체크된 문제를 최우선으로 앞에 두도록 하였습니다. enableImport가 참일 경우 항상 체크 여부를 커스텀 정렬보다 우선순위를 높게 설정하였습니다.

3. import 모달 테이블에서 20개 초과 문제를 체크할 수 없도록 하였습니다. 5개 문제를 한꺼번에 체크하는 헤더의 체크박스에도 로직을 적용하였습니다. 만일 20개를 넘어가게 된다면 작동하지 않으면서 toast를 띄웁니다. 문제의 정렬을 선택하는 OptionSelect에서도 5개를 넘어가면 스크롤바가 나오도록 변경하였고, 클라이언트에서도 문제를 20개까지 가져오도록 수정하였습니다.(?take=20을 임의로 줬는데, 백엔드에서 기본값을 변경하는 게 맞을지도요..?)

4. import 문구를 import / edit 문구로 변경하였습니다.

5. contest 점수를 0 이상의 점수만 입력받도록 하였습니다. 서진이형이 테스트케이스에서 적용한 방식을 따라했는데, focus를 잃는다고 바로 뜨는 것이 아니라 edit/create 버튼을 눌러야 경고가 뜨도록 되어 있는 것 같습니다.

6. contest overall의 submission 페이지에서 문제 제목이 길면 필터 상자를 튀어나오는 문제를 넓이를 좀 더 넓히고 ...처리를 통해 해결하였습니다.

7. 오타를 수정하였습니다. (Create Contest? -> Create Problem?)

(추가)
8. All Submissions와 Participant 페이지의 테이블에서 problem filter가 적용되지 않던 문제를 수정했습니다!

closes TAS-838
closes TAS-842
closes TAS-843
closes TAS-854
closes TAS-857
closes TAS-873
 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
