### PR TITLE
fix(fe): restore the score of the problems when the new problems are imported

### DIFF
--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -9,6 +9,7 @@ interface ContestProblem {
   id: number
   title: string
   difficulty: string
+  score: number
 }
 
 interface OrderContestProblem {
@@ -56,8 +57,11 @@ export default function ImportProblemTable({
           ...tag,
           id: +tag.id
         }
-      }))
+      })),
+      score: checkedProblems.find((item) => item.id === Number(problem.id))
+        ?.score
     })) ?? []
+
   return (
     <>
       {loading ? (

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
@@ -13,6 +13,7 @@ interface DataTableProblem {
   submissionCount: number
   acceptedRate: number
   languages: string[]
+  score?: number
 }
 
 export const columns: ColumnDef<DataTableProblem>[] = [


### PR DESCRIPTION
### Description

`ImportProblemTable` 데이터에 score 정보를 포함하도록 합니다.


https://github.com/user-attachments/assets/ecf18a2b-82ea-4178-9131-9c4e432df179



closes TAS-979


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
