### PR TITLE
fix(fe): block editing problem when contest has submission

### DIFF
--- a/apps/frontend/app/admin/contest/[id]/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/[id]/_components/Columns.tsx
@@ -81,9 +81,8 @@ export const columns = (
         <Input
           disabled={disableInput}
           defaultValue={row.getValue('score')}
-          className="hide-spin-button w-[70px] focus-visible:ring-0"
+          className="hide-spin-button w-[70px] focus-visible:ring-0 disabled:pointer-events-none"
           type="number"
-          style={{ pointerEvents: disableInput ? 'none' : 'auto' }}
           min={0}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
@@ -136,27 +135,25 @@ export const columns = (
             }
           }}
         >
-          <div style={{ pointerEvents: disableInput ? 'none' : 'auto' }}>
-            <OptionSelect
-              value={
-                row.original.order !== undefined
-                  ? String.fromCharCode(Number(65 + row.original.order))
-                  : String.fromCharCode(Number(65 + row.index))
-              }
-              options={alphabetArray}
-              onChange={(selectedOrder) => {
-                setProblems((prevProblems: ContestProblem[]) =>
-                  prevProblems.map((problem) =>
-                    problem.id === row.original.id
-                      ? { ...problem, order: selectedOrder.charCodeAt(0) - 65 }
-                      : problem
-                  )
+          <OptionSelect
+            value={
+              row.original.order !== undefined
+                ? String.fromCharCode(Number(65 + row.original.order))
+                : String.fromCharCode(Number(65 + row.index))
+            }
+            options={alphabetArray}
+            onChange={(selectedOrder) => {
+              setProblems((prevProblems: ContestProblem[]) =>
+                prevProblems.map((problem) =>
+                  problem.id === row.original.id
+                    ? { ...problem, order: selectedOrder.charCodeAt(0) - 65 }
+                    : problem
                 )
-              }}
-              className="w-[70px]"
-              disabled={disableInput}
-            />
-          </div>
+              )
+            }}
+            className="w-[70px] disabled:pointer-events-none"
+            disabled={disableInput}
+          />
         </div>
       )
     }

--- a/apps/frontend/app/admin/contest/[id]/_components/Columns.tsx
+++ b/apps/frontend/app/admin/contest/[id]/_components/Columns.tsx
@@ -8,6 +8,7 @@ import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
 import type { Level } from '@/types/type'
 import { useQuery } from '@apollo/client'
 import type { ColumnDef, Row } from '@tanstack/react-table'
+import { toast } from 'sonner'
 import type { ContestProblem } from '../../utils'
 
 function Included({ row }: { row: Row<ContestProblem> }) {
@@ -25,7 +26,8 @@ function Included({ row }: { row: Row<ContestProblem> }) {
 
 export const columns = (
   problems: ContestProblem[],
-  setProblems: React.Dispatch<React.SetStateAction<ContestProblem[]>>
+  setProblems: React.Dispatch<React.SetStateAction<ContestProblem[]>>,
+  disableInput: boolean
 ): ColumnDef<ContestProblem>[] => [
   // {
   //   id: 'select',
@@ -68,11 +70,20 @@ export const columns = (
     accessorKey: 'score',
     header: () => <p className="text-center text-sm">Score</p>,
     cell: ({ row }) => (
-      <div className="flex justify-center">
+      <div
+        className="flex justify-center"
+        onClick={() => {
+          if (disableInput) {
+            toast.error('Problem scoring cannot be edited')
+          }
+        }}
+      >
         <Input
+          disabled={disableInput}
           defaultValue={row.getValue('score')}
           className="hide-spin-button w-[70px] focus-visible:ring-0"
           type="number"
+          style={{ pointerEvents: disableInput ? 'none' : 'auto' }}
           min={0}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
@@ -117,25 +128,35 @@ export const columns = (
         String.fromCharCode(65 + index)
       )
       return (
-        <div className="flex justify-center">
-          <OptionSelect
-            value={
-              row.original.order !== undefined
-                ? String.fromCharCode(Number(65 + row.original.order))
-                : String.fromCharCode(Number(65 + row.index))
+        <div
+          className="flex justify-center"
+          onClick={() => {
+            if (disableInput) {
+              toast.error('Problem order cannot be edited')
             }
-            options={alphabetArray}
-            onChange={(selectedOrder) => {
-              setProblems((prevProblems: ContestProblem[]) =>
-                prevProblems.map((problem) =>
-                  problem.id === row.original.id
-                    ? { ...problem, order: selectedOrder.charCodeAt(0) - 65 }
-                    : problem
+          }}
+        >
+          <div style={{ pointerEvents: disableInput ? 'none' : 'auto' }}>
+            <OptionSelect
+              value={
+                row.original.order !== undefined
+                  ? String.fromCharCode(Number(65 + row.original.order))
+                  : String.fromCharCode(Number(65 + row.index))
+              }
+              options={alphabetArray}
+              onChange={(selectedOrder) => {
+                setProblems((prevProblems: ContestProblem[]) =>
+                  prevProblems.map((problem) =>
+                    problem.id === row.original.id
+                      ? { ...problem, order: selectedOrder.charCodeAt(0) - 65 }
+                      : problem
+                  )
                 )
-              )
-            }}
-            className="w-[70px]"
-          />
+              }}
+              className="w-[70px]"
+              disabled={disableInput}
+            />
+          </div>
         </div>
       )
     }

--- a/apps/frontend/components/OptionSelect.tsx
+++ b/apps/frontend/components/OptionSelect.tsx
@@ -15,6 +15,7 @@ interface OptionSelectProps {
   value?: string
   placeholder?: string
   className?: string
+  disabled?: boolean
 }
 
 export default function OptionSelect({
@@ -22,10 +23,15 @@ export default function OptionSelect({
   onChange,
   value,
   placeholder,
-  className
+  className,
+  disabled
 }: OptionSelectProps) {
   return (
-    <Select value={value} onValueChange={(value) => onChange(value)}>
+    <Select
+      value={value}
+      onValueChange={(value) => onChange(value)}
+      disabled={disabled}
+    >
       <SelectTrigger
         className={cn(
           'w-[115px] bg-white font-bold hover:bg-gray-50 focus:outline-none focus:ring-0 focus:ring-offset-0',


### PR DESCRIPTION
### Description
![image](https://github.com/user-attachments/assets/e272d5ab-a331-4398-9fec-5bd6002c1523)
Contest에 Submission이 존재하는 경우
- import 버튼을 숨깁니다
- Contest Problem List에서 score, order 수정을 막습니다
- score order 필드를 클릭하면 수정할 수 없다는 토스트가 노출됩니다
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-1002
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
