### PR TITLE
refactor(be): improve client submission module error handling logic

### DIFF
--- a/apps/backend/apps/client/src/submission/submission.controller.ts
+++ b/apps/backend/apps/client/src/submission/submission.controller.ts
@@ -1,4 +1,3 @@
-// submission.controller.ts
 import {
   Controller,
   Get,
@@ -63,6 +62,10 @@ export class SubmissionController {
     }
   }
 
+  /**
+   * Open Testcase에 대해 채점하는 Test를 요청합니다.
+   * 채점 결과는 Cache에 저장됩니다.
+   */
   @Post('test')
   async submitTest(
     @Req() req: AuthenticatedRequest,
@@ -76,6 +79,10 @@ export class SubmissionController {
     )
   }
 
+  /**
+   * requestTest의 반환으로 받은 key를 통해 Test 결과를 조회합니다.
+   * @returns Testcase별 결과가 담겨있는 Object
+   */
   @Get('test')
   async getTestResult(@Req() req: AuthenticatedRequest) {
     return await this.submissionService.getTestResult(req.user.id)

--- a/apps/backend/apps/client/src/submission/submission.controller.ts
+++ b/apps/backend/apps/client/src/submission/submission.controller.ts
@@ -1,3 +1,4 @@
+// submission.controller.ts
 import {
   Controller,
   Get,
@@ -5,20 +6,11 @@ import {
   Param,
   Body,
   Req,
-  NotFoundException,
-  InternalServerErrorException,
-  Logger,
   Query,
   DefaultValuePipe,
   Headers
 } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
 import { AuthNotNeededIfOpenSpace, AuthenticatedRequest } from '@libs/auth'
-import {
-  ConflictFoundException,
-  EntityNotExistException,
-  ForbiddenAccessException
-} from '@libs/exception'
 import {
   CursorValidationPipe,
   GroupIDPipe,
@@ -30,8 +22,6 @@ import { SubmissionService } from './submission.service'
 
 @Controller('submission')
 export class SubmissionController {
-  private readonly logger = new Logger(SubmissionController.name)
-
   constructor(private readonly submissionService: SubmissionService) {}
 
   @Post()
@@ -44,82 +34,48 @@ export class SubmissionController {
     @Query('contestId', IDValidationPipe) contestId: number | null,
     @Query('workbookId', IDValidationPipe) workbookId: number | null
   ) {
-    try {
-      if (!contestId && !workbookId) {
-        return await this.submissionService.submitToProblem(
-          submissionDto,
-          userIp,
-          req.user.id,
-          problemId,
-          groupId
-        )
-      } else if (contestId) {
-        return await this.submissionService.submitToContest(
-          submissionDto,
-          userIp,
-          req.user.id,
-          problemId,
-          contestId,
-          groupId
-        )
-      } else if (workbookId) {
-        return await this.submissionService.submitToWorkbook(
-          submissionDto,
-          userIp,
-          req.user.id,
-          problemId,
-          workbookId,
-          groupId
-        )
-      }
-    } catch (error) {
-      if (error instanceof ConflictFoundException) {
-        throw error.convert2HTTPException()
-      }
-      if (
-        (error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.name == 'NotFoundError') ||
-        error instanceof EntityNotExistException
-      ) {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
+    if (!contestId && !workbookId) {
+      return await this.submissionService.submitToProblem(
+        submissionDto,
+        userIp,
+        req.user.id,
+        problemId,
+        groupId
+      )
+    } else if (contestId) {
+      return await this.submissionService.submitToContest(
+        submissionDto,
+        userIp,
+        req.user.id,
+        problemId,
+        contestId,
+        groupId
+      )
+    } else if (workbookId) {
+      return await this.submissionService.submitToWorkbook(
+        submissionDto,
+        userIp,
+        req.user.id,
+        problemId,
+        workbookId,
+        groupId
+      )
     }
   }
 
-  /**
-   * Open Testcase에 대해 채점하는 Test를 요청합니다.
-   * 채점 결과는 Cache에 저장됩니다.
-   */
   @Post('test')
   async submitTest(
     @Req() req: AuthenticatedRequest,
     @Query('problemId', new RequiredIntPipe('problemId')) problemId: number,
     @Body() submissionDto: CreateSubmissionDto
   ) {
-    try {
-      return await this.submissionService.submitTest(
-        req.user.id,
-        problemId,
-        submissionDto
-      )
-    } catch (error) {
-      if (
-        error instanceof EntityNotExistException ||
-        error instanceof ConflictFoundException
-      ) {
-        throw error.convert2HTTPException()
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
+    return await this.submissionService.submitTest(
+      req.user.id,
+      problemId,
+      submissionDto
+    )
   }
 
-  /**
-   * requestTest의 반환으로 받은 key를 통해 Test 결과를 조회합니다.
-   * @returns Testcase별 결과가 담겨있는 Object
-   */
   @Get('test')
   async getTestResult(@Req() req: AuthenticatedRequest) {
     return await this.submissionService.getTestResult(req.user.id)
@@ -139,24 +95,12 @@ export class SubmissionController {
     @Query('problemId', new RequiredIntPipe('problemId')) problemId: number,
     @Query('groupId', GroupIDPipe) groupId: number
   ) {
-    try {
-      return await this.submissionService.getSubmissions({
-        cursor,
-        take,
-        problemId,
-        groupId
-      })
-    } catch (error) {
-      if (
-        (error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.name == 'NotFoundError') ||
-        error instanceof EntityNotExistException
-      ) {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
+    return await this.submissionService.getSubmissions({
+      cursor,
+      take,
+      problemId,
+      groupId
+    })
   }
 
   @Get(':id')
@@ -167,35 +111,19 @@ export class SubmissionController {
     @Query('contestId', IDValidationPipe) contestId: number | null,
     @Param('id', new RequiredIntPipe('id')) id: number
   ) {
-    try {
-      return await this.submissionService.getSubmission(
-        id,
-        problemId,
-        req.user.id,
-        req.user.role,
-        groupId,
-        contestId
-      )
-    } catch (error) {
-      if (
-        (error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.name == 'NotFoundError') ||
-        error instanceof EntityNotExistException
-      ) {
-        throw new NotFoundException(error.message)
-      } else if (error instanceof ForbiddenAccessException) {
-        throw error.convert2HTTPException()
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
+    return await this.submissionService.getSubmission(
+      id,
+      problemId,
+      req.user.id,
+      req.user.role,
+      groupId,
+      contestId
+    )
   }
 }
 
 @Controller('contest/:contestId/submission')
 export class ContestSubmissionController {
-  private readonly logger = new Logger(ContestSubmissionController.name)
-
   constructor(private readonly submissionService: SubmissionService) {}
 
   @Get()
@@ -208,24 +136,13 @@ export class ContestSubmissionController {
     @Query('problemId', new RequiredIntPipe('problemId')) problemId: number,
     @Query('groupId', GroupIDPipe) groupId: number
   ) {
-    try {
-      return await this.submissionService.getContestSubmissions({
-        cursor,
-        take,
-        problemId,
-        contestId,
-        userId: req.user.id,
-        groupId
-      })
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.name == 'NotFoundError'
-      ) {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException()
-    }
+    return await this.submissionService.getContestSubmissions({
+      cursor,
+      take,
+      problemId,
+      contestId,
+      userId: req.user.id,
+      groupId
+    })
   }
 }

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -1,16 +1,18 @@
+// submission.service.ts
 import { HttpService } from '@nestjs/axios'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import {
   ResultStatus,
-  type Submission,
-  type Language,
-  type Problem,
-  Role
+  Submission,
+  Language,
+  Problem,
+  Role,
+  Prisma
 } from '@prisma/client'
-import type { AxiosRequestConfig } from 'axios'
-import type { Cache } from 'cache-manager'
+import { AxiosRequestConfig } from 'axios'
+import { Cache } from 'cache-manager'
 import { plainToInstance } from 'class-transformer'
 import { Span } from 'nestjs-otel'
 import { testKey } from '@libs/cache'
@@ -22,12 +24,13 @@ import {
 import {
   ConflictFoundException,
   EntityNotExistException,
-  ForbiddenAccessException
+  ForbiddenAccessException,
+  UnprocessableDataException
 } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
 import { ProblemRepository } from '@client/problem/problem.repository'
 import {
-  type CreateSubmissionDto,
+  CreateSubmissionDto,
   Snippet,
   Template
 } from './class/create-submission.dto'
@@ -54,7 +57,7 @@ export class SubmissionService {
     problemId: number,
     groupId = OPEN_SPACE_ID
   ) {
-    const problem = await this.prisma.problem.findFirstOrThrow({
+    const problem = await this.prisma.problem.findFirst({
       where: {
         id: problemId,
         groupId,
@@ -63,6 +66,9 @@ export class SubmissionService {
         }
       }
     })
+    if (!problem) {
+      throw new EntityNotExistException('Problem')
+    }
     const submission = await this.createSubmission(
       submissionDto,
       problem,
@@ -88,7 +94,7 @@ export class SubmissionService {
     groupId = OPEN_SPACE_ID
   ) {
     const now = new Date()
-    await this.prisma.contest.findFirstOrThrow({
+    const contest = await this.prisma.contest.findFirst({
       where: {
         id: contestId,
         groupId,
@@ -100,7 +106,10 @@ export class SubmissionService {
         }
       }
     })
-    const { contest } = await this.prisma.contestRecord.findUniqueOrThrow({
+    if (!contest) {
+      throw new EntityNotExistException('Contest')
+    }
+    const contestRecord = await this.prisma.contestRecord.findUnique({
       where: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         contestId_userId: {
@@ -118,15 +127,21 @@ export class SubmissionService {
         }
       }
     })
-    if (contest.groupId !== groupId) {
-      throw new EntityNotExistException('Contest Not Found')
-    } else if (contest.startTime > now || contest.endTime <= now) {
+    if (!contestRecord) {
+      throw new EntityNotExistException('ContestRecord')
+    }
+    if (contestRecord.contest.groupId !== groupId) {
+      throw new EntityNotExistException('Contest')
+    } else if (
+      contestRecord.contest.startTime > now ||
+      contestRecord.contest.endTime <= now
+    ) {
       throw new ConflictFoundException(
         'Submission is only allowed to ongoing contests'
       )
     }
 
-    const { problem } = await this.prisma.contestProblem.findUniqueOrThrow({
+    const contestProblem = await this.prisma.contestProblem.findUnique({
       where: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         contestId_problemId: {
@@ -138,6 +153,10 @@ export class SubmissionService {
         problem: true
       }
     })
+    if (!contestProblem) {
+      throw new EntityNotExistException('ContestProblem')
+    }
+    const { problem } = contestProblem
 
     const submission = await this.createSubmission(
       submissionDto,
@@ -161,7 +180,7 @@ export class SubmissionService {
     workbookId: number,
     groupId = OPEN_SPACE_ID
   ) {
-    const { problem } = await this.prisma.workbookProblem.findUniqueOrThrow({
+    const workbookProblem = await this.prisma.workbookProblem.findUnique({
       where: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         workbookId_problemId: {
@@ -173,11 +192,15 @@ export class SubmissionService {
         problem: true
       }
     })
+    if (!workbookProblem) {
+      throw new EntityNotExistException('WorkbookProblem')
+    }
+    const { problem } = workbookProblem
     if (
       problem.groupId !== groupId ||
-      problem.visibleLockTime.getTime() !== MIN_DATE.getTime() // 공개된 problem이 아닐 때
+      problem.visibleLockTime.getTime() !== MIN_DATE.getTime()
     ) {
-      throw new EntityNotExistException('problem')
+      throw new EntityNotExistException('Problem')
     }
 
     const submission = await this.createSubmission(
@@ -227,18 +250,25 @@ export class SubmissionService {
       ...data
     }
 
-    const submission = await this.prisma.submission.create({
-      data: {
-        ...submissionData,
-        contestId: idOptions?.contestId,
-        workbookId: idOptions?.workbookId
+    try {
+      const submission = await this.prisma.submission.create({
+        data: {
+          ...submissionData,
+          contestId: idOptions?.contestId,
+          workbookId: idOptions?.workbookId
+        }
+      })
+
+      await this.createSubmissionResults(submission)
+
+      await this.publish.publishJudgeRequestMessage(code, submission)
+      return submission
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new UnprocessableDataException('Failed to create submission')
       }
-    })
-
-    await this.createSubmissionResults(submission)
-
-    await this.publish.publishJudgeRequestMessage(code, submission)
-    return submission
+      throw error
+    }
   }
 
   @Span()
@@ -304,7 +334,7 @@ export class SubmissionService {
     })
 
     if (!problem) {
-      throw new EntityNotExistException('problem')
+      throw new EntityNotExistException('Problem')
     }
 
     if (!problem.languages.includes(submissionDto.language)) {
@@ -411,7 +441,6 @@ export class SubmissionService {
     }
   }
 
-  // FIXME: Workbook 구분
   @Span()
   async getSubmissions({
     problemId,
@@ -426,7 +455,7 @@ export class SubmissionService {
   }) {
     const paginator = this.prisma.getPaginator(cursor)
 
-    await this.prisma.problem.findFirstOrThrow({
+    const problem = await this.prisma.problem.findFirst({
       where: {
         id: problemId,
         groupId,
@@ -435,6 +464,9 @@ export class SubmissionService {
         }
       }
     })
+    if (!problem) {
+      throw new EntityNotExistException('Problem')
+    }
 
     const submissions = await this.prisma.submission.findMany({
       ...paginator,
@@ -481,7 +513,7 @@ export class SubmissionService {
     let isJudgeResultVisible: boolean | null = null
 
     if (contestId) {
-      const contestRecord = await this.prisma.contestRecord.findUniqueOrThrow({
+      const contestRecord = await this.prisma.contestRecord.findUnique({
         where: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           contestId_userId: {
@@ -500,15 +532,19 @@ export class SubmissionService {
           }
         }
       })
+      if (!contestRecord) {
+        throw new EntityNotExistException('ContestRecord')
+      }
       if (contestRecord.contest.groupId !== groupId) {
-        throw new EntityNotExistException('contest')
+        throw new EntityNotExistException('Contest')
       }
       contest = contestRecord.contest
       isJudgeResultVisible = contest.isJudgeResultVisible
     }
 
+    let problem
     if (!contestId) {
-      await this.prisma.problem.findFirstOrThrow({
+      problem = await this.prisma.problem.findFirst({
         where: {
           id: problemId,
           groupId,
@@ -517,16 +553,22 @@ export class SubmissionService {
           }
         }
       })
+      if (!problem) {
+        throw new EntityNotExistException('Problem')
+      }
     } else {
-      await this.prisma.problem.findFirstOrThrow({
+      problem = await this.prisma.problem.findFirst({
         where: {
           id: problemId,
           groupId
         }
       })
+      if (!problem) {
+        throw new EntityNotExistException('Problem')
+      }
     }
 
-    const submission = await this.prisma.submission.findFirstOrThrow({
+    const submission = await this.prisma.submission.findFirst({
       where: {
         id,
         problemId,
@@ -547,6 +589,9 @@ export class SubmissionService {
         codeSize: true
       }
     })
+    if (!submission) {
+      throw new EntityNotExistException('Submission')
+    }
 
     if (
       contest &&
@@ -570,7 +615,6 @@ export class SubmissionService {
       const results = submission.submissionResult.map((result) => {
         return {
           ...result,
-          // TODO: 채점 속도가 너무 빠른경우에 대한 수정 필요 (0ms 미만)
           cpuTime:
             result.cpuTime || result.cpuTime === BigInt(0)
               ? result.cpuTime.toString()
@@ -633,7 +677,7 @@ export class SubmissionService {
     })
 
     if (!isAdmin) {
-      await this.prisma.contestRecord.findUniqueOrThrow({
+      const contestRecord = await this.prisma.contestRecord.findUnique({
         where: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           contestId_userId: {
@@ -642,9 +686,12 @@ export class SubmissionService {
           }
         }
       })
+      if (!contestRecord) {
+        throw new EntityNotExistException('ContestRecord')
+      }
     }
 
-    await this.prisma.contestProblem.findFirstOrThrow({
+    const contestProblem = await this.prisma.contestProblem.findFirst({
       where: {
         problem: {
           id: problemId,
@@ -653,17 +700,22 @@ export class SubmissionService {
         contestId
       }
     })
+    if (!contestProblem) {
+      throw new EntityNotExistException('ContestProblem')
+    }
 
-    const isJudgeResultVisible = (
-      await this.prisma.contest.findFirstOrThrow({
-        where: {
-          id: contestId
-        },
-        select: {
-          isJudgeResultVisible: true
-        }
-      })
-    ).isJudgeResultVisible
+    const contest = await this.prisma.contest.findFirst({
+      where: {
+        id: contestId
+      },
+      select: {
+        isJudgeResultVisible: true
+      }
+    })
+    if (!contest) {
+      throw new EntityNotExistException('Contest')
+    }
+    const isJudgeResultVisible = contest.isJudgeResultVisible
 
     const submissions = await this.prisma.submission.findMany({
       ...paginator,

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -1,4 +1,3 @@
-// submission.service.ts
 import { HttpService } from '@nestjs/axios'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger } from '@nestjs/common'
@@ -441,6 +440,7 @@ export class SubmissionService {
     }
   }
 
+  // FIXME: Workbook 구분
   @Span()
   async getSubmissions({
     problemId,
@@ -615,6 +615,7 @@ export class SubmissionService {
       const results = submission.submissionResult.map((result) => {
         return {
           ...result,
+          // TODO: 채점 속도가 너무 빠른경우에 대한 수정 필요 (0ms 미만)
           cpuTime:
             result.cpuTime || result.cpuTime === BigInt(0)
               ? result.cpuTime.toString()

--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -1,10 +1,9 @@
 import { HttpModule } from '@nestjs/axios'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
-import { NotFoundException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import { Test, type TestingModule } from '@nestjs/testing'
-import { Language, Role, type Contest, type User } from '@prisma/client'
-import type { Cache } from 'cache-manager'
+import { Test, TestingModule } from '@nestjs/testing'
+import { Language, Role, Contest, User } from '@prisma/client'
+import { Cache } from 'cache-manager'
 import { expect } from 'chai'
 import { plainToInstance } from 'class-transformer'
 import { TraceService } from 'nestjs-otel'
@@ -27,7 +26,7 @@ import { SubmissionService } from '../submission.service'
 const db = {
   submission: {
     findMany: stub(),
-    findFirstOrThrow: stub(),
+    findFirst: stub(),
     findUnique: stub(),
     create: stub(),
     update: stub(),
@@ -39,8 +38,7 @@ const db = {
     updateMany: stub()
   },
   problem: {
-    findFirstOrThrow: stub(),
-    findUniqueOrThrow: stub(),
+    findFirst: stub(),
     findUnique: stub(),
     update: stub()
   },
@@ -48,21 +46,20 @@ const db = {
     findMany: stub()
   },
   contest: {
-    findFirstOrThrow: stub()
+    findFirst: stub()
   },
   contestProblem: {
-    findUniqueOrThrow: stub(),
-    findFirstOrThrow: stub()
+    findUnique: stub(),
+    findFirst: stub()
   },
   workbookProblem: {
-    findUniqueOrThrow: stub()
+    findUnique: stub()
   },
   contestRecord: {
-    findUniqueOrThrow: stub(),
+    findUnique: stub(),
     update: stub()
   },
   user: {
-    findFirstOrThrow: stub(),
     findFirst: stub()
   },
   getPaginator: PrismaService.prototype.getPaginator
@@ -141,22 +138,21 @@ describe('SubmissionService', () => {
 
   describe('submitToProblem', () => {
     it('should call createSubmission', async () => {
-      db.problem.findFirstOrThrow.resolves(problems[0])
+      db.problem.findFirst.resolves(problems[0])
       const createSpy = stub(service, 'createSubmission')
 
       await service.submitToProblem(
         submissionDto,
         USERIP,
         submissions[0].userId,
+        problems[0].id,
         problems[0].groupId
       )
       expect(createSpy.calledOnce).to.be.true
     })
 
     it('should throw exception if problem is not found', async () => {
-      db.problem.findFirstOrThrow.rejects(
-        new NotFoundException('No problem found error')
-      )
+      db.problem.findFirst.resolves(null)
       const createSpy = stub(service, 'createSubmission')
 
       await expect(
@@ -164,9 +160,10 @@ describe('SubmissionService', () => {
           submissionDto,
           USERIP,
           submissions[0].userId,
+          problems[0].id,
           problems[0].groupId
         )
-      ).to.be.rejectedWith(NotFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
       expect(createSpy.called).to.be.false
     })
   })
@@ -174,15 +171,15 @@ describe('SubmissionService', () => {
   describe('submitToContest', () => {
     it('should call createSubmission', async () => {
       const createSpy = stub(service, 'createSubmission')
-      db.contest.findFirstOrThrow(mockContest)
-      db.contestRecord.findUniqueOrThrow.resolves({
+      db.contest.findFirst.resolves(mockContest)
+      db.contestRecord.findUnique.resolves({
         contest: {
           groupId: 1,
           startTime: new Date(Date.now() - 10000),
           endTime: new Date(Date.now() + 10000)
         }
       })
-      db.contestProblem.findUniqueOrThrow.resolves({ problem: problems[0] })
+      db.contestProblem.findUnique.resolves({ problem: problems[0] })
 
       await service.submitToContest(
         submissionDto,
@@ -197,19 +194,7 @@ describe('SubmissionService', () => {
 
     it('should throw exception if contest is not ongoing', async () => {
       const createSpy = stub(service, 'createSubmission')
-      db.contestRecord.findUniqueOrThrow.resolves({
-        contest: {
-          groupId: 1,
-          startTime: new Date(Date.now() - 10000),
-          endTime: new Date(Date.now() - 10000)
-        }
-      })
-      db.contestProblem.findUniqueOrThrow.resolves({
-        problem: {
-          ...problems[0],
-          visibleLockTime: new Date(Date.now() + 10000)
-        }
-      })
+      db.contest.findFirst.resolves(null)
 
       await expect(
         service.submitToContest(
@@ -220,7 +205,7 @@ describe('SubmissionService', () => {
           CONTEST_ID,
           problems[0].groupId
         )
-      ).to.be.rejectedWith(ConflictFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
       expect(createSpy.called).to.be.false
     })
   })
@@ -228,7 +213,7 @@ describe('SubmissionService', () => {
   describe('submitToWorkbook', () => {
     it('should call createSubmission', async () => {
       const createSpy = stub(service, 'createSubmission')
-      db.workbookProblem.findUniqueOrThrow.resolves({ problem: problems[0] })
+      db.workbookProblem.findUnique.resolves({ problem: problems[0] })
 
       await service.submitToWorkbook(
         submissionDto,
@@ -243,12 +228,7 @@ describe('SubmissionService', () => {
 
     it('should throw exception if groupId does not match or problem is not exposed', async () => {
       const createSpy = stub(service, 'createSubmission')
-      db.workbookProblem.findUniqueOrThrow.resolves({
-        problem: {
-          ...problems[0],
-          visibleLockTime: new Date(Date.now() + 10000)
-        }
-      })
+      db.workbookProblem.findUnique.resolves(null)
 
       await expect(
         service.submitToWorkbook(
@@ -268,7 +248,6 @@ describe('SubmissionService', () => {
     it('should create submission', async () => {
       const createSpy = stub(service, 'createSubmissionResults')
       const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      db.problem.findUnique.resolves(problems[0])
       db.submission.create.resolves(submissions[0])
 
       expect(
@@ -278,7 +257,7 @@ describe('SubmissionService', () => {
           submissions[0].userId,
           USERIP
         )
-      ).to.be.deep.equal(submissions[0])
+      ).to.deep.equal(submissions[0])
       expect(createSpy.calledOnceWith(submissions[0])).to.be.true
       expect(publishSpy.calledOnce).to.be.true
     })
@@ -368,7 +347,6 @@ describe('SubmissionService', () => {
 
     it('should throw exception if the language is not supported', async () => {
       const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      db.problem.findUnique.resolves(problems[0])
 
       await expect(
         service.createSubmission(
@@ -384,7 +362,6 @@ describe('SubmissionService', () => {
     it('should throw error if locked code is modified', async () => {
       const validateSpy = spy(service, 'isValidCode')
       const publishSpy = stub(publish, 'publishJudgeRequestMessage')
-      db.problem.findUnique.resolves(problems[0])
 
       await expect(
         service.createSubmission(
@@ -404,22 +381,20 @@ describe('SubmissionService', () => {
 
   describe('getSubmissions', () => {
     it('should return submissions', async () => {
-      db.problem.findFirstOrThrow.resolves(problems[0])
+      db.problem.findFirst.resolves(problems[0])
       db.submission.findMany.resolves(submissions)
 
       expect(
         await service.getSubmissions({ problemId: problems[0].id })
-      ).to.be.deep.equal({ data: submissions, total: 1 })
+      ).to.deep.equal({ data: submissions, total: 1 })
     })
 
     it('should throw not found error', async () => {
-      db.problem.findFirstOrThrow.rejects(
-        new NotFoundException('No problem found error')
-      )
+      db.problem.findFirst.resolves(null)
 
       await expect(
         service.getSubmissions({ problemId: problems[0].id })
-      ).to.be.rejectedWith(NotFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
     })
   })
 
@@ -436,13 +411,13 @@ describe('SubmissionService', () => {
       })
 
       const passSpy = spy(problemRepository, 'hasPassedProblem')
-      db.problem.findFirstOrThrow.resolves(problems[0])
-      db.submission.findFirstOrThrow.resolves({
+      db.problem.findFirst.resolves(problems[0])
+      db.submission.findFirst.resolves({
         ...submissions[0],
         user: { username: 'username' },
         submissionResult: submissionResults
       })
-      db.user.findFirstOrThrow.resolves({
+      db.user.findFirst.resolves({
         username: 'username',
         id: submissions[0].userId,
         role: Role.User
@@ -457,7 +432,7 @@ describe('SubmissionService', () => {
           undefined,
           null
         )
-      ).to.be.deep.equal({
+      ).to.deep.equal({
         problemId: problems[0].id,
         username: 'username',
         code: submissions[0].code.map((snippet) => snippet.text).join('\n'),
@@ -470,9 +445,7 @@ describe('SubmissionService', () => {
     })
 
     it('should throw exception if problem is not found', async () => {
-      db.problem.findFirstOrThrow.rejects(
-        new NotFoundException('No problem found error')
-      )
+      db.problem.findFirst.resolves(null)
 
       await expect(
         service.getSubmission(
@@ -483,14 +456,12 @@ describe('SubmissionService', () => {
           undefined,
           null
         )
-      ).to.be.rejectedWith(NotFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
     })
 
     it('should throw exception if submission is not found', async () => {
-      db.problem.findFirstOrThrow.resolves(problems[0])
-      db.submission.findFirstOrThrow.rejects(
-        new NotFoundException('No submission found error')
-      )
+      db.problem.findFirst.resolves(problems[0])
+      db.submission.findFirst.resolves(null)
 
       await expect(
         service.getSubmission(
@@ -501,15 +472,15 @@ describe('SubmissionService', () => {
           undefined,
           null
         )
-      ).to.be.rejectedWith(NotFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
     })
 
     it("should throw exception if submission is not user's and user has not passed this problem", async () => {
       const passSpy = stub(problemRepository, 'hasPassedProblem').resolves(
         false
       )
-      db.problem.findFirstOrThrow.resolves(problems[0])
-      db.submission.findFirstOrThrow.resolves({ ...submissions[0], userId: 2 })
+      db.problem.findFirst.resolves(problems[0])
+      db.submission.findFirst.resolves({ ...submissions[0], userId: 2 })
 
       await expect(
         service.getSubmission(
@@ -539,52 +510,48 @@ describe('SubmissionService', () => {
         studentId: null,
         major: null
       }
-      db.contestRecord.findUniqueOrThrow.resolves()
-      db.contestProblem.findFirstOrThrow.resolves()
-      db.submission.findMany.resolves(submissions)
       db.user.findFirst.resolves(adminUser)
-      db.contest.findFirstOrThrow.resolves({ isJudgeVisible: true })
+      db.contestRecord.findUnique.resolves({})
+      db.contestProblem.findFirst.resolves({})
+      db.submission.findMany.resolves(submissions)
+      db.contest.findFirst.resolves({ isJudgeResultVisible: true })
 
       expect(
         await service.getContestSubmissions({
           problemId: problems[0].id,
-          contestId: 1,
+          contestId: CONTEST_ID,
           userId: submissions[0].userId
         })
-      ).to.be.deep.equal({ data: submissions, total: 1 })
+      ).to.deep.equal({ data: submissions, total: 1 })
     })
 
     it('should throw exception if user is not registered to contest', async () => {
       db.user.findFirst.resolves(null)
-      db.contestRecord.findUniqueOrThrow.rejects(
-        new NotFoundException('No contestRecord found error')
-      )
+      db.contestRecord.findUnique.resolves(null)
 
       await expect(
         service.getContestSubmissions({
           problemId: problems[0].id,
-          contestId: 1,
+          contestId: CONTEST_ID,
           userId: submissions[0].userId
         })
-      ).to.be.rejectedWith(NotFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
     })
 
     it("should throw exception if contest doesn't have this problem", async () => {
-      db.contestRecord.findUniqueOrThrow.resolves()
-      db.contestProblem.findFirstOrThrow.rejects(
-        new NotFoundException('No contestProblem found error')
-      )
+      db.user.findFirst.resolves({})
+      db.contestRecord.findUnique.resolves({})
+      db.contestProblem.findFirst.resolves(null)
 
       await expect(
         service.getContestSubmissions({
           problemId: problems[0].id,
-          contestId: 1,
+          contestId: CONTEST_ID,
           userId: submissions[0].userId
         })
-      ).to.be.rejectedWith(NotFoundException)
+      ).to.be.rejectedWith(EntityNotExistException)
     })
   })
-
   // TODO: 기획 문의 / 확정 후 Test DB 기반으로 재작성 예정
   // describe('getContestSubmisssion', () => {
   //   it('should return submission', async () => {


### PR DESCRIPTION
## Description
submission 모듈에서 에러 핸들링 로직을 글로벌 예외 처리 메커니즘으로 통합합니다. 컨트롤러와 서비스에서의 로컬 에러 처리를 제거하고, 레포지토리에서 발생하는 Prisma 예외는 적절한 Business exception으로 변환하여 전체적인 백엔드 코드의 일관성을 높입니다.

### 주요 변경 사항
controller에서 에러 처리하는 로직 제거
모든 try catch 블록 제거 / 서비스에서 발생한 예외를 그대로 글로벌 에러로 전파시킴

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
