### PR TITLE
feat(infra): created gateway vpc endpoint to replace NAT instance

### DIFF
--- a/apps/infra/production/network/gateway_vpc_endpoint_to_s3.tf
+++ b/apps/infra/production/network/gateway_vpc_endpoint_to_s3.tf
@@ -1,0 +1,24 @@
+resource "aws_vpc_endpoint" "s3_endpoint" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-2.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [
+      {
+        Action    = "*",
+        Effect    = "Allow",
+        Resource  = "*",
+        Principal = "*"
+      }
+    ]
+  })
+
+  tags = {
+    "Name" = "s3-endpoint"
+  }
+}
+
+


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
NAT 인스턴스의 ECS와 S3 간의 커뮤니케이션을 대체하기 위해 gateway vpc endpoint를 추가하였습니다.
이 기능이 작동하는지 테스트하려면, NAT instance public ip를 허용하는 S3 bucket policy를 지운후,
ECS와 S3 간의 통신이 여전히 유지되는 경우,
이 게이트웨이 vpc 엔드포인트가 제대로 작동하는 것으로 간주하여 테스트 할수 있을것 같습니다.

Closes TAS-887
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
