### PR TITLE
fix(fe): show warning when editing contest if submission exists

### DIFF
--- a/apps/frontend/app/admin/contest/[id]/edit/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/edit/page.tsx
@@ -33,6 +33,7 @@ import {
 import { GET_CONTEST } from '@/graphql/contest/queries'
 import { UPDATE_CONTEST_PROBLEMS_ORDER } from '@/graphql/problem/mutations'
 import { GET_CONTEST_PROBLEMS } from '@/graphql/problem/queries'
+import { GET_CONTEST_SUBMISSIONS_COUNT } from '@/graphql/submission/queries'
 import { useMutation, useQuery } from '@apollo/client'
 import type { UpdateContestInput } from '@generated/graphql'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -62,6 +63,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const { id } = params
 
   const shouldSkipWarning = useRef(false)
+  const hasSubmission = useRef(false)
   const router = useRouter()
 
   useConfirmNavigation(shouldSkipWarning)
@@ -75,6 +77,20 @@ export default function Page({ params }: { params: { id: string } }) {
   })
 
   const { handleSubmit, getValues, setValue } = methods
+
+  useQuery(GET_CONTEST_SUBMISSIONS_COUNT, {
+    variables: {
+      input: {
+        contestId: Number(id)
+      },
+      take: 2
+    },
+    onCompleted: (data) => {
+      if (data.getContestSubmissions.length !== 0) {
+        hasSubmission.current = true
+      }
+    }
+  })
 
   useQuery(GET_CONTEST, {
     variables: { contestId: Number(id) },
@@ -152,36 +168,49 @@ export default function Page({ params }: { params: { id: string } }) {
       return
     }
 
-    await removeProblemsFromContest({
-      variables: {
-        groupId: 1,
-        contestId: Number(id),
-        problemIds: prevProblemIds
-      }
-    })
-    await importProblemsToContest({
-      variables: {
-        groupId: 1,
-        contestId: Number(id),
-        problemIdsWithScore: problems.map((problem) => {
-          return {
-            problemId: problem.id,
-            score: problem.score
+    if (hasSubmission.current) {
+      await new Promise<void>((resolve) => {
+        toast.warning(
+          'Submissions exist. Only Contest information will be updated.',
+          {
+            onAutoClose: () => {
+              resolve()
+            },
+            duration: 4000
           }
-        })
-      }
-    })
-
-    const orderArray = problems
-      .sort((a, b) => a.order - b.order)
-      .map((problem) => problem.id)
-    await updateContestProblemsOrder({
-      variables: {
-        groupId: 1,
-        contestId: Number(id),
-        orders: orderArray
-      }
-    })
+        )
+      })
+    } else {
+      await removeProblemsFromContest({
+        variables: {
+          groupId: 1,
+          contestId: Number(id),
+          problemIds: prevProblemIds
+        }
+      })
+      await importProblemsToContest({
+        variables: {
+          groupId: 1,
+          contestId: Number(id),
+          problemIdsWithScore: problems.map((problem) => {
+            return {
+              problemId: problem.id,
+              score: problem.score
+            }
+          })
+        }
+      })
+      const orderArray = problems
+        .sort((a, b) => a.order - b.order)
+        .map((problem) => problem.id)
+      await updateContestProblemsOrder({
+        variables: {
+          groupId: 1,
+          contestId: Number(id),
+          orders: orderArray
+        }
+      })
+    }
 
     shouldSkipWarning.current = true
     toast.success('Contest updated successfully')

--- a/apps/frontend/app/admin/contest/[id]/edit/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/edit/page.tsx
@@ -171,7 +171,7 @@ export default function Page({ params }: { params: { id: string } }) {
     if (hasSubmission.current) {
       await new Promise<void>((resolve) => {
         toast.warning(
-          'Submissions exist. Only Contest information will be updated.',
+          'Submissions exist. Only contest changes, excluding changes to the contest problems, will be saved.',
           {
             onAutoClose: () => {
               resolve()

--- a/apps/frontend/graphql/submission/queries.ts
+++ b/apps/frontend/graphql/submission/queries.ts
@@ -1,5 +1,21 @@
 import { gql } from '@generated'
 
+const GET_CONTEST_SUBMISSIONS_COUNT = gql(`
+  query GetContestSubmissionsCount(
+  $input: GetContestSubmissionsInput!,
+  $cursor: Int,
+  $take: Int
+) {
+  getContestSubmissions(
+    input: $input,
+    cursor: $cursor,
+    take: $take
+  ) {
+    id
+  }
+}
+`)
+
 const GET_CONTEST_SUBMISSIONS = gql(`
   query GetContestSubmissions(
   $input: GetContestSubmissionsInput!,
@@ -74,4 +90,8 @@ const GET_SUBMISSION = gql(`query GetSubmission(
   }
 }`)
 
-export { GET_CONTEST_SUBMISSIONS, GET_SUBMISSION }
+export {
+  GET_CONTEST_SUBMISSIONS_COUNT,
+  GET_CONTEST_SUBMISSIONS,
+  GET_SUBMISSION
+}


### PR DESCRIPTION
### Description
- Contest에 Submission이 존재하는지 확인하고
존재하는 경우, Problem Import 관련 요청을 보내지 않습니다.

- 만약 Contest에 Submission이 존재하고
관리자가 Contest 관련 정보와 Problem을 추가로 Import한 경우
경고 토스트가 생성되고, Contest 관련 정보만이 Update 됩니다.


https://github.com/user-attachments/assets/1114d9af-31bf-4583-a775-501d5129351c


Contest Description을 수정하고, Problem을 추가로 Import 했지만
Submission이 존재하기 때문에, warning toast가 생성되었고
Contest Description만 Update 되었습니다

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-958
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
