### PR TITLE
fix(be): check if score or score-weight is non-negative integer

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.module.ts
+++ b/apps/backend/apps/admin/src/contest/contest.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { RolesModule } from '@libs/auth'
+import { ProblemModule } from '@admin/problem/problem.module'
 import { ContestResolver } from './contest.resolver'
 import { ContestService } from './contest.service'
 
 @Module({
-  imports: [RolesModule],
+  imports: [RolesModule, ProblemModule],
   providers: [ContestService, ContestResolver]
 })
 export class ContestModule {}

--- a/apps/backend/apps/admin/src/contest/model/problem-score.input.ts
+++ b/apps/backend/apps/admin/src/contest/model/problem-score.input.ts
@@ -1,10 +1,11 @@
 import { Field, InputType, Int } from '@nestjs/graphql'
+import { IntScoreScalar } from '@admin/problem/scalar/int-score.scalar'
 
 @InputType()
 export class ProblemScoreInput {
   @Field(() => Int)
   problemId: number
 
-  @Field(() => Int)
+  @Field(() => IntScoreScalar)
   score: number
 }

--- a/apps/backend/apps/admin/src/problem/model/testcase.input.ts
+++ b/apps/backend/apps/admin/src/problem/model/testcase.input.ts
@@ -1,10 +1,13 @@
-import { InputType, PickType } from '@nestjs/graphql'
+import { Field, InputType, PickType } from '@nestjs/graphql'
 import { ProblemTestcaseCreateInput } from '@admin/@generated'
+import { IntScoreScalar } from '../scalar/int-score.scalar'
 
 @InputType()
 export class Testcase extends PickType(ProblemTestcaseCreateInput, [
   'input',
   'output',
-  'scoreWeight',
   'isHidden'
-]) {}
+]) {
+  @Field(() => IntScoreScalar, { nullable: true })
+  scoreWeight?: number
+}

--- a/apps/backend/apps/admin/src/problem/problem.module.ts
+++ b/apps/backend/apps/admin/src/problem/problem.module.ts
@@ -8,6 +8,7 @@ import {
   WorkbookProblemResolver
 } from './problem.resolver'
 import { ProblemService } from './problem.service'
+import { IntScoreScalar } from './scalar/int-score.scalar'
 
 @Module({
   imports: [StorageModule, ConfigModule],
@@ -17,7 +18,9 @@ import { ProblemService } from './problem.service'
     TagResolver,
     ProblemService,
     ContestProblemResolver,
-    WorkbookProblemResolver
-  ]
+    WorkbookProblemResolver,
+    IntScoreScalar
+  ],
+  exports: [IntScoreScalar]
 })
 export class ProblemModule {}

--- a/apps/backend/apps/admin/src/problem/scalar/int-score.scalar.ts
+++ b/apps/backend/apps/admin/src/problem/scalar/int-score.scalar.ts
@@ -5,7 +5,7 @@ import { UnprocessableDataException } from '@libs/exception'
 @Scalar('IntScore', () => IntScoreScalar)
 export class IntScoreScalar implements CustomScalar<number, number> {
   parseValue(value: number) {
-    if (typeof value !== 'number' || value < 0 || !Number.isInteger(value)) {
+    if (value < 0 || !Number.isInteger(value)) {
       throw new UnprocessableDataException(
         'Score(ScoreWeight) must be a non-negative integer.'
       )

--- a/apps/backend/apps/admin/src/problem/scalar/int-score.scalar.ts
+++ b/apps/backend/apps/admin/src/problem/scalar/int-score.scalar.ts
@@ -1,0 +1,29 @@
+import { Scalar, type CustomScalar } from '@nestjs/graphql'
+import { type ValueNode, Kind } from 'graphql'
+import { UnprocessableDataException } from '@libs/exception'
+
+@Scalar('IntScore', () => IntScoreScalar)
+export class IntScoreScalar implements CustomScalar<number, number> {
+  parseValue(value: number) {
+    if (typeof value !== 'number' || value < 0 || !Number.isInteger(value)) {
+      throw new UnprocessableDataException(
+        'Score(ScoreWeight) must be a non-negative integer.'
+      )
+    }
+    return value
+  }
+
+  serialize(value: number) {
+    return value
+  }
+
+  parseLiteral(ast: ValueNode) {
+    if (ast.kind === Kind.INT) {
+      const value = parseInt(ast.value, 10)
+      if (value >= 0) return value
+    }
+    throw new UnprocessableDataException(
+      'Score(ScoreWeight) must be a non-negative integer.'
+    )
+  }
+}

--- a/collection/admin/Problem/Create Problem/Succeed.bru
+++ b/collection/admin/Problem/Create Problem/Succeed.bru
@@ -63,7 +63,8 @@ body:graphql:vars {
         {
           "input": "input",
           "output": "output",
-          "isHidden": false
+          "isHidden": false,
+          "scoreWeight": 10
         }
       ],
       "tagIds": [1]


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-862

0 이상의 정수만을 받는 `IntScore` GraphQL Scalar Type을 만들고, score와 scoreWeight에 적용해 0 이상의 정수만을 받을 수 있도록 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
