### PR TITLE
feat(be): implement search in contest overall apis

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest.resolver.ts
@@ -304,15 +304,21 @@ export class ContestResolver {
    */
   @Query(() => [UserContestScoreSummaryWithUserInfo])
   async getContestScoreSummaries(
-    @Args('take', { type: () => Int, defaultValue: 10 }) take: number,
-    @Args('contestId', { type: () => Int }) contestId: number,
-    @Args('cursor', { type: () => Int, nullable: true }) cursor: number | null
+    @Args('contestId', { type: () => Int, nullable: false }, IDValidationPipe)
+    contestId: number,
+    @Args('take', { type: () => Int, defaultValue: 10 })
+    take: number,
+    @Args('cursor', { type: () => Int, nullable: true }, CursorValidationPipe)
+    cursor: number | null,
+    @Args('searchingName', { type: () => String, nullable: true })
+    searchingName?: string
   ) {
     try {
       return await this.contestService.getContestScoreSummaries(
-        take,
         contestId,
-        cursor
+        take,
+        cursor,
+        searchingName
       )
     } catch (error) {
       if (error instanceof EntityNotExistException) {

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -789,9 +789,10 @@ export class ContestService {
   }
 
   async getContestScoreSummaries(
-    take: number,
     contestId: number,
-    cursor: number | null
+    take: number,
+    cursor: number | null,
+    searchingName?: string
   ) {
     const paginator = this.prisma.getPaginator(cursor)
 
@@ -801,7 +802,17 @@ export class ContestService {
         contestId,
         userId: {
           not: null
-        }
+        },
+        user: searchingName
+          ? {
+              userProfile: {
+                realName: {
+                  contains: searchingName,
+                  mode: 'insensitive'
+                }
+              }
+            }
+          : undefined
       },
       take,
       include: {

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -766,17 +766,24 @@ export class ContestService {
       const problemId = submission.problemId
       if (problemId in latestSubmissions) continue
 
-      const maxScore = (
-        await this.prisma.contestProblem.findUniqueOrThrow({
-          where: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            contestId_problemId: {
-              contestId: submission.contestId!,
-              problemId: submission.problemId
-            }
+      const contestProblem = await this.prisma.contestProblem.findUnique({
+        where: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          contestId_problemId: {
+            contestId: submission.contestId!,
+            problemId: submission.problemId
           }
-        })
-      ).score
+        },
+        select: {
+          score: true
+        }
+      })
+
+      if (!contestProblem) {
+        throw new EntityNotExistException('contestProblem')
+      }
+
+      const maxScore = contestProblem.score
 
       latestSubmissions[problemId] = {
         result: submission.result as ResultStatus,

--- a/apps/backend/apps/admin/src/submission/model/get-contest-submission.input.ts
+++ b/apps/backend/apps/admin/src/submission/model/get-contest-submission.input.ts
@@ -7,4 +7,7 @@ export class GetContestSubmissionsInput {
 
   @Field(() => Int, { nullable: true })
   problemId?: number
+
+  @Field(() => String, { nullable: true })
+  searchingName?: string
 }

--- a/apps/backend/apps/admin/src/submission/submission.service.ts
+++ b/apps/backend/apps/admin/src/submission/submission.service.ts
@@ -14,13 +14,23 @@ export class SubmissionService {
   ) {
     const paginator = this.prisma.getPaginator(cursor)
 
-    const { contestId, problemId } = input
+    const { contestId, problemId, searchingName } = input
     const contestSubmissions = await this.prisma.submission.findMany({
       ...paginator,
       take,
       where: {
         contestId,
-        problemId
+        problemId,
+        user: searchingName
+          ? {
+              userProfile: {
+                realName: {
+                  contains: searchingName,
+                  mode: 'insensitive'
+                }
+              }
+            }
+          : undefined
       },
       include: {
         user: {
@@ -41,7 +51,7 @@ export class SubmissionService {
             contestProblem: {
               where: {
                 contestId,
-                problemId: problemId ?? undefined
+                problemId
               }
             }
           }

--- a/collection/admin/Contest/Get Contest Score Summaries/Succeed.bru
+++ b/collection/admin/Contest/Get Contest Score Summaries/Succeed.bru
@@ -33,8 +33,8 @@ body:graphql {
 body:graphql:vars {
   {
     "contestId": 1,
-    "userId": 4
-    // "searchingName": "kim"
+    "userId": 1
+    // "searchingName": "lee"
   }
 }
 

--- a/collection/admin/Contest/Get Contest Score Summaries/Succeed.bru
+++ b/collection/admin/Contest/Get Contest Score Summaries/Succeed.bru
@@ -34,7 +34,7 @@ body:graphql:vars {
   {
     "contestId": 1,
     "userId": 4
-    // "problemId": 1
+    // "searchingName": "kim"
   }
 }
 
@@ -44,4 +44,9 @@ docs {
   * Contest에 참여한 User와, 점수 요약을 함께 불러옵니다.
   * Contest Overall 페이지의 Participants 탭의 정보
   * https://github.com/skkuding/codedang/pull/2029
+  
+  #### 필요 인자
+  | `contestId` | `searchingName?` | `take?` | `cursor?` |
+  |----------|--------|----------|------------|
+  | 불러올 Contest의 id | 필터링할 User의 realName(없으면 모든 유저) | Pagination 구현을 위함(default: 10) | Pagination 구현을 위함(default: null) |
 }

--- a/collection/admin/Submission/Get Contest Submissions/Succeed.bru
+++ b/collection/admin/Submission/Get Contest Submissions/Succeed.bru
@@ -40,7 +40,9 @@ body:graphql {
 body:graphql:vars {
   {
     "input": {
-      "contestId": 1
+      "contestId": 1,
+      "problemId": 1,
+      "searchingName": "kim"
     },
     "take": 10
   }
@@ -53,7 +55,13 @@ docs {
   - https://github.com/skkuding/codedang/pull/1924
   
   #### 필요 인자
-  |`input`|`take`|`cursor`|
-  |----------|----------|----------|
-  | `contestId`: 제출 내역을 불러올 Contest의 ID입니다.  `problemId?`: 제출된 내역 중 특정 Problem의 제출만을 필터링 할 수 있습니다.| pagination 구현을 위함 | pagination 구현을 위함 |
+  | `input`  | `take` | `cursor` |
+  |----------|--------|----------|
+  | 밑에서 설명 | Pagination 구현을 위함 | Pagination 구현을 위함 |
+  
+  `input`
+  - `contestId`: 제출 내역을 불러올 Contest의 ID
+  - `problemId?`: 제출된 내역 중 특정 Problem의 제출만 필터링
+  - `searchingName?`: 필터링할 User의 realName(없으면 모든 유저)
+  
 }

--- a/collection/admin/Submission/Get Contest Submissions/Succeed.bru
+++ b/collection/admin/Submission/Get Contest Submissions/Succeed.bru
@@ -42,7 +42,7 @@ body:graphql:vars {
     "input": {
       "contestId": 1,
       "problemId": 1,
-      "searchingName": "kim"
+      "searchingName": "lee"
     },
     "take": 10
   }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-898

- Admin Contest Overall 페이지에서 유저의 realName으로 검색하는 기능
- All Submissions 페이지에서 Contest에 속한 문제로 필터링하는 기능

을 구현합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
