### PR TITLE
feat(infra): add lifecycle policy to ecr repositories

### DIFF
--- a/apps/infra/production/codedang/codedang_service_admin.tf
+++ b/apps/infra/production/codedang/codedang_service_admin.tf
@@ -2,6 +2,28 @@ data "aws_ecr_repository" "admin_api" {
   name = "codedang-admin-api"
 }
 
+resource "aws_ecr_lifecycle_policy" "admin_api_repository_policy" {
+  repository = data.aws_ecr_repository.admin_api.name
+  policy     = <<EOF
+    {
+        "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep the last 2 multi-architecture sets (1 image index, 2 architecture images).",
+            "selection": {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": 6
+            },
+            "action": {
+            "type": "expire"
+            }
+        }
+        ]
+    }
+    EOF
+}
+
 module "admin_api_loadbalancer" {
   source = "./modules/loadbalancing"
 

--- a/apps/infra/production/codedang/codedang_service_client.tf
+++ b/apps/infra/production/codedang/codedang_service_client.tf
@@ -2,6 +2,28 @@ data "aws_ecr_repository" "client_api" {
   name = "codedang-client-api"
 }
 
+resource "aws_ecr_lifecycle_policy" "client_api_repository_policy" {
+  repository = data.aws_ecr_repository.client_api.name
+  policy     = <<EOF
+    {
+        "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep the last 2 multi-architecture sets (1 image index, 2 architecture images).",
+            "selection": {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": 6
+            },
+            "action": {
+            "type": "expire"
+            }
+        }
+        ]
+    }
+    EOF
+}
+
 module "client_api_loadbalancer" {
   source = "./modules/loadbalancing"
 

--- a/apps/infra/production/codedang/codedang_service_iris.tf
+++ b/apps/infra/production/codedang/codedang_service_iris.tf
@@ -2,6 +2,28 @@ data "aws_ecr_repository" "iris" {
   name = "codedang-iris"
 }
 
+resource "aws_ecr_lifecycle_policy" "iris_repository_policy" {
+  repository = data.aws_ecr_repository.iris.name
+  policy     = <<EOF
+    {
+        "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep the last 2 multi-architecture sets (1 image index, 2 architecture images).",
+            "selection": {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": 6
+            },
+            "action": {
+            "type": "expire"
+            }
+        }
+        ]
+    }
+    EOF
+}
+
 module "iris" {
   source = "./modules/service_autoscaling"
 


### PR DESCRIPTION
### Description

closes TAS-931
이전에 ECR 레포지토리에 배포되어 있던 도커 이미지 파일을 자동으로 제거하는 수명 정책을 추가합니다.

<왜 최근 6개의 이미지를 킵하나요?>
저희 코드당은 배포 시 Docker Buildx를 사용합니다. 여러 플랫폼에 대한 빌드를 지원하며, 이 때에 두 개의 image와 한 개의 image index 파일 (총 3개의 파일)이 생성되어 ECR에 저장 됩니다. 따라서, 최신의 이미지 파일과 직전 이미지 파일을 보존하기 위해 직전 6개의 파일을 저장해 두도록 설정하였습니다.

<적용 방법>
깃헙 액션에서 이미지를 제거하는 방법, 그리고 AWS ECR에서 수명 정책을 생성하는 방법, 총 두 가지의 선택지가 있었습니다.
기존 코드당 테라폼 코드에서는 이미 콘솔 내에서 생성된 레포지토리를 참조하는 방식으로 짜임새가 맞추어져 있어, 테라폼으로 수명 정책을 추가하는 것으로도 문제가 없음을 판단하였습니다.

또한, 깃헙 액션 상에서 코드를 작성할 경우, 각 CD 파일에서 admin, client, iris에 대한 레포지토리에 각각 접근해야 하기 때문에 코드 상 중복이 많아지고, 유지 관리에 어려움이 발생할 수 있다고 판단, 최종적으로 수명 정책을 테라폼 내에서 추가하는 것으로 결정하였습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
