### PR TITLE
fix(fe): not show add/delete buttons when testcase cannot be edited

### DIFF
--- a/apps/frontend/app/admin/problem/_components/ExampleTextarea.tsx
+++ b/apps/frontend/app/admin/problem/_components/ExampleTextarea.tsx
@@ -27,10 +27,15 @@ export default function ExampleTextarea({
         className
       )}
     >
-      <RxCross2
-        className="absolute right-2 top-2 w-3 cursor-pointer p-0 text-gray-400"
-        onClick={() => onRemove()}
-      />
+      {!blockEdit && (
+        <button
+          type="button"
+          className="absolute right-2 top-2 w-3 p-0 text-gray-400"
+          onClick={onRemove}
+        >
+          <RxCross2 />
+        </button>
+      )}
       <Textarea
         disabled={blockEdit}
         placeholder="Input"

--- a/apps/frontend/app/admin/problem/_components/TestcaseField.tsx
+++ b/apps/frontend/app/admin/problem/_components/TestcaseField.tsx
@@ -18,7 +18,11 @@ import AddBadge from './AddBadge'
 import { CautionDialog } from './CautionDialog'
 import TestcaseItem from './TestcaseItem'
 
-export default function TestcaseField({ blockEdit }: { blockEdit?: boolean }) {
+export default function TestcaseField({
+  blockEdit = false
+}: {
+  blockEdit?: boolean
+}) {
   const {
     formState: { errors },
     getValues,
@@ -127,7 +131,7 @@ export default function TestcaseField({ blockEdit }: { blockEdit?: boolean }) {
               />
             )
         )}
-        <AddBadge onClick={() => addTestcase(false)} />
+        {!blockEdit && <AddBadge onClick={() => addTestcase(false)} />}
       </div>
       <div className="flex flex-col gap-4">
         <Label required={false}>Hidden Testcase</Label>
@@ -143,7 +147,7 @@ export default function TestcaseField({ blockEdit }: { blockEdit?: boolean }) {
               />
             )
         )}
-        <AddBadge onClick={() => addTestcase(true)} />
+        {!blockEdit && <AddBadge onClick={() => addTestcase(true)} />}
       </div>
       <div className="flex w-full justify-end">
         <TooltipProvider>


### PR DESCRIPTION
### Description

submission이 존재해 테스트케이스를 수정할 수 없는 경우 테케 추가/삭제 버튼이 보이지 않도록 합니다. ([피그마](https://www.figma.com/design/c7RefqPCB4HC9DuFhT7eFg/%EC%BD%94%EB%93%9C%EB%8B%B9-%EB%A6%AC%EB%94%94%EC%9E%90%EC%9D%B8-(2024ver)?node-id=3104-9040&t=Z23hwZbwq8N83MJl-1)에서 제시한 대로 수정했습니다)

closes TAS-989

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
