### PR TITLE
feat(be): add double depth field to admin get submission api

### DIFF
--- a/apps/backend/apps/admin/src/submission/model/submission-detail.output.ts
+++ b/apps/backend/apps/admin/src/submission/model/submission-detail.output.ts
@@ -31,12 +31,8 @@ class TestCaseResult {
 
 @ObjectType()
 export class SubmissionDetail extends OmitType(Submission, [
-  'user',
   'submissionResult',
   'code',
-  'problem',
-  'contest',
-  'workbook',
   '_count'
 ] as const) {
   @Field(() => String)
@@ -44,7 +40,4 @@ export class SubmissionDetail extends OmitType(Submission, [
 
   @Field(() => [TestCaseResult])
   testcaseResult: TestCaseResult[]
-
-  @Field(() => String, { nullable: true })
-  username: string | null
 }

--- a/apps/backend/apps/admin/src/submission/submission.service.ts
+++ b/apps/backend/apps/admin/src/submission/submission.service.ts
@@ -81,10 +81,12 @@ export class SubmissionService {
       },
       include: {
         user: {
-          select: {
-            username: true
+          include: {
+            userProfile: true
           }
         },
+        problem: true,
+        contest: true,
         submissionResult: true
       }
     })
@@ -103,14 +105,12 @@ export class SubmissionService {
     })
     results.sort((a, b) => a.problemTestcaseId - b.problemTestcaseId)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { submissionResult, user, ...submissionWithoutResultAndUser } =
-      submission
+    const { submissionResult, ...submissionWithoutResult } = submission
 
     return {
-      ...submissionWithoutResultAndUser,
+      ...submissionWithoutResult,
       code: code.map((snippet) => snippet.text).join('\n'),
-      testcaseResult: results,
-      username: submission.user?.username ?? null
+      testcaseResult: results
     }
   }
 }

--- a/collection/admin/Submission/Get Submission Detail/Succeed.bru
+++ b/collection/admin/Submission/Get Submission Detail/Succeed.bru
@@ -38,7 +38,22 @@ body:graphql {
         createTime
         updateTime
       }
-      username
+      user {
+        id
+        studentId
+        userProfile {
+          realName
+        }
+      }
+      contest {
+        id
+        title
+      }
+      problem {
+        id
+        title
+        
+      }
     }
   }
   


### PR DESCRIPTION
### Description

admin get submission by id api에서 user / contest / problem 정보도 같이 받아오도록 추가합니다.
백엔드에서 정보를 같이 주지 않으면 프론트 코드 구조상 이를 구현하기가 어렵습니다. 

Admin API라서 많이 호출될 일은 없기 때문에 일단은 비효율적이지만 간단하게 user, contest, problem의 모든 relational field를 불러오도록 했습니다.
join이 너무 많아져서 비효율적이긴 해서, 추후에 GraphQL에서 동적으로 요청한 필드에 대해서만 select를 하도록 변경하면 좋을 것 같습니다.  <- Admin에서 Graphql을 사용하는만큼 Query의 경우에 Response의 자유도를 높이고, 요청하는 필드에 대해서만 on-demand로 select하도록 다른 Admin API들도 같이 적용하면 좋겠네요! 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
