### PR TITLE
fix(fe): fix text editor placeholder, componentize katex

### DIFF
--- a/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/@tabs/page.tsx
@@ -1,6 +1,6 @@
+import KatexContent from '@/components/KatexContent'
 import { auth } from '@/lib/auth'
 import { fetcherWithAuth } from '@/lib/utils'
-import { sanitize } from 'isomorphic-dompurify'
 import RegisterButton from './_components/RegisterButton'
 
 interface ContestTop {
@@ -37,9 +37,9 @@ export default async function ContestTop({ params }: ContestTopProps) {
 
   return (
     <>
-      <main
-        className="prose w-full max-w-full border-b-2 border-b-gray-300 p-5 py-12"
-        dangerouslySetInnerHTML={{ __html: sanitize(data.description) }}
+      <KatexContent
+        content={data.description}
+        classname="prose w-full max-w-full border-b-2 border-b-gray-300 p-5 py-12"
       />
       {session && state !== 'Finished' && (
         <div className="mt-10 flex justify-center">

--- a/apps/frontend/app/admin/contest/[id]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/contest/[id]/(overall)/layout.tsx
@@ -1,14 +1,13 @@
 'use client'
 
+import KatexContent from '@/components/KatexContent'
 import { Button } from '@/components/ui/button'
 import { GET_CONTEST } from '@/graphql/contest/queries'
-import { renderKatex } from '@/lib/renderKatex'
 import { dateFormatter } from '@/lib/utils'
 import Period from '@/public/period.svg'
 import { useQuery } from '@apollo/client'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useRef } from 'react'
 import { FaAngleLeft, FaPencil } from 'react-icons/fa6'
 import ContestOverallTabs from '../_components/ContestOverallTabs'
 
@@ -26,18 +25,6 @@ export default function Layout({
       contestId: Number(id)
     }
   }).data?.getContest
-
-  const katexRef = useRef<HTMLDivElement>(null)!
-  useEffect(() => {
-    renderKatex(contestData?.description, katexRef)
-  }, [contestData?.description, katexRef])
-
-  const katexContent = (
-    <div
-      className="prose mb-4 w-full max-w-full border-y-2 border-y-gray-300 p-5 py-12"
-      ref={katexRef}
-    />
-  )
 
   return (
     <main className="flex flex-col gap-6 px-20 py-16">
@@ -67,7 +54,10 @@ export default function Layout({
           </p>
         </div>
       </div>
-      {katexContent}
+      <KatexContent
+        content={contestData?.description}
+        classname="prose mb-4 w-full max-w-full border-y-2 border-y-gray-300 p-5 py-12"
+      />
       <ContestOverallTabs contestId={id} />
       {tabs}
     </main>

--- a/apps/frontend/app/admin/problem/[id]/page.tsx
+++ b/apps/frontend/app/admin/problem/[id]/page.tsx
@@ -1,16 +1,14 @@
 'use client'
 
+import KatexContent from '@/components/KatexContent'
 import Paginator from '@/components/Paginator'
 import { Button } from '@/components/ui/button'
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { GET_PROBLEM_DETAIL } from '@/graphql/problem/queries'
 import { usePagination } from '@/lib/pagination'
-import { renderKatex } from '@/lib/renderKatex'
 import type { SubmissionItem } from '@/types/type'
 import { useQuery } from '@apollo/client'
-// import { sanitize } from 'isomorphic-dompurify'
 import Link from 'next/link'
-import { useEffect, useRef } from 'react'
 import { FaAngleLeft, FaPencil } from 'react-icons/fa6'
 import { columns } from './_components/Columns'
 import DataTable from './_components/DataTable'
@@ -30,17 +28,6 @@ export default function Page({ params }: { params: { id: string } }) {
     20
   )
 
-  const katexRef = useRef<HTMLDivElement>(null)!
-  useEffect(() => {
-    renderKatex(problemData?.description, katexRef)
-  }, [problemData?.description, katexRef])
-
-  const katexContent = (
-    <div
-      className="prose mb-12 w-full max-w-full border-y-2 border-y-gray-300 p-5 py-12"
-      ref={katexRef}
-    />
-  )
   return (
     <ScrollArea className="shrink-0">
       <main className="flex flex-col gap-6 px-20 py-16">
@@ -58,7 +45,10 @@ export default function Page({ params }: { params: { id: string } }) {
             </Button>
           </Link>
         </div>
-        {katexContent}
+        <KatexContent
+          content={problemData?.description}
+          classname="prose mb-12 w-full max-w-full border-y-2 border-y-gray-300 p-5 py-12"
+        />
 
         <p className="text-xl font-bold">Submission</p>
         <DataTable

--- a/apps/frontend/components/EditorDescription.tsx
+++ b/apps/frontend/components/EditorDescription.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import KatexContent from '@/components/KatexContent'
 import {
   Accordion,
   AccordionContent,
@@ -14,7 +15,6 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog'
-import { renderKatex } from '@/lib/renderKatex'
 import { convertToLetter } from '@/lib/utils'
 import CopyIcon from '@/public/24_copy.svg'
 import compileIcon from '@/public/compileVersion.svg'
@@ -26,7 +26,7 @@ import { motion } from 'framer-motion'
 import { sanitize } from 'isomorphic-dompurify'
 import { FileText } from 'lucide-react'
 import Image from 'next/image'
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard'
 import { toast } from 'sonner'
 import {
@@ -68,13 +68,6 @@ export function EditorDescription({
 }) {
   const { copiedID, copy } = useCopy()
 
-  const katexRef = useRef<HTMLDivElement>(null)!
-  useEffect(() => {
-    renderKatex(problem.description, katexRef)
-    console.log(level)
-  }, [problem.description, katexRef])
-
-  const katexContent = <div ref={katexRef} />
   const level = problem.difficulty
   const levelNumber = level.slice(-1)
   return (
@@ -92,7 +85,7 @@ export function EditorDescription({
           )}
         </div>
         <div className="prose prose-invert max-w-full text-sm leading-relaxed text-slate-300">
-          {katexContent}
+          <KatexContent content={problem.description} />
         </div>
         <hr className="border-slate-700" />
       </div>

--- a/apps/frontend/components/KatexContent.tsx
+++ b/apps/frontend/components/KatexContent.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { renderKatex } from '@/lib/renderKatex'
+import { useEffect, useRef } from 'react'
+
+export default function KatexContent({
+  content,
+  classname
+}: {
+  content: string | undefined
+  classname?: string
+}) {
+  const katexRef = useRef<HTMLDivElement>(null)!
+  useEffect(() => {
+    renderKatex(content, katexRef)
+  }, [content, katexRef])
+  return <div className={classname} ref={katexRef} />
+}

--- a/apps/frontend/components/TextEditor.tsx
+++ b/apps/frontend/components/TextEditor.tsx
@@ -171,7 +171,10 @@ export default function TextEditor({
       StarterKit,
       MathExtension as Extension,
       Placeholder.configure({
-        placeholder,
+        placeholder: ({ editor }) => {
+          if (editor.getHTML() === '<p></p>') return placeholder
+          else return ''
+        },
         emptyEditorClass:
           'before:absolute before:text-gray-300 before:float-left before:content-[attr(data-placeholder)] before:pointer-events-none'
       }),
@@ -187,6 +190,7 @@ export default function TextEditor({
     },
     onUpdate({ editor }) {
       onChange(editor.getHTML())
+      console.log(editor.getHTML())
     },
     content: defaultValue
   })

--- a/apps/frontend/components/TextEditor.tsx
+++ b/apps/frontend/components/TextEditor.tsx
@@ -188,7 +188,6 @@ export default function TextEditor({
     },
     onUpdate({ editor }) {
       onChange(editor.getHTML())
-      console.log(editor.getHTML())
     },
     content: defaultValue
   })

--- a/apps/frontend/components/TextEditor.tsx
+++ b/apps/frontend/components/TextEditor.tsx
@@ -171,10 +171,8 @@ export default function TextEditor({
       StarterKit,
       MathExtension as Extension,
       Placeholder.configure({
-        placeholder: ({ editor }) => {
-          if (editor.getHTML() === '<p></p>') return placeholder
-          else return ''
-        },
+        placeholder: ({ editor }) =>
+          editor.getHTML() === '<p></p>' ? placeholder : '',
         emptyEditorClass:
           'before:absolute before:text-gray-300 before:float-left before:content-[attr(data-placeholder)] before:pointer-events-none'
       }),


### PR DESCRIPTION
### Description
### TextEditor에서 수식을 입력해도 placeholder가 남아있는 문제 해결
TextEditor 내의 HTML이 `<p></p>` 일 때만 placeholder를 표시하는 방식으로 수정했습니다
### 수식 입력해도 Contest Detail에서 보이지 않던 문제 해결
Contest Detail의 description에도 KatexContent를 적용해서 katex 수식이 보이도록 했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-839
Closes TAS-840
### Additional context
katex를 보여주는 곳마다 중복된 코드가 있어 KatexContent를 컴포넌트화 했습니다
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
