### PR TITLE
fix(fe): allocate more memory to node in devcontainer for smooth frontend build

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -67,6 +67,9 @@ pnpm exec lefthook install
 # Init MinIO
 pnpm run init:storage
 
+# Set NODE_OPTIONS to increase memory limit for frontend build (next build)
+echo "export NODE_OPTIONS=--max-old-space-size=4096" >> ~/.bashrc
+
 # Enable git auto completion
 if ! grep -q "bash-completion/completions/git" ~/.bashrc
 then


### PR DESCRIPTION
### Description
- Devcontainer에서 Frontend build 과정 중 JavaScript heap out of memory 에러를 방지합니다.
- [https://velog.io/@kwontae1313/build-과정-중-JavaScript-heap-out-of-memory-에러](https://velog.io/@kwontae1313/build-%EA%B3%BC%EC%A0%95-%EC%A4%91-JavaScript-heap-out-of-memory-%EC%97%90%EB%9F%AC)
- 위 레퍼런스를 참고하여 Devcontainer의 postInstallation script인 `scripts/setup.sh` 에 노드에 메모리를 기본으로 약 4GB 할당하도록 변경합니다. (Default: 약 2GB -> 변경: 약 4GB)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
