### PR TITLE
fix(fe): don't calculate contest score when contest is upcoming

### DIFF
--- a/apps/frontend/app/(main)/contest/[contestId]/layout.tsx
+++ b/apps/frontend/app/(main)/contest/[contestId]/layout.tsx
@@ -1,6 +1,6 @@
 import ContestStatusTimeDiff from '@/components/ContestStatusTimeDiff'
 import { auth } from '@/lib/auth'
-import { fetcher, fetcherWithAuth } from '@/lib/utils'
+import { fetcher, fetcherWithAuth, getStatusWithStartEnd } from '@/lib/utils'
 import { dateFormatter } from '@/lib/utils'
 import Calendar from '@/public/20_calendar.svg'
 import CheckIcon from '@/public/check_blue.svg'
@@ -40,9 +40,14 @@ export default async function Layout({
     )
     const isJudgeResultVisible = contest.isJudgeResultVisible
     const isRegistered = contest.isRegistered
+    const contestStatus = getStatusWithStartEnd(
+      formattedStartTime,
+      formattedEndTime
+    )
+
     let totalScore = 0
     let totalMaxScore = 0
-    if (isRegistered && isJudgeResultVisible) {
+    if (isRegistered && isJudgeResultVisible && contestStatus !== 'upcoming') {
       const [score, maxScore] = await calculateContestScore({ contestId })
       totalScore = score
       totalMaxScore = maxScore
@@ -56,7 +61,7 @@ export default async function Layout({
               {contest?.title}
             </h2>
             <div className="flex items-center gap-2">
-              {isRegistered && (
+              {isRegistered && contestStatus !== 'upcoming' && (
                 <>
                   <Image src={CheckIcon} alt="check" width={24} height={24} />
                   <p className="text-primary-light text-sm font-bold">

--- a/apps/frontend/app/(main)/contest/utils.ts
+++ b/apps/frontend/app/(main)/contest/utils.ts
@@ -1,4 +1,4 @@
-import { fetcherWithAuth } from '@/lib/utils'
+import { safeFetcherWithAuth } from '@/lib/utils'
 import type { ContestProblem } from '@/types/type'
 
 interface ContestProblemsApiRes {
@@ -6,23 +6,27 @@ interface ContestProblemsApiRes {
 }
 
 const calculateContestScore = async ({ contestId }: { contestId: string }) => {
-  const contestProblems: ContestProblemsApiRes = await fetcherWithAuth
-    .get(`contest/${contestId}/problem`)
-    .json()
+  try {
+    const contestProblems: ContestProblemsApiRes = await safeFetcherWithAuth
+      .get(`contest/${contestId}/problem`)
+      .json()
 
-  const { totalScore, totalMaxScore } = contestProblems.data.reduce(
-    (acc, curr) => {
-      const score = curr.score ? parseInt(curr.score, 10) : 0
-      const maxScore = curr.maxScore || 0
+    const { totalScore, totalMaxScore } = contestProblems.data.reduce(
+      (acc, curr) => {
+        const score = curr.score ? parseInt(curr.score, 10) : 0
+        const maxScore = curr.maxScore || 0
 
-      acc.totalScore += score
-      acc.totalMaxScore += maxScore
+        acc.totalScore += score
+        acc.totalMaxScore += maxScore
 
-      return acc
-    },
-    { totalScore: 0, totalMaxScore: 0 }
-  )
-  return [totalScore, totalMaxScore]
+        return acc
+      },
+      { totalScore: 0, totalMaxScore: 0 }
+    )
+    return [totalScore, totalMaxScore]
+  } catch (error) {
+    return [0, 0]
+  }
 }
 
 export { calculateContestScore }


### PR DESCRIPTION
### Description

contest가 upcoming인 경우 contest score를 계산하지 않습니다.

보통의 경우 upcoming인 경우 registered 되어있을 수 없으므로 contest score를 계산하지 않아 오류가 발생하지 않았지만, 
duplicate contest의 경우 대회가 시작하지 않았을 때에도 registered되어 있으므로, contest score를 계산하려고 시도합니다.
하지만 upcoming contest의 경우 백엔드에서 contestProblem을 가져올 수 없으므로 contest score도 계산할 수 없습니다.
이에 따라 contest가 upcoming인 경우 contest score를 계산하지 않습니다.

추가적으로 calculateContestScore에서 사용하는 api를 safeFetcherWithAuth로 변경하고 try catch로 에러를 잡아 핸들링하도록 리팩토링합니다



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
