### PR TITLE
fix(be): no not-found exception in get-score-summaries api

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -708,7 +708,7 @@ export class ContestService {
    * 특정 user의 특정 Contest에 대한 총점, 통과한 문제 개수와 각 문제별 테스트케이스 통과 개수를 불러옵니다.
    */
   async getContestScoreSummary(userId: number, contestId: number) {
-    const [contestProblems, submissions, contestRecord] = await Promise.all([
+    const [contestProblems, submissions] = await Promise.all([
       this.prisma.contestProblem.findMany({
         where: {
           contestId
@@ -722,19 +722,9 @@ export class ContestService {
         orderBy: {
           createTime: 'desc'
         }
-      }),
-      this.prisma.contestRecord.findFirst({
-        where: {
-          userId,
-          contestId
-        }
       })
     ])
-    if (!contestProblems.length) {
-      throw new EntityNotExistException('ContestProblems')
-    } else if (!contestRecord) {
-      throw new EntityNotExistException('contestRecord')
-    }
+
     if (!submissions.length) {
       return {
         submittedProblemCount: 0,
@@ -747,6 +737,7 @@ export class ContestService {
         problemScores: []
       }
     }
+
     // 하나의 Problem에 대해 여러 개의 Submission이 존재한다면, 마지막에 제출된 Submission만을 점수 계산에 반영함
     const latestSubmissions: {
       [problemId: string]: {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

closes TAS-981

getContestScoreSummary 함수에서 불필요한 예외를 던지는 문제를 해결합니다.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
