### PR TITLE
feat(fe): longer contest timer toast

### DIFF
--- a/apps/frontend/components/ContestStatusTimeDiff.tsx
+++ b/apps/frontend/components/ContestStatusTimeDiff.tsx
@@ -61,10 +61,10 @@ export default function ContestStatusTimeDiff({
 
     if (inContestEditor) {
       if (days === 0 && hours === 0 && minutes === 5 && seconds === 0) {
-        toast.error('Contest ends in 5 minutes.')
+        toast.error('Contest ends in 5 minutes.', { duration: 10000 })
       }
       if (days === 0 && hours === 0 && minutes === 1 && seconds === 0) {
-        toast.error('Contest ends in 1 minute.')
+        toast.error('Contest ends in 1 minute.', { duration: 10000 })
       }
     }
 


### PR DESCRIPTION
### Description
contest timer toast duration을 10초로 늘립니다.
원래는 2초가 기본값이지만, 옵션으로 인자를 넘겨서 default값을 오버라이드합니다.

closes TAS-853 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
