### PR TITLE
fix(infra): set portgres version to 14 to avoid downgrade errors and ensure latest minor updates

### DIFF
--- a/apps/infra/production/storage/database.tf
+++ b/apps/infra/production/storage/database.tf
@@ -71,7 +71,7 @@ resource "random_password" "postgres_password" {
 resource "aws_db_instance" "postgres" {
   db_name           = "codedang_db"
   engine            = "postgres"
-  engine_version    = "14.10"
+  engine_version    = "14"
   allocated_storage = 5
   instance_class    = "db.t4g.small"
 

--- a/collection/client/environments/Stage.bru
+++ b/collection/client/environments/Stage.bru
@@ -1,5 +1,5 @@
 vars {
-  baseUrl: https://stage.codedang.com/api
+  baseUrl: https://coolify.codedang.com/api
 }
 vars:secret [
   jwtToken

--- a/collection/client/environments/Stage.bru
+++ b/collection/client/environments/Stage.bru
@@ -1,5 +1,5 @@
 vars {
-  baseUrl: https://coolify.codedang.com/api
+  baseUrl: https://stage.codedang.com/api
 }
 vars:secret [
   jwtToken


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Closes TAS-1006

 RDS의 자동 업데이트가 허용 되어 있었으나, 테라폼 콘솔 내에서는 마이너 버전의 업데이트 이전 버전이 작성되어 있어 배포에 오류가 발생하고 있었습니다. 적어도 테라폼에서는 DB 버전의 다운그레이드를 지원하지 않습니다.

 따라서, 메이저 버전만을 명시해 마이너 버전은 '현 상태'와 마찬가지로 자동으로 업데이트 되도록 버전을 "14.10" 에서 "14"로 재명시 하였습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
