### PR TITLE
feat(be): add admin get submission by id api

### DIFF
--- a/apps/backend/apps/admin/src/problem/model/template.input.ts
+++ b/apps/backend/apps/admin/src/problem/model/template.input.ts
@@ -2,7 +2,7 @@ import { Field, InputType, Int } from '@nestjs/graphql'
 import { Language } from '@generated'
 
 @InputType()
-class Snippet {
+export class Snippet {
   @Field(() => Int, { nullable: false })
   id!: number
 

--- a/apps/backend/apps/admin/src/submission/model/submission-detail.output.ts
+++ b/apps/backend/apps/admin/src/submission/model/submission-detail.output.ts
@@ -1,0 +1,50 @@
+import { ObjectType, Field, Int, OmitType } from '@nestjs/graphql'
+import type { $Enums } from '@prisma/client'
+import { ResultStatus, Submission } from '@admin/@generated'
+
+@ObjectType()
+class TestCaseResult {
+  @Field(() => String, { nullable: true })
+  cpuTime: string | null
+
+  @Field(() => Int)
+  id: number
+
+  @Field(() => Int)
+  submissionId: number
+
+  @Field(() => Int)
+  problemTestcaseId: number
+
+  @Field(() => ResultStatus)
+  result: $Enums.ResultStatus
+
+  @Field(() => Int, { nullable: true })
+  memoryUsage: number | null
+
+  @Field(() => Date)
+  createTime: Date
+
+  @Field(() => Date)
+  updateTime: Date
+}
+
+@ObjectType()
+export class SubmissionDetail extends OmitType(Submission, [
+  'user',
+  'submissionResult',
+  'code',
+  'problem',
+  'contest',
+  'workbook',
+  '_count'
+] as const) {
+  @Field(() => String)
+  code: string
+
+  @Field(() => [TestCaseResult])
+  testcaseResult: TestCaseResult[]
+
+  @Field(() => String, { nullable: true })
+  username: string | null
+}

--- a/apps/backend/apps/admin/src/submission/submission.resolver.ts
+++ b/apps/backend/apps/admin/src/submission/submission.resolver.ts
@@ -1,9 +1,11 @@
 import { InternalServerErrorException, Logger } from '@nestjs/common'
 import { Args, Int, Query, Resolver } from '@nestjs/graphql'
-import { CursorValidationPipe } from '@libs/pipe'
+import { OPEN_SPACE_ID } from '@libs/constants'
+import { CursorValidationPipe, GroupIDPipe } from '@libs/pipe'
 import { Submission } from '@admin/@generated'
 import { ContestSubmission } from './model/contest-submission.model'
 import { GetContestSubmissionsInput } from './model/get-contest-submission.input'
+import { SubmissionDetail } from './model/submission-detail.output'
 import { SubmissionService } from './submission.service'
 
 @Resolver(() => Submission)
@@ -34,6 +36,34 @@ export class SubmissionResolver {
         input,
         take,
         cursor
+      )
+    } catch (error) {
+      this.logger.error(error.error)
+      throw new InternalServerErrorException()
+    }
+  }
+  /**
+   * 특정 Contest의 특정 제출 내역에 대한 상세 정보를 불러옵니다.
+   */
+  @Query(() => SubmissionDetail)
+  async getSubmission(
+    @Args('id', { type: () => Int }) id: number,
+    @Args('problemId', { type: () => Int }) problemId: number,
+    @Args(
+      'groupId',
+      { defaultValue: OPEN_SPACE_ID, type: () => Int },
+      GroupIDPipe
+    )
+    groupId: number,
+    @Args('contestId', { nullable: true, type: () => Int })
+    contestId: number | null
+  ): Promise<SubmissionDetail> {
+    try {
+      return await this.submissionService.getSubmission(
+        id,
+        problemId,
+        groupId,
+        contestId
       )
     } catch (error) {
       this.logger.error(error.error)

--- a/apps/backend/apps/admin/src/submission/submission.resolver.ts
+++ b/apps/backend/apps/admin/src/submission/submission.resolver.ts
@@ -1,7 +1,6 @@
 import { InternalServerErrorException, Logger } from '@nestjs/common'
 import { Args, Int, Query, Resolver } from '@nestjs/graphql'
-import { OPEN_SPACE_ID } from '@libs/constants'
-import { CursorValidationPipe, GroupIDPipe } from '@libs/pipe'
+import { CursorValidationPipe } from '@libs/pipe'
 import { Submission } from '@admin/@generated'
 import { ContestSubmission } from './model/contest-submission.model'
 import { GetContestSubmissionsInput } from './model/get-contest-submission.input'
@@ -47,22 +46,8 @@ export class SubmissionResolver {
    */
   @Query(() => SubmissionDetail)
   async getSubmission(
-    @Args('id', { type: () => Int }) id: number,
-    @Args('problemId', { type: () => Int }) problemId: number,
-    @Args(
-      'groupId',
-      { defaultValue: OPEN_SPACE_ID, type: () => Int },
-      GroupIDPipe
-    )
-    groupId: number,
-    @Args('contestId', { nullable: true, type: () => Int })
-    contestId: number | null
+    @Args('id', { type: () => Int }) id: number
   ): Promise<SubmissionDetail> {
-    return await this.submissionService.getSubmission(
-      id,
-      problemId,
-      groupId,
-      contestId
-    )
+    return await this.submissionService.getSubmission(id)
   }
 }

--- a/apps/backend/apps/admin/src/submission/submission.resolver.ts
+++ b/apps/backend/apps/admin/src/submission/submission.resolver.ts
@@ -58,16 +58,11 @@ export class SubmissionResolver {
     @Args('contestId', { nullable: true, type: () => Int })
     contestId: number | null
   ): Promise<SubmissionDetail> {
-    try {
-      return await this.submissionService.getSubmission(
-        id,
-        problemId,
-        groupId,
-        contestId
-      )
-    } catch (error) {
-      this.logger.error(error.error)
-      throw new InternalServerErrorException()
-    }
+    return await this.submissionService.getSubmission(
+      id,
+      problemId,
+      groupId,
+      contestId
+    )
   }
 }

--- a/apps/backend/apps/admin/src/submission/submission.service.ts
+++ b/apps/backend/apps/admin/src/submission/submission.service.ts
@@ -74,27 +74,10 @@ export class SubmissionService {
     return results
   }
 
-  async getSubmission(
-    id: number,
-    problemId: number,
-    groupId: number,
-    contestId: number | null
-  ) {
-    const problem = await this.prisma.problem.findFirst({
-      where: {
-        id: problemId,
-        groupId
-      }
-    })
-    if (!problem) {
-      throw new EntityNotExistException('Problem not found')
-    }
-
+  async getSubmission(id: number) {
     const submission = await this.prisma.submission.findFirst({
       where: {
-        id,
-        problemId,
-        contestId
+        id
       },
       include: {
         user: {

--- a/apps/backend/apps/admin/src/submission/submission.service.ts
+++ b/apps/backend/apps/admin/src/submission/submission.service.ts
@@ -90,7 +90,7 @@ export class SubmissionService {
       throw new EntityNotExistException('Problem not found')
     }
 
-    const submission = await this.prisma.submission.findFirstOrThrow({
+    const submission = await this.prisma.submission.findFirst({
       where: {
         id,
         problemId,
@@ -105,6 +105,9 @@ export class SubmissionService {
         submissionResult: true
       }
     })
+    if (!submission) {
+      throw new EntityNotExistException('Submission')
+    }
     const code = plainToInstance(Snippet, submission.code)
     const results = submission.submissionResult.map((result) => {
       return {

--- a/collection/admin/Submission/Get Submission Detail/Succeed.bru
+++ b/collection/admin/Submission/Get Submission Detail/Succeed.bru
@@ -13,11 +13,8 @@ post {
 body:graphql {
   query GetSubmission(
     $id: Int!
-    $problemId: Int!
-    $groupId: Int
-    $contestId: Int
   ) {
-    getSubmission(id: $id, problemId: $problemId, groupId: $groupId, contestId: $contestId) {
+    getSubmission(id: $id) {
       id
       userId
       userIp
@@ -49,19 +46,17 @@ body:graphql {
 
 body:graphql:vars {
   {
-    "id": 1,
-    "problemId": 1,
-    "contestId": 1
+    "id": 1
   }
 }
 
 docs {
   ## Get Submission by id
   
-  - Admin에서 submission id(id), problemId, contestId, groupId를 이용하여 Submission detail을 가져옵니다.
+  - Admin에서 submission id(id)를 이용하여 Submission detail을 가져옵니다.
   
   #### 필요 인자
-  |`id`|`problemId`|`contestId`|`groupId`|
-  |----------|----------|----------|--------------|
-  | `contestId?`: 제출 내역을 불러올 Contest의 ID입니다. Contest의 Submission이 아닌 경우 비워둘 수 있습니다.. | `problemId`: 제출 내역을 불러올 수 Problem의 ID 입니다. | `groupId`: 제출 내역을 불러올 Group의 ID 입니다. 주어지지 않을 경우 OPEN_SPACE_ID입니다.| 
+  |`id`|
+  |----------|
+  |`id`: 제출 내역을 불러올 Submission ID입니다. |
 }

--- a/collection/admin/Submission/Get Submission Detail/Succeed.bru
+++ b/collection/admin/Submission/Get Submission Detail/Succeed.bru
@@ -31,18 +31,17 @@ body:graphql {
       score
       createTime
       updateTime
-      problem {
+      testcaseResult {
+        cpuTime
         id
+        submissionId
+        problemTestcaseId
+        result
+        memoryUsage
+        createTime
+        updateTime
       }
-      contest {
-        id
-      }
-      workbook {
-        id
-      }
-      _count {
-        submissionResult
-      }
+      username
     }
   }
   

--- a/collection/admin/Submission/Get Submission Detail/Succeed.bru
+++ b/collection/admin/Submission/Get Submission Detail/Succeed.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Succeed
+  type: graphql
+  seq: 1
+}
+
+post {
+  url: {{gqlUrl}}
+  body: graphql
+  auth: none
+}
+
+body:graphql {
+  query GetSubmission(
+    $id: Int!
+    $problemId: Int!
+    $groupId: Int!
+    $contestId: Int
+  ) {
+    getSubmission(id: $id, problemId: $problemId, groupId: $groupId, contestId: $contestId) {
+      id
+      userId
+      userIp
+      problemId
+      contestId
+      workbookId
+      code
+      codeSize
+      language
+      result
+      score
+      createTime
+      updateTime
+      problem {
+        id
+      }
+      contest {
+        id
+      }
+      workbook {
+        id
+      }
+      _count {
+        submissionResult
+      }
+    }
+  }
+  
+}
+
+body:graphql:vars {
+  {
+    "id": 1,
+    "problemId": 1,
+    "contestId": 1,
+    "groupId": 1
+  }
+}

--- a/collection/admin/Submission/Get Submission Detail/Succeed.bru
+++ b/collection/admin/Submission/Get Submission Detail/Succeed.bru
@@ -14,7 +14,7 @@ body:graphql {
   query GetSubmission(
     $id: Int!
     $problemId: Int!
-    $groupId: Int!
+    $groupId: Int
     $contestId: Int
   ) {
     getSubmission(id: $id, problemId: $problemId, groupId: $groupId, contestId: $contestId) {
@@ -51,7 +51,17 @@ body:graphql:vars {
   {
     "id": 1,
     "problemId": 1,
-    "contestId": 1,
-    "groupId": 1
+    "contestId": 1
   }
+}
+
+docs {
+  ## Get Submission by id
+  
+  - Admin에서 submission id(id), problemId, contestId, groupId를 이용하여 Submission detail을 가져옵니다.
+  
+  #### 필요 인자
+  |`id`|`problemId`|`contestId`|`groupId`|
+  |----------|----------|----------|--------------|
+  | `contestId?`: 제출 내역을 불러올 Contest의 ID입니다. Contest의 Submission이 아닌 경우 비워둘 수 있습니다.. | `problemId`: 제출 내역을 불러올 수 Problem의 ID 입니다. | `groupId`: 제출 내역을 불러올 Group의 ID 입니다. 주어지지 않을 경우 OPEN_SPACE_ID입니다.| 
 }


### PR DESCRIPTION
### Description

Admin에서 Submission을 submission ID를 통해서 받아올 수 있도록 구현합니다. 
기존에는 `Client - get submission by id` api에 Admin 권한을 뚫어서 사용하고 있었으나, client api가 과도하게 복잡해져 바꿀 필요가 있었고, admin / client간의 독립성을 높여 유지보수에 용이할 것으로 보입니다. 

`Admin - get submission by id` api는 submission ID만으로 모든 데이터를 가져올 수 있습니다. `Client - get submission by id` api는 여러 권한 검사와 response validation이 포함되어 있지만, 
admin에서는 각종 권한 검사와 response validation을 수행하지 않으므로, 프론트엔드에서 사용할 때 각 시나리오(contest, problem List, workbook ... ) 별로 잘 구분하여 사용하면 좋을 것 같습니다.

- `Admin get Submission by Id`의 response는 `Submission` model에서 기본적으로 depth가 1인 필드만 가져옵니다.
- User 쪽과 비슷하게 response를 구성하면서도, 원하는 정보를 최대한 받아올 수 있도록 (어차피 graphql을 사용하므로) 최대한 선택권을 열어둡니다.
- 단 `SubmissionResult`는 `TestcaseResult`를 변형하여 반환하고, `code`도 raw json을 string 형태로 변형하여 반환합니다. 

closes TAS-906

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
