### PR TITLE
fix(infra): remove aws elastic ip for nat gateway

### DIFF
--- a/apps/infra/production/network/public_network.tf
+++ b/apps/infra/production/network/public_network.tf
@@ -6,20 +6,6 @@ resource "aws_internet_gateway" "main" {
   }
 }
 
-resource "aws_eip" "for_nat" {
-  domain = "vpc"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  depends_on = [aws_internet_gateway.main]
-
-  tags = {
-    Name = "Codedang-NatEIP"
-  }
-}
-
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 


### PR DESCRIPTION
### Description

Closes TAS-925

지난 학기에 비용 절감을 위해 NAT Gateway를 삭제하여 더 이상 이를 위한 Elastic IP가 불필요합니다. 불필요한 비용 청구를 방지하기 위해 테라폼 코드에서 해당 코드를 삭제합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
