### PR TITLE
refactor(be): improve client problem error handling logic

### DIFF
--- a/apps/backend/apps/client/src/problem/problem.controller.ts
+++ b/apps/backend/apps/client/src/problem/problem.controller.ts
@@ -1,4 +1,3 @@
-// problem.controller.ts
 import {
   Controller,
   DefaultValuePipe,

--- a/apps/backend/apps/client/src/problem/problem.controller.ts
+++ b/apps/backend/apps/client/src/problem/problem.controller.ts
@@ -1,24 +1,17 @@
+// problem.controller.ts
 import {
   Controller,
   DefaultValuePipe,
   Get,
-  InternalServerErrorException,
-  Logger,
-  NotFoundException,
   Param,
   Query,
   Req
 } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
 import {
   AuthNotNeededIfOpenSpace,
   UserNullWhenAuthFailedIfOpenSpace,
-  type AuthenticatedRequest
+  AuthenticatedRequest
 } from '@libs/auth'
-import {
-  EntityNotExistException,
-  ForbiddenAccessException
-} from '@libs/exception'
 import {
   CursorValidationPipe,
   GroupIDPipe,
@@ -35,8 +28,6 @@ import {
 
 @Controller('problem')
 export class ProblemController {
-  private readonly logger = new Logger(ProblemController.name)
-
   constructor(
     private readonly problemService: ProblemService,
     private readonly workbookProblemService: WorkbookProblemService
@@ -56,33 +47,22 @@ export class ProblemController {
     order: ProblemOrder,
     @Query('search') search?: string
   ) {
-    try {
-      if (!workbookId) {
-        return await this.problemService.getProblems({
-          userId: req.user?.id ?? null,
-          cursor,
-          take,
-          groupId,
-          order,
-          search
-        })
-      }
-      return await this.workbookProblemService.getWorkbookProblems(
-        workbookId!,
+    if (!workbookId) {
+      return await this.problemService.getProblems({
+        userId: req.user?.id ?? null,
         cursor,
         take,
-        groupId
-      )
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.name === 'NotFoundError'
-      ) {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
+        groupId,
+        order,
+        search
+      })
     }
+    return await this.workbookProblemService.getWorkbookProblems(
+      workbookId!,
+      cursor,
+      take,
+      groupId
+    )
   }
 
   @Get(':problemId')
@@ -92,32 +72,19 @@ export class ProblemController {
     @Query('workbookId', IDValidationPipe) workbookId: number | null,
     @Param('problemId', new RequiredIntPipe('problemId')) problemId: number
   ) {
-    try {
-      if (!workbookId) {
-        return await this.problemService.getProblem(problemId, groupId)
-      }
-      return await this.workbookProblemService.getWorkbookProblem(
-        workbookId!,
-        problemId,
-        groupId
-      )
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.name === 'NotFoundError'
-      ) {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
+    if (!workbookId) {
+      return await this.problemService.getProblem(problemId, groupId)
     }
+    return await this.workbookProblemService.getWorkbookProblem(
+      workbookId!,
+      problemId,
+      groupId
+    )
   }
 }
 
 @Controller('contest/:contestId/problem')
 export class ContestProblemController {
-  private readonly logger = new Logger(ContestProblemController.name)
-
   constructor(private readonly contestProblemService: ContestProblemService) {}
 
   @Get()
@@ -129,24 +96,13 @@ export class ContestProblemController {
     @Query('take', new DefaultValuePipe(10), new RequiredIntPipe('take'))
     take: number
   ) {
-    try {
-      return await this.contestProblemService.getContestProblems(
-        contestId,
-        req.user.id,
-        cursor,
-        take,
-        groupId
-      )
-    } catch (error) {
-      if (
-        error instanceof EntityNotExistException ||
-        error instanceof ForbiddenAccessException
-      ) {
-        throw error.convert2HTTPException()
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
+    return await this.contestProblemService.getContestProblems(
+      contestId,
+      req.user.id,
+      cursor,
+      take,
+      groupId
+    )
   }
 
   @Get(':problemId')
@@ -156,25 +112,11 @@ export class ContestProblemController {
     @Param('problemId', new RequiredIntPipe('problemId')) problemId: number,
     @Query('groupId', GroupIDPipe) groupId: number
   ) {
-    try {
-      return await this.contestProblemService.getContestProblem(
-        contestId,
-        problemId,
-        req.user.id,
-        groupId
-      )
-    } catch (error) {
-      if (
-        (error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.name === 'NotFoundError') ||
-        error instanceof EntityNotExistException
-      ) {
-        throw new NotFoundException(error.message)
-      } else if (error instanceof ForbiddenAccessException) {
-        throw error.convert2HTTPException()
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
+    return await this.contestProblemService.getContestProblem(
+      contestId,
+      problemId,
+      req.user.id,
+      groupId
+    )
   }
 }

--- a/apps/backend/apps/client/src/problem/problem.repository.ts
+++ b/apps/backend/apps/client/src/problem/problem.repository.ts
@@ -246,6 +246,7 @@ export class ProblemRepository {
   async getContestProblem(contestId: number, problemId: number) {
     const contestProblem = await this.prisma.contestProblem.findUnique({
       where: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         contestId_problemId: {
           contestId,
           problemId
@@ -309,6 +310,7 @@ export class ProblemRepository {
   async getWorkbookProblem(workbookId: number, problemId: number) {
     const workbookProblem = await this.prisma.workbookProblem.findUnique({
       where: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         workbookId_problemId: {
           workbookId,
           problemId

--- a/apps/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.spec.ts
@@ -1,4 +1,3 @@
-// problem.service.spec.ts
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Test, TestingModule } from '@nestjs/testing'
 import { faker } from '@faker-js/faker'

--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -1,20 +1,18 @@
+// problem.service.ts
 import { Injectable } from '@nestjs/common'
 import { plainToInstance } from 'class-transformer'
 import { OPEN_SPACE_ID } from '@libs/constants'
-import {
-  ForbiddenAccessException,
-  EntityNotExistException
-} from '@libs/exception'
+import { ForbiddenAccessException } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
 import { ContestService } from '@client/contest/contest.service'
 import { WorkbookService } from '@client/workbook/workbook.service'
 import { CodeDraftResponseDto } from './dto/code-draft.response.dto'
-import type { CreateTemplateDto } from './dto/create-code-draft.dto'
+import { CreateTemplateDto } from './dto/create-code-draft.dto'
 import { ProblemResponseDto } from './dto/problem.response.dto'
 import { ProblemsResponseDto } from './dto/problems.response.dto'
 import { RelatedProblemResponseDto } from './dto/related-problem.response.dto'
 import { RelatedProblemsResponseDto } from './dto/related-problems.response.dto'
-import type { ProblemOrder } from './enum/problem-order.enum'
+import { ProblemOrder } from './enum/problem-order.enum'
 import { ProblemRepository } from './problem.repository'
 
 @Injectable()
@@ -202,8 +200,11 @@ export class WorkbookProblemService {
     take: number,
     groupId = OPEN_SPACE_ID
   ) {
-    if (!(await this.workbookService.isVisible(workbookId, groupId))) {
-      throw new EntityNotExistException('Workbook')
+    const isVisible = await this.workbookService.isVisible(workbookId, groupId)
+    if (!isVisible) {
+      throw new ForbiddenAccessException(
+        'You do not have access to this workbook.'
+      )
     }
     const data = await this.problemRepository.getWorkbookProblems(
       workbookId,
@@ -225,8 +226,11 @@ export class WorkbookProblemService {
     problemId: number,
     groupId = OPEN_SPACE_ID
   ) {
-    if (!(await this.workbookService.isVisible(workbookId, groupId))) {
-      throw new EntityNotExistException('Workbook')
+    const isVisible = await this.workbookService.isVisible(workbookId, groupId)
+    if (!isVisible) {
+      throw new ForbiddenAccessException(
+        'You do not have access to this workbook.'
+      )
     }
     const data = await this.problemRepository.getWorkbookProblem(
       workbookId,

--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -1,4 +1,3 @@
-// problem.service.ts
 import { Injectable } from '@nestjs/common'
 import { plainToInstance } from 'class-transformer'
 import { OPEN_SPACE_ID } from '@libs/constants'


### PR DESCRIPTION
### Description
`problem` 모듈에서 에러 핸들링 로직을 글로벌 예외 처리 메커니즘으로 통합합니다. 컨트롤러와 서비스에서의 로컬 에러 처리를 제거하고, 레포지토리에서 발생하는 Prisma 예외는 적절한 Business exception으로 변환하여 전체적인 백엔드 코드의 일관성을 높입니다.

### 주요 변경 사항
1. controller에서 에러 처리하는 로직 제거
모든 try catch 블록 제거 / 서비스에서 발생한 예외를 그대로 글로벌 에러로 전파시킴

2. `problem.repository.ts`에서 Prisma 예외를 비즈니스 예외로 변환.
Prisma 예외 코드에 의존하지 않고 비즈니스 로직에 맞는 예외를 던지도록 수정함.
`findUniqueOrThrow`를 `findUnique`로 변경하고 결과가 없을 때 Exception을 발생시킴.

3. Prisma `upsert`에서 에러 핸들링 추가
upsert를 하는 메서드에서는 Prisma 에러가 날 수 있으므로, try catch로 에러를 잡아 적절한 비즈니스 예외로 변환함. 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
