### PR TITLE
fix(fe): fix edit imported contest problem bug

### DIFF
--- a/apps/frontend/app/admin/problem/[id]/edit/page.tsx
+++ b/apps/frontend/app/admin/problem/[id]/edit/page.tsx
@@ -156,7 +156,7 @@ export default function Page({ params }: { params: { id: string } }) {
 
               <FormSection title="Visible">
                 <PopoverVisibleInfo />
-                <VisibleForm />
+                <VisibleForm blockEdit={getValues('isVisible') === null} />
               </FormSection>
             </div>
 

--- a/apps/frontend/app/admin/problem/_components/VisibleForm.tsx
+++ b/apps/frontend/app/admin/problem/_components/VisibleForm.tsx
@@ -2,7 +2,7 @@ import { useFormContext, useController } from 'react-hook-form'
 import { FaEye, FaEyeSlash } from 'react-icons/fa'
 import ErrorMessage from '../../_components/ErrorMessage'
 
-export default function VisibleForm() {
+export default function VisibleForm({ blockEdit }: { blockEdit: boolean }) {
   const {
     control,
     formState: { errors }
@@ -25,6 +25,7 @@ export default function VisibleForm() {
               onChange={() => isVisibleField.onChange(true)}
               checked={isVisibleField.value === true}
               className="text-primary-light"
+              disabled={blockEdit}
             />
             <FaEye className="text-gray-400" size={18} />
           </label>
@@ -35,6 +36,7 @@ export default function VisibleForm() {
               onChange={() => isVisibleField.onChange(false)}
               checked={isVisibleField.value === false}
               className="text-primary-light"
+              disabled={blockEdit}
             />
             <FaEyeSlash className="text-gray-400" size={18} />
           </label>

--- a/apps/frontend/app/admin/problem/utils.ts
+++ b/apps/frontend/app/admin/problem/utils.ts
@@ -6,7 +6,6 @@ const commonSchema = z.object({
     .string()
     .min(1, 'The title must contain at least 1 character(s)')
     .max(200, 'The title can only be up to 200 characters long'),
-  isVisible: z.boolean().optional(),
   difficulty: z.enum(levels),
   languages: z.array(z.enum(languages)).min(1),
   description: z
@@ -62,11 +61,13 @@ const commonSchema = z.object({
 
 export const editSchema = commonSchema.extend({
   id: z.number(),
+  isVisible: z.boolean().nullish(),
   tags: z
     .object({ create: z.array(z.number()), delete: z.array(z.number()) })
     .optional()
 })
 
 export const createSchema = commonSchema.extend({
+  isVisible: z.boolean(),
   tagIds: z.array(z.number())
 })


### PR DESCRIPTION
### Description
### Contest에 import 된 problem이 수정 불가능한 버그 해결
### 문제 원인
problem이 contest에 import되면 isVisible이 null이 되나
editSchema에서 null을 허용하지 않기 때문에 zod에서 걸리고 있었음
### 해결 방법
- editSchema에서만 isVisible null을 허용하게 수정했고
- isVisible이 null일 때 VisibleForm을 수정 불가능하게 변경함

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-881
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
