### PR TITLE
feat(fe): apply scrollarea only to score table

### DIFF
--- a/apps/frontend/app/admin/contest/[id]/(overall)/@tabs/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/[id]/(overall)/@tabs/_components/Columns.tsx
@@ -30,7 +30,8 @@ export const columns = (
         <div className="whitespace-nowrap text-center text-xs font-medium">
           {row.original.realName}
         </div>
-      )
+      ),
+      filterFn: 'includesString'
     },
     {
       accessorKey: 'username',

--- a/apps/frontend/app/admin/contest/[id]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/(overall)/@tabs/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { DataTableAdmin } from '@/components/DataTableAdmin'
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { Skeleton } from '@/components/ui/skeleton'
 import { GET_CONTEST_SCORE_SUMMARIES } from '@/graphql/contest/queries'
 import { GET_CONTEST_PROBLEMS } from '@/graphql/problem/queries'
@@ -41,13 +42,25 @@ export default function Submission() {
           ))}
         </>
       ) : (
-        <DataTableAdmin
-          columns={columns(problemData as ProblemData[])}
-          data={summariesData as ScoreSummary[]}
-          enableSearch={true}
-          searchColumn="realName"
-          enablePagination={true}
-        />
+        <>
+          <p className="mb-3 font-medium">
+            <span className="text-primary font-bold">
+              {summariesData?.length}
+            </span>{' '}
+            Participants
+          </p>
+          <ScrollArea>
+            <DataTableAdmin
+              columns={columns(problemData as ProblemData[])}
+              data={summariesData as ScoreSummary[]}
+              enableSearch={true}
+              searchColumn="realName"
+              enablePagination={true}
+            />
+            <div className="mt-6" />
+            <ScrollBar orientation="horizontal" />
+          </ScrollArea>
+        </>
       )}
     </div>
   )

--- a/apps/frontend/app/admin/contest/[id]/(overall)/@tabs/submission/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/(overall)/@tabs/submission/page.tsx
@@ -15,7 +15,7 @@ export default function Submission() {
       input: {
         contestId: Number(id)
       },
-      take: 10
+      take: 1000
     }
   })
   const submissions = data?.getContestSubmissions || []

--- a/apps/frontend/app/admin/contest/[id]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/contest/[id]/(overall)/layout.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { GET_CONTEST } from '@/graphql/contest/queries'
 import { renderKatex } from '@/lib/renderKatex'
 import { dateFormatter } from '@/lib/utils'
@@ -41,39 +40,36 @@ export default function Layout({
   )
 
   return (
-    <ScrollArea className="shrink-0">
-      <main className="flex flex-col gap-6 px-20 py-16">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Link href="/admin/contest">
-              <FaAngleLeft className="h-12 hover:text-gray-700/80" />
-            </Link>
-            <span className="text-4xl font-bold">{contestData?.title}</span>
-          </div>
-          <Link href={`/admin/contest/${id}/edit`}>
-            <Button variant="default">
-              <FaPencil className="mr-2 h-4 w-4" />
-              Edit
-            </Button>
+    <main className="flex flex-col gap-6 px-20 py-16">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link href="/admin/contest">
+            <FaAngleLeft className="h-12 hover:text-gray-700/80" />
           </Link>
+          <span className="text-4xl font-bold">{contestData?.title}</span>
         </div>
-        <div className="flex justify-between">
-          <p className="text-primary font-bold">
-            Invitation code: {contestData?.invitationCode}
+        <Link href={`/admin/contest/${id}/edit`}>
+          <Button variant="default">
+            <FaPencil className="mr-2 h-4 w-4" />
+            Edit
+          </Button>
+        </Link>
+      </div>
+      <div className="flex justify-between">
+        <p className="text-primary font-bold">
+          Invitation code: {contestData?.invitationCode}
+        </p>
+        <div className="flex items-center gap-2">
+          <Image src={Period} alt="period" width={22} />
+          <p className="font-semibold">
+            {dateFormatter(contestData?.startTime, 'YY-MM-DD HH:mm')} ~{' '}
+            {dateFormatter(contestData?.endTime, 'YY-MM-DD HH:mm')}
           </p>
-          <div className="flex items-center gap-2">
-            <Image src={Period} alt="period" width={22} />
-            <p className="font-semibold">
-              {dateFormatter(contestData?.startTime, 'YY-MM-DD HH:mm')} ~{' '}
-              {dateFormatter(contestData?.endTime, 'YY-MM-DD HH:mm')}
-            </p>
-          </div>
         </div>
-        {katexContent}
-        <ContestOverallTabs contestId={id} />
-        {tabs}
-      </main>
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+      </div>
+      {katexContent}
+      <ContestOverallTabs contestId={id} />
+      {tabs}
+    </main>
   )
 }

