### PR TITLE
fix(fe): fix admin problem language template bug

### DIFF
--- a/apps/frontend/app/admin/problem/_components/TemplateField.tsx
+++ b/apps/frontend/app/admin/problem/_components/TemplateField.tsx
@@ -1,11 +1,41 @@
+'use client'
+
 import { Textarea } from '@/components/ui/textarea'
-import type { Language } from '@/types/type'
+import type { Template, Language } from '@generated/graphql'
+import { useEffect, useRef } from 'react'
 import { useFormContext } from 'react-hook-form'
 import Label from '../../_components/Label'
 
 export default function TemplateField() {
-  const { register, watch } = useFormContext()
-  const watchedLanguages: Language[] = watch('languages')
+  const { register, unregister, watch, getValues, setValue } = useFormContext()
+  const watchedLanguages: Language[] = watch('languages') ?? []
+  const watchedTemplates: Template[] = watch('template') ?? []
+  const previousLanguagesRef = useRef<Language[]>([])
+
+  useEffect(() => {
+    const previousLanguages = previousLanguagesRef.current ?? []
+    const removedCount =
+      previousLanguages.length - watchedLanguages.length > 0
+        ? previousLanguages.length - watchedLanguages.length
+        : 0
+
+    // Unregister templates that are no longer associated with existing languages
+    for (let i = 0; i < removedCount; i++) {
+      const index = previousLanguages.length - 1 - i
+      unregister(`template.${index}`)
+    }
+
+    // Filter out any empty template objects
+    // Note: Even after unregistering, some templates may remain as empty objects
+    const filteredTemplates = watchedTemplates.filter((template) => {
+      return Object.keys(template).length > 0
+    })
+
+    setValue('template', filteredTemplates)
+
+    previousLanguagesRef.current = watchedLanguages
+  }, [watchedLanguages, unregister, getValues])
+
   return (
     <div className="flex flex-col gap-6">
       {watchedLanguages &&

--- a/apps/frontend/app/admin/problem/_components/TemplateField.tsx
+++ b/apps/frontend/app/admin/problem/_components/TemplateField.tsx
@@ -7,7 +7,7 @@ import { useFormContext } from 'react-hook-form'
 import Label from '../../_components/Label'
 
 export default function TemplateField() {
-  const { register, unregister, watch, getValues, setValue } = useFormContext()
+  const { register, unregister, watch, setValue } = useFormContext()
   const watchedLanguages: Language[] = watch('languages') ?? []
   const watchedTemplates: Template[] = watch('template') ?? []
   const previousLanguagesRef = useRef<Language[]>([])
@@ -34,7 +34,7 @@ export default function TemplateField() {
     setValue('template', filteredTemplates)
 
     previousLanguagesRef.current = watchedLanguages
-  }, [watchedLanguages, unregister, getValues])
+  }, [watchedLanguages, unregister])
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
### Description
문제 생성 도중 languages 를 선택하고 나서 template을 작성 후

다시 languages를 선택 해제하고 문제 생성을 시도 시 실패하던 문제 해결

### 문제 재현

1. 문제 생성 페이지 접속
2. 다른 것 모두 작성
3. languages로 C / C++ / java / python3 작성
4. C언어 템플릿 작성
5. languages에서 C 선택 해제
6. Submit
7. `This problem does not support language` 에러 발생

### 문제 원인
- Language를 선택 취소하더라도 Template이 form에 남아 있음

### 해결 방법
- ref를 이용해 이전 Template 정보를 기록
- 현재 Template 정보와 비교해서 필요 없는 부분을 unregister
- 하지만 unregister 하더라도 빈 객체가 남기에 이를 필터링 후 setValue
### Additional context
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-827



<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
