### PR TITLE
fix(fe): differentiate toast messages for save and submit actions

### DIFF
--- a/apps/frontend/components/EditorHeader.tsx
+++ b/apps/frontend/components/EditorHeader.tsx
@@ -153,7 +153,7 @@ export default function Editor({
       }
     })
     if (res.ok) {
-      saveCode()
+      saveCode(true)
       const submission: Submission = await res.json()
       setSubmissionId(submission.id)
     } else {
@@ -242,14 +242,16 @@ export default function Editor({
     poll()
   }
 
-  const saveCode = async () => {
+  const saveCode = async (isSubmitting?: boolean) => {
     const session = await auth()
     if (!session) {
       toast.error('Log in first to save your code')
     } else {
-      if (storeCodeToLocalstorage())
-        toast.success('Successfully saved the code')
-      else toast.error('Failed to save the code')
+      if (storeCodeToLocalstorage()) {
+        toast.success(
+          `Successfully ${isSubmitting ? 'submitted' : 'saved'} the code`
+        )
+      } else toast.error('Failed to save the code')
     }
   }
 
@@ -314,7 +316,7 @@ export default function Editor({
         <Button
           size="icon"
           className="size-7 h-8 w-[77px] shrink-0 gap-[5px] rounded-[4px] bg-[#D7E5FE] font-medium text-[#484C4D] hover:bg-[#c6d3ea]"
-          onClick={saveCode}
+          onClick={() => saveCode()}
         >
           <Save className="stroke-1" size={22} />
           Save

--- a/apps/frontend/components/EditorHeader.tsx
+++ b/apps/frontend/components/EditorHeader.tsx
@@ -157,12 +157,12 @@ export default function Editor({
       const submission: Submission = await res.json()
       setSubmissionId(submission.id)
     } else {
+      setLoading(false)
       if (res.status === 401) {
         showSignIn()
         toast.error('Log in first to submit your code')
       } else toast.error('Please try again later.')
     }
-    setLoading(false)
   }
 
   const submitTest = async () => {


### PR DESCRIPTION
### Description
### AS-IS
Submit과 Save에 대해 공통적으로 `Successfully saved the code` 토스트 노출
### TO-BE
Submit인 경우 `Successfully submitted the code` 토스트 노출
Save나 Test의 경우 `Successfully saved the code` 토스트 노출

### 코드 제출해도 Submission 탭으로 안 넘어가던 문제 해결
submissionId가 세팅되고 loading이 true인 상태여야 useInterval 안의 submission 탭으로 이동이 트리거 되는데
loading이 바로 false로 바뀌는 바람에 넘어가지 못하고 있었던 것 같습니다!

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
