### PR TITLE
fix(fe): restore the imported problem order

### DIFF
--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -10,6 +10,7 @@ interface ContestProblem {
   title: string
   difficulty: string
   score: number
+  order: number
 }
 
 interface OrderContestProblem {
@@ -94,9 +95,18 @@ export default function ImportProblemTable({
           checkedRows={checkedProblems}
           onSelectedExport={(problems) => {
             onCloseDialog()
-            const problemsWithOrder = problems.map((problem, index) => {
-              return { ...problem, order: index }
-            })
+            const problemsWithOrder = problems
+              .map((problem) => ({
+                ...problem,
+                order:
+                  checkedProblems.find((item) => item.id === problem.id)
+                    ?.order ?? Number.MAX_SAFE_INTEGER
+              }))
+              .sort((a, b) => a.order - b.order)
+              .map((problem, index) => ({
+                ...problem,
+                order: index
+              }))
             onSelectedExport(problemsWithOrder)
           }}
           defaultPageSize={5}

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -95,6 +95,7 @@ export default function ImportProblemTable({
           checkedRows={checkedProblems}
           onSelectedExport={(problems) => {
             onCloseDialog()
+
             const problemsWithOrder = problems
               .map((problem) => ({
                 ...problem,
@@ -103,11 +104,25 @@ export default function ImportProblemTable({
                     ?.order ?? Number.MAX_SAFE_INTEGER
               }))
               .sort((a, b) => a.order - b.order)
-              .map((problem, index) => ({
-                ...problem,
-                order: index
-              }))
-            onSelectedExport(problemsWithOrder)
+
+            let order = 0
+            const exportedProblems = problemsWithOrder.map(
+              (problem, index, arr) => {
+                if (
+                  index > 0 &&
+                  // NOTE: 만약 현재 요소가 새로 추가된 문제이거나 새로 추가된 문제가 아니라면 이전 문제와 기존 순서가 다를 때
+                  (arr[index].order === Number.MAX_SAFE_INTEGER ||
+                    arr[index - 1].order !== arr[index].order)
+                ) {
+                  order++
+                }
+                return {
+                  ...problem,
+                  order
+                }
+              }
+            )
+            onSelectedExport(exportedProblems)
           }}
           defaultPageSize={5}
         />

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -241,8 +241,7 @@ export default function Page() {
                 </Dialog>
               </div>
               <DataTableAdmin
-                // eslint-disable-next-line
-                columns={columns(problems, setProblems) as any[]}
+                columns={columns(problems, setProblems, false)}
                 data={problems as ContestProblem[]}
                 defaultSortColumn={{ id: 'order', desc: false }}
                 enableFooter={true}


### PR DESCRIPTION
### Description

이미 임포트된 문제들의 순서를 유지하도록 합니다.

다음과 같은 정책을 따릅니다. 

```
기존 문제들은 오름차순대로 순서 유지 && 빈 번호를 채워서 앞으로 당겨짐. 새 문제는 뒤에 차례대로 추가됨.

예시 1) 기존 문제 A(0), B(1), C(2) 존재하는 상황에서 B를 삭제하고 새 문제(D, E)를 추가한다고 가정

A(0), C(2->1), D(2), E(3)

예시 2) 기존 문제 A(0), B(0), C(2) 존재하는 상황에서 C를 삭제하고 새 문제(D, E)를 추가한다고 가정

A(0), B(0), D(1), E(2)
```


https://github.com/user-attachments/assets/58f2cc9d-067f-4138-b90c-d1aeb8179067




closes TAS-979

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
