### PR TITLE
fix(be): add condition for compile-error when run test

### DIFF
--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -89,7 +89,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       >(key)) ?? []
 
     testcases.forEach((tc) => {
-      if (tc.id === testcaseId) {
+      if (!testcaseId || tc.id === testcaseId) {
         tc.result = status
       }
     })


### PR DESCRIPTION
### Description

iris에서 채점할 코드 실행 중 Compile Error 발생 시 mq로 전송되는 메세지의 judgeResult 속성이 null로 세팅됩니다.
이 경우를 Test 전용 메세지를 핸들링하는 handleRunMessage 함수에서 처리하지 않아, Compile Error가 발생하는 코드를 Test를 통해 제출 시 무한 Judging이 발생합니다. (일반 Submit은 상관 없음)

위 문제를 해결합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