--- a/apps/frontend/app/admin/contest/[id]/participant/[userId]/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/participant/[userId]/page.tsx
@@ -26,7 +26,7 @@ export default function Page({
   const userData = user.data?.getGroupMember
 
   const submissions = useQuery(GET_CONTEST_SUBMISSION_SUMMARIES_OF_USER, {
-    variables: { contestId: Number(id), userId: Number(userId) }
+    variables: { contestId: Number(id), userId: Number(userId), take: 1000 }
   })
   const submissionsLoading = submissions.loading
   const scoreData =

--- a/apps/frontend/components/DataTableAdmin.tsx
+++ b/apps/frontend/components/DataTableAdmin.tsx
@@ -271,7 +271,11 @@ export function DataTableAdmin<TData, TValue>({
               <div className="relative">
                 <IoSearch className="text-muted-foreground absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
                 <Input
-                  placeholder="Search"
+                  placeholder={
+                    /^\/admin\/contest\/\d+$/.test(pathname)
+                      ? 'Search Name'
+                      : 'Search'
+                  }
                   value={
                     (table
                       .getColumn(searchColumn)

--- a/apps/frontend/graphql/contest/queries.ts
+++ b/apps/frontend/graphql/contest/queries.ts
@@ -71,8 +71,8 @@ const GET_CONTEST_SCORE_SUMMARIES =
   }`)
 
 const GET_CONTEST_SUBMISSION_SUMMARIES_OF_USER =
-  gql(`query getContestSubmissionSummariesByUserId($contestId: Int!, $userId: Int!) {
-  getContestSubmissionSummaryByUserId(contestId: $contestId, userId: $userId) {
+  gql(`query getContestSubmissionSummariesByUserId($contestId: Int!, $userId: Int!, $take: Int!) {
+  getContestSubmissionSummaryByUserId(contestId: $contestId, userId: $userId, take: $take) {
     scoreSummary {
       contestPerfectScore
       problemScores {

--- a/collection/admin/Contest/Get Contest Score Summary of User/Succeed.bru
+++ b/collection/admin/Contest/Get Contest Score Summary of User/Succeed.bru
@@ -11,8 +11,8 @@ post {
 }
 
 body:graphql {
-  query getContestSubmissionSummariesByUserId($contestId: Int!, $userId: Int!) {
-    getContestSubmissionSummaryByUserId(contestId: $contestId, userId: $userId) {
+  query getContestSubmissionSummariesByUserId($contestId: Int!, $userId: Int!, $take: Int!) {
+    getContestSubmissionSummaryByUserId(contestId: $contestId, userId: $userId, take: $take) {
       scoreSummary {
         contestPerfectScore
         problemScores {
@@ -39,13 +39,14 @@ body:graphql {
       }
     }
   }
-  
+
 }
 
 body:graphql:vars {
   {
     "contestId": 1,
-    "userId": 4
+    "userId": 4,
+    "take": 500
     // "problemId": 1
   }
 }
@@ -53,10 +54,10 @@ body:graphql:vars {
 docs {
   ## Get Contest Score Summary of User
   유저의 특정 Contest에 대한 점수 요약을 반환합니다.
-  
+
   Contest Overall 페이지에서 특정 유저를 선택했을 때 사용
   https://github.com/skkuding/codedang/pull/1894
-  
+
   - submittedProblemCount
     - 제출된 문제의 개수(정답 여부와 관계 없음)
   - totalProblemCount


### PR DESCRIPTION
### Description

1. Contest overall participant page에서 score table에만 횡스크롤을 적용시켜 Edit 버튼과 기간이 스크롤해야 나타나는 문제를 해결하였습니다.

2. Contest overall participant page의 score table 위에 Participant 수를 추가하였습니다.

3. Contest overall의 Participant Detail Page, All submissions Page에서 submission이 10개만 노출되는 것을 1000개로 늘렸습니다. (bruno에 take가 명시되어 있지 않아 바꾸었는데 괜찮겠죠?)

4. Contest overall participant page의 검색 input의 placeholder를 'Search Name'으로 수정하였습니다. 

5. Contest overall에서 검색이 안 되는 문제를 해결하였습니다. **(꽤 유익할 만한 정보가 있습니다..!)**
Contest overall participant page에서 검색을 했을 때 어떤 Contest는 대소문자 구분없이 일부만 match되도 잘 뜨고 어떤 Contest는 처음부터 끝까지 정확히 일치해야만 뜨는 현상이 있었습니다. 몇 시간동안 머리를 싸매며 검색한 결과, filterFn을 따로 설정하지 않았을 때 디폴트 값은 'auto'로 이는 column의 첫 번째 값을 기준으로 필터링 방식을 결정하는데, realName의 경우 string | null type이고, Contest의 첫 번째 realName이 운 나쁘게 null인 경우 'equals'(===)으로 결정하고, 'includesString'(대소문자 상관없이 포함도 가능)로 설정하는 것 같습니다. 테스트해보진 않았지만 chatGPT와 토론해본 결과 sortingFn의 경우에도 비슷한 메커니즘이 적용될 것으로 예상됩니다. 따라서 null과 같은 type을 가질 수 있는 column을 기준으로 filtering이나 sorting을 구현할 때는 처음에는 문제가 없어보일지라도 filterFn이나 sortingFn을 반드시 명시하는 게 좋아보입니다..!

closes TAS-865
closes TAS-866
closes TAS-867
closes TAS-868


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
