### PR TITLE
chore(fe): wrap the line of the hint automatically

### DIFF
--- a/apps/frontend/components/EditorDescription.tsx
+++ b/apps/frontend/components/EditorDescription.tsx
@@ -286,7 +286,7 @@ export function EditorDescription({
           <AccordionContent>
             <pre
               dangerouslySetInnerHTML={{ __html: sanitize(problem.hint) }}
-              className="prose prose-invert max-w-full text-sm leading-relaxed text-slate-300"
+              className="prose prose-invert max-w-full whitespace-pre-wrap break-keep text-sm leading-relaxed text-slate-300"
             />
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
### Description

- 힌트가 길 때 자동으로 줄바꿈 되도록 수정합니다. 이때 단어 기준으로 줄바꿈됩니다.
- 개행문자를 유지하면 줄바꿈이 되다 보니 아래 사진처럼 이상하게 보일 수 있는데 그렇다고 개행문자를 무시할 순 없어서 유지하는 방향으로 수정했습니다.

![image](https://github.com/user-attachments/assets/e3a35734-88c0-47d8-80d5-cecf7bad3cb0)


closes TAS-960


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
