### PR TITLE
feat(be): add accepted-rate calculating logic when submission created

### DIFF
--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -336,11 +336,22 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       }
     }
 
+    const problem = await this.prisma.problem.findFirstOrThrow({
+      where: {
+        id
+      }
+    })
+
     await this.prisma.problem.update({
       where: {
         id
       },
-      data
+      data: {
+        ...data,
+        acceptedRate: isAccepted
+          ? (problem.acceptedCount + 1) / (problem.submissionCount + 1)
+          : problem.acceptedCount / (problem.submissionCount + 1)
+      }
     })
   }
 }

--- a/apps/backend/apps/client/src/submission/test/submission-sub.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission-sub.service.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '@libs/constants'
 import { UnprocessableDataException } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
+import { problems } from '@admin/problem/mock/mock'
 import { contestRecord } from '../mock/contestRecord.mock'
 import { submissions } from '../mock/submission.mock'
 import { submissionResults } from '../mock/submissionResult.mock'
@@ -75,7 +76,8 @@ const db = {
     findFirstOrThrow: mockFunc
   },
   problem: {
-    update: mockFunc
+    update: mockFunc,
+    findFirstOrThrow: mockFunc
   }
 }
 
@@ -552,6 +554,7 @@ describe('SubmissionSubscriptionService', () => {
   describe('updateProblemAccepted', () => {
     it('should update submissionCount', async () => {
       const updateSpy = sandbox.stub(db.problem, 'update').resolves()
+      sandbox.stub(db.problem, 'findFirstOrThrow').resolves(problems[0])
       const id = 1
       const isAccepted = false
 
@@ -564,7 +567,9 @@ describe('SubmissionSubscriptionService', () => {
           data: {
             submissionCount: {
               increment: 1
-            }
+            },
+            acceptedRate:
+              problems[0].acceptedCount / (problems[0].submissionCount + 1)
           }
         })
       ).to.be.true
@@ -572,6 +577,7 @@ describe('SubmissionSubscriptionService', () => {
 
     it('should update submissionCount and acceptedCount', async () => {
       const updateSpy = sandbox.stub(db.problem, 'update').resolves()
+      sandbox.stub(db.problem, 'findFirstOrThrow').resolves(problems[0])
       const id = 1
       const isAccepted = true
 
@@ -587,7 +593,10 @@ describe('SubmissionSubscriptionService', () => {
             },
             acceptedCount: {
               increment: 1
-            }
+            },
+            acceptedRate:
+              (problems[0].acceptedCount + 1) /
+              (problems[0].submissionCount + 1)
           }
         })
       ).to.be.true


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-841

Problem 조회 시 Accepted Rate가 0으로 표시되는 문제를 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
