### PR TITLE
feat(be): redact max-score, score when is-judge-result-visible of contest is false

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
+import { Prisma, type Contest } from '@prisma/client'
 import { OPEN_SPACE_ID } from '@libs/constants'
 import {
   ConflictFoundException,
@@ -328,7 +328,7 @@ export class ContestService {
     // check if the user has already registered this contest
     // initial value is false
     let isRegistered = false
-    let contest
+    let contest: Partial<Contest>
     if (userId) {
       const hasRegistered = await this.prisma.contestRecord.findFirst({
         where: { userId, contestId: id }

--- a/apps/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.spec.ts
@@ -286,7 +286,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        isRegistered: true
+        isRegistered: true,
+        invitationCodeExists: true,
+        isJudgeResultVisible: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
       db.submission.findMany.resolves([])
@@ -309,7 +311,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        isRegistered: true
+        isRegistered: true,
+        invitationCodeExists: true,
+        isJudgeResultVisible: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -347,7 +351,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.future(),
         endTime: faker.date.future(),
-        isRegistered: true
+        isRegistered: true,
+        isJudgeResultVisible: true,
+        invitationCodeExists: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -361,7 +367,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        isRegistered: false
+        isRegistered: false,
+        isJudgeResultVisible: true,
+        invitationCodeExists: true
       })
       db.contestProblem.findMany.resolves(mockContestProblems)
 
@@ -378,7 +386,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        isRegistered: true
+        isRegistered: true,
+        isJudgeResultVisible: true,
+        invitationCodeExists: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
 
@@ -401,7 +411,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        isRegistered: true
+        isRegistered: true,
+        isJudgeResultVisible: true,
+        invitationCodeExists: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
 
@@ -434,7 +446,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.future(),
         endTime: faker.date.future(),
-        isRegistered: true
+        isRegistered: true,
+        isJudgeResultVisible: true,
+        invitationCodeExists: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
       await expect(
@@ -447,7 +461,9 @@ describe('ContestProblemService', () => {
       getContestSpy.resolves({
         startTime: faker.date.past(),
         endTime: faker.date.future(),
-        isRegistered: false
+        isRegistered: false,
+        isJudgeResultVisible: true,
+        invitationCodeExists: true
       })
       db.contestProblem.findUniqueOrThrow.resolves(mockContestProblem)
       await expect(

--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -97,11 +97,11 @@ export class ContestProblemService {
       userId
     )
     const now = new Date()
-    if (contest.isRegistered && contest.startTime > now) {
+    if (contest.isRegistered && contest.startTime! > now) {
       throw new ForbiddenAccessException(
         'Cannot access problems before the contest starts.'
       )
-    } else if (!contest.isRegistered && contest.endTime > now) {
+    } else if (!contest.isRegistered && contest.endTime! > now) {
       throw new ForbiddenAccessException(
         'Register to access the problems of this contest.'
       )
@@ -137,15 +137,17 @@ export class ContestProblemService {
       if (!submission) {
         return {
           ...contestProblem,
-          maxScore: contestProblem.score,
+          maxScore: contest.isJudgeResultVisible ? contestProblem.score : null,
           score: null,
           submissionTime: null
         }
       }
       return {
         ...contestProblem,
-        maxScore: contestProblem.score,
-        score: ((submission.score * contestProblem.score) / 100).toFixed(0),
+        maxScore: contest.isJudgeResultVisible ? contestProblem.score : null,
+        score: contest.isJudgeResultVisible
+          ? ((submission.score * contestProblem.score) / 100).toFixed(0)
+          : null,
         submissionTime: submission.createTime ?? null
       }
     })
@@ -171,11 +173,11 @@ export class ContestProblemService {
       userId
     )
     const now = new Date()
-    if (contest.isRegistered && contest.startTime > now) {
+    if (contest.isRegistered && contest.startTime! > now) {
       throw new ForbiddenAccessException(
         'Cannot access to problems before the contest starts.'
       )
-    } else if (!contest.isRegistered && contest.endTime > now) {
+    } else if (!contest.isRegistered && contest.endTime! > now) {
       throw new ForbiddenAccessException('Register to access this problem.')
     }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-886

`isJudgeResultVisible === false` 인 경우 getContestProblems API의 결과로 반환되는 `maxScore`, `score`를 null로 대체합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
