### PR TITLE
fix(fe): render katex in editor input, output description

### DIFF
--- a/apps/frontend/components/EditorDescription.tsx
+++ b/apps/frontend/components/EditorDescription.tsx
@@ -93,23 +93,17 @@ export function EditorDescription({
 
       <div className="px-6">
         <h2 className="mb-3 font-bold">Input</h2>
-        <div
-          className="prose prose-invert mb-4 max-w-full text-sm leading-relaxed text-slate-300"
-          dangerouslySetInnerHTML={{
-            __html: sanitize(problem.inputDescription)
-          }}
-        />
+        <div className="prose prose-invert mb-4 max-w-full text-sm leading-relaxed text-slate-300">
+          <KatexContent content={problem.inputDescription} />
+        </div>
         <hr className="border-slate-700" />
       </div>
 
       <div className="px-6">
         <h2 className="mb-3 font-bold">Output</h2>
-        <div
-          className="prose prose-invert max-w-full text-sm leading-relaxed text-slate-300"
-          dangerouslySetInnerHTML={{
-            __html: sanitize(problem.outputDescription)
-          }}
-        />
+        <div className="prose prose-invert max-w-full text-sm leading-relaxed text-slate-300">
+          <KatexContent content={problem.outputDescription} />
+        </div>
       </div>
 
       <hr className="border-4 border-[#121728]" />


### PR DESCRIPTION
### Description

input, output description 에서 katex를 렌더링하지 않고 있습니다.
어드민에는 katex를 넣는 기능이 있지만, 클라이언트에서는 katex를 렌더링하지 않습니다.
페어가 맞지 않아 이를 변경합니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
