### PR TITLE
chore(fe): fix admin contest time format

### DIFF
--- a/apps/frontend/app/admin/contest/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/_components/Columns.tsx
@@ -164,7 +164,7 @@ export const columns: ColumnDef<DataTableContest>[] = [
     ),
     cell: ({ row }) => (
       <p className="overflow-hidden whitespace-nowrap text-center font-normal">
-        {`${dateFormatter(row.original.startTime, 'YY-MM-DD hh:mm')} ~ ${dateFormatter(row.original.endTime, 'YY-MM-DD hh:mm')}`}
+        {`${dateFormatter(row.original.startTime, 'YY-MM-DD HH:mm')} ~ ${dateFormatter(row.original.endTime, 'YY-MM-DD HH:mm')}`}
       </p>
     ),
     size: 250


### PR DESCRIPTION
### Description

admin contest table의 period 타임 포맷을 12시간제에서 24시간제로 수정했습니다!
(task 핑계로 리팩토링 덜 하고 싶었는데 4글자 바꾼 게 다라서 안 되겠네요...ㅋㅋㅋㅋ)

closes TAS-961

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
