### PR TITLE
refactor(fe): replace data table admin component to new components (1)

### DIFF
--- a/apps/frontend/app/admin/_components/table/DataTableMultiSelectFilter.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableMultiSelectFilter.tsx
@@ -17,6 +17,7 @@ import { Separator } from '@/components/ui/separator'
 import type { Column } from '@tanstack/react-table'
 import type { ReactNode } from 'react'
 import { IoFilter } from 'react-icons/io5'
+import { useDataTable } from './context'
 
 interface DataTableMultiSelectFilterProps<TData, TValue> {
   column?: Column<TData, TValue>
@@ -45,6 +46,7 @@ export default function DataTableMultiSelectFilter<TData, TValue>({
   options,
   emptyMessage
 }: DataTableMultiSelectFilterProps<TData, TValue>) {
+  const { table } = useDataTable()
   const selectedValues = getSelectedValues(column?.getFilterValue())
 
   return (
@@ -109,6 +111,7 @@ export default function DataTableMultiSelectFilter<TData, TValue>({
                     column?.setFilterValue(
                       filterValues.length ? filterValues : undefined
                     )
+                    table.resetPageIndex()
                   }}
                 >
                   <Checkbox checked={selectedValues.has(value)} />

--- a/apps/frontend/app/admin/_components/table/DataTableProblemFilter.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableProblemFilter.tsx
@@ -84,6 +84,7 @@ export default function DataTableProblemFilter({
                   onSelect={() => {
                     column?.setFilterValue(value)
                     setOpen(false)
+                    table.resetPageIndex()
                   }}
                 >
                   <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">

--- a/apps/frontend/app/admin/contest/[id]/edit/page.tsx
+++ b/apps/frontend/app/admin/contest/[id]/edit/page.tsx
@@ -5,7 +5,6 @@ import DescriptionForm from '@/app/admin/_components/DescriptionForm'
 import FormSection from '@/app/admin/_components/FormSection'
 import SwitchField from '@/app/admin/_components/SwitchField'
 import TitleForm from '@/app/admin/_components/TitleForm'
-import { DataTableAdmin } from '@/components/DataTableAdmin'
 import {
   AlertDialog,
   AlertDialogTrigger,
@@ -40,16 +39,19 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { PlusCircleIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useRef, useState } from 'react'
+import { Suspense, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { FaAngleLeft } from 'react-icons/fa6'
 import { IoIosCheckmarkCircle } from 'react-icons/io'
 import { toast } from 'sonner'
 import ContestProblemListLabel from '../../_components/ContestProblemListLabel'
-import ImportProblemTable from '../../_components/ImportProblemTable'
+import ContestProblemTable from '../../_components/ContestProblemTable'
+import {
+  ImportProblemTable,
+  ImportProblemTableFallback
+} from '../../_components/ImportProblemTable'
 import TimeForm from '../../_components/TimeForm'
 import { type ContestProblem, editSchema } from '../../utils'
-import { columns } from '../_components/Columns'
 
 export default function Page({ params }: { params: { id: string } }) {
   const [prevProblemIds, setPrevProblemIds] = useState<number[]>([])
@@ -305,22 +307,22 @@ export default function Page({ params }: { params: { id: string } }) {
                     <DialogHeader>
                       <DialogTitle>Import Problem</DialogTitle>
                     </DialogHeader>
-                    <ImportProblemTable
-                      checkedProblems={problems as ContestProblem[]}
-                      onSelectedExport={(problems) =>
-                        setProblems(problems as ContestProblem[])
-                      }
-                      onCloseDialog={() => setShowImportDialog(false)}
-                    />
+                    <Suspense fallback={<ImportProblemTableFallback />}>
+                      <ImportProblemTable
+                        checkedProblems={problems}
+                        onSelectedExport={(problems) => {
+                          setProblems(problems)
+                          setShowImportDialog(false)
+                        }}
+                      />
+                    </Suspense>
                   </DialogContent>
                 </Dialog>
               </div>
-              <DataTableAdmin
-                columns={columns(problems, setProblems, hasSubmission)}
-                data={problems as ContestProblem[]}
-                defaultSortColumn={{ id: 'order', desc: false }}
-                enableFooter={true}
-                defaultPageSize={20}
+              <ContestProblemTable
+                problems={problems}
+                setProblems={setProblems}
+                disableInput={hasSubmission}
               />
             </div>
             <Button

--- a/apps/frontend/app/admin/contest/_components/ContestProblemColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestProblemColumns.tsx
@@ -4,28 +4,12 @@ import ContainedContests from '@/app/admin/problem/_components/ContainedContests
 import OptionSelect from '@/components/OptionSelect'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
-import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
 import type { Level } from '@/types/type'
-import { useQuery } from '@apollo/client'
-import type { ColumnDef, Row } from '@tanstack/react-table'
+import type { ColumnDef } from '@tanstack/react-table'
 import { toast } from 'sonner'
-import type { ContestProblem } from '../../utils'
+import type { ContestProblem } from '../utils'
 
-function Included({ row }: { row: Row<ContestProblem> }) {
-  const contestData = useQuery(GET_BELONGED_CONTESTS, {
-    variables: {
-      problemId: Number(row.original.id)
-    }
-  }).data
-  return (
-    <div className="flex justify-center">
-      {contestData && <ContainedContests data={contestData} />}
-    </div>
-  )
-}
-
-export const columns = (
-  problems: ContestProblem[],
+export const createColumns = (
   setProblems: React.Dispatch<React.SetStateAction<ContestProblem[]>>,
   disableInput: boolean
 ): ColumnDef<ContestProblem>[] => [
@@ -103,15 +87,15 @@ export const columns = (
         />
       </div>
     ),
-    footer: () => (
+    footer: ({ table }) => (
       <div className="flex justify-center">
         <Input
           disabled={true}
           className="w-[70px] focus-visible:ring-0"
-          defaultValue={problems.reduce(
-            (total, problem) => total + problem.score,
-            0
-          )}
+          defaultValue={table
+            .getCoreRowModel()
+            .rows.map((row) => row.original)
+            .reduce((total, problem) => total + problem.score, 0)}
         />
       </div>
     ),
@@ -180,7 +164,11 @@ export const columns = (
   {
     accessorKey: 'included',
     header: () => <p className="text-center text-sm">Included</p>,
-    cell: ({ row }) => <Included row={row} />,
+    cell: ({ row }) => (
+      <div className="flex justify-center">
+        <ContainedContests problemId={row.original.id} />
+      </div>
+    ),
     enableSorting: false
   }
 ]

--- a/apps/frontend/app/admin/contest/_components/ContestProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestProblemTable.tsx
@@ -1,0 +1,33 @@
+import { useMemo, type Dispatch, type SetStateAction } from 'react'
+import DataTable from '../../_components/table/DataTable'
+import DataTableRoot from '../../_components/table/DataTableRoot'
+import type { ContestProblem } from '../utils'
+import { createColumns } from './ContestProblemColumns'
+
+interface ContestProblemTableProps {
+  problems: ContestProblem[]
+  setProblems: Dispatch<SetStateAction<ContestProblem[]>>
+  disableInput: boolean
+}
+
+export default function ContestProblemTable({
+  problems,
+  setProblems,
+  disableInput
+}: ContestProblemTableProps) {
+  const columns = useMemo(
+    () => createColumns(setProblems, disableInput),
+    [setProblems, disableInput]
+  )
+
+  return (
+    <DataTableRoot
+      columns={columns}
+      data={problems}
+      defaultPageSize={20}
+      defaultSortState={[{ id: 'order', desc: false }]}
+    >
+      <DataTable showFooter={true} />
+    </DataTableRoot>
+  )
+}

--- a/apps/frontend/app/admin/contest/_components/ContestTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestTable.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { DELETE_CONTEST } from '@/graphql/contest/mutations'
+import { GET_CONTESTS } from '@/graphql/contest/queries'
+import { useApolloClient, useMutation, useSuspenseQuery } from '@apollo/client'
+import DataTable from '../../_components/table/DataTable'
+import DataTableDeleteButton from '../../_components/table/DataTableDeleteButton'
+import DataTableFallback from '../../_components/table/DataTableFallback'
+import DataTablePagination from '../../_components/table/DataTablePagination'
+import DataTableRoot from '../../_components/table/DataTableRoot'
+import DataTableSearchBar from '../../_components/table/DataTableSearchBar'
+import { columns } from './ContestTableColumns'
+import DuplicateContestButton from './DuplicateContestButton'
+
+const headerStyle = {
+  select: '',
+  title: 'w-3/5',
+  startTime: 'px-0 w-1/5',
+  participants: 'px-0 w-1/12',
+  isVisible: 'px-0 w-1/12'
+}
+
+export function ContestTable() {
+  const { data } = useSuspenseQuery(GET_CONTESTS, {
+    variables: {
+      groupId: 1,
+      take: 300
+    }
+  })
+
+  const contests = data.getContests.map((contest) => ({
+    ...contest,
+    id: Number(contest.id)
+  }))
+
+  return (
+    <DataTableRoot
+      data={contests}
+      columns={columns}
+      defaultSortState={[{ id: 'startTime', desc: true }]}
+    >
+      <div className="flex gap-2">
+        <DataTableSearchBar columndId="title" />
+        <DuplicateContestButton />
+        <ContestsDeleteButton />
+      </div>
+      <DataTable
+        headerStyle={headerStyle}
+        getHref={(data) => `/admin/contest/${data.id}`}
+      />
+      <DataTablePagination showSelection />
+    </DataTableRoot>
+  )
+}
+
+function ContestsDeleteButton() {
+  const client = useApolloClient()
+  const [deleteContest] = useMutation(DELETE_CONTEST)
+
+  const deleteTarget = (id: number) => {
+    return deleteContest({
+      variables: {
+        groupId: 1,
+        contestId: id
+      }
+    })
+  }
+
+  const onSuccess = () => {
+    client.refetchQueries({
+      include: [GET_CONTESTS]
+    })
+  }
+
+  return (
+    <DataTableDeleteButton
+      target="contest"
+      deleteTarget={deleteTarget}
+      onSuccess={onSuccess}
+    />
+  )
+}
+
+export function ContestTableFallback() {
+  return <DataTableFallback columns={columns} headerStyle={headerStyle} />
+}

--- a/apps/frontend/app/admin/contest/_components/ContestTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestTableColumns.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DataTableColumnHeader } from '@/components/DataTableColumnHeader'
+import DataTableColumnHeader from '@/app/admin/_components/table/DataTableColumnHeader'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
 import {
@@ -19,7 +19,7 @@ import type { ColumnDef, Row } from '@tanstack/react-table'
 import Image from 'next/image'
 import { toast } from 'sonner'
 
-interface DataTableContest {
+export interface DataTableContest {
   id: number
   title: string
   startTime: string
@@ -77,6 +77,7 @@ function VisibleCell({ row }: { row: Row<DataTableContest> }) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
+                  type="button"
                   onClick={(e) => e.stopPropagation()}
                   className="h-6 w-6"
                 >

--- a/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
+++ b/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
@@ -37,9 +37,6 @@ export default function DuplicateContestButton() {
         table.getSelectedRowModel().rows[0].original.startTime,
         table.getSelectedRowModel().rows[0].original.endTime
       )}
-      onCompleted={() => {
-        table.resetRowSelection()
-      }}
     />
   ) : (
     <DisabledDuplicateButton />
@@ -66,13 +63,13 @@ function DisabledDuplicateButton() {
 
 function EnabledDuplicateButton({
   contestId,
-  contestStatus,
-  onCompleted
+  contestStatus
 }: {
   contestId: number
   contestStatus: string
-  onCompleted?: () => void
 }) {
+  const { table } = useDataTable<DataTableContest>()
+
   const client = useApolloClient()
   const [duplicateContest] = useMutation(DUPLICATE_CONTEST)
 
@@ -91,10 +88,10 @@ function EnabledDuplicateButton({
             id: toastId
           }
         )
-        onCompleted?.()
         client.refetchQueries({
           include: [GET_CONTESTS]
         })
+        table.resetRowSelection()
       },
       onError: (error) => {
         console.log(error)

--- a/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
+++ b/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip'
+import { DUPLICATE_CONTEST } from '@/graphql/contest/mutations'
+import { GET_CONTESTS } from '@/graphql/contest/queries'
+import { getStatusWithStartEnd } from '@/lib/utils'
+import { useApolloClient, useMutation } from '@apollo/client'
+import { CopyIcon } from 'lucide-react'
+import { toast } from 'sonner'
+import { useDataTable } from '../../_components/table/context'
+import type { DataTableContest } from './ContestTableColumns'
+
+export default function DuplicateContestButton() {
+  const { table } = useDataTable<DataTableContest>()
+
+  return table.getSelectedRowModel().rows.length === 1 ? (
+    <EnabledDuplicateButton
+      contestId={table.getSelectedRowModel().rows[0].original.id}
+      contestStatus={getStatusWithStartEnd(
+        table.getSelectedRowModel().rows[0].original.startTime,
+        table.getSelectedRowModel().rows[0].original.endTime
+      )}
+      onCompleted={() => {
+        table.resetRowSelection()
+      }}
+    />
+  ) : (
+    <DisabledDuplicateButton />
+  )
+}
+
+function DisabledDuplicateButton() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button className="ml-auto" variant="default" size="default" disabled>
+            <CopyIcon className="mr-2 h-4 w-4" />
+            Duplicate
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p> Select only one contest to duplicate</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+function EnabledDuplicateButton({
+  contestId,
+  contestStatus,
+  onCompleted
+}: {
+  contestId: number
+  contestStatus: string
+  onCompleted?: () => void
+}) {
+  const client = useApolloClient()
+  const [duplicateContest] = useMutation(DUPLICATE_CONTEST)
+
+  const duplicateContestById = async () => {
+    const toastId = toast.loading('Duplicating contest...')
+
+    duplicateContest({
+      variables: {
+        groupId: 1,
+        contestId
+      },
+      onCompleted: (data) => {
+        toast.success(
+          `Contest duplicated completed.\n Duplicated contest title: ${data.duplicateContest.contest.title}`,
+          {
+            id: toastId
+          }
+        )
+        onCompleted?.()
+        client.refetchQueries({
+          include: [GET_CONTESTS]
+        })
+      },
+      onError: (error) => {
+        console.log(error)
+      }
+    })
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button className="ml-auto" variant="default" size="default">
+          <CopyIcon className="mr-2 h-4 w-4" />
+          Duplicate
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="border-slate-80 border bg-white">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-xl font-bold text-black">
+            Duplicate {contestStatus === 'ongoing' ? 'Ongoing ' : ''}Contest
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-neutral-500">
+            <p className="font-semibold">Contents That Will Be Copied:</p>
+            <ul className="mb-3 ml-5 list-disc">
+              <li>Title</li>
+              <li>Start Time & End Time</li>
+              <li>Description</li>
+              <li>
+                Contest Security Settings (invitation code, allow copy/paste)
+              </li>
+              <li>Contest Problems</li>
+              <li className="text-red-500">
+                Participants of the selected contest <br />
+                <span className="text-xs">
+                  (All participants of the selected contest will be
+                  automatically registered for the duplicated contest.)
+                </span>
+              </li>
+            </ul>
+            <p className="font-semibold">Contents That Will Not Be Copied:</p>
+            <ul className="mb-3 ml-5 list-disc">
+              <li>Users&apos; Submissions</li>
+            </ul>
+            {contestStatus === 'ongoing' ? (
+              <p className="mb-3 mt-4 text-red-500">
+                Caution: The new contest will be set to visible.
+              </p>
+            ) : (
+              <p className="mb-3 mt-4 text-red-500">
+                Caution: The new contest will be set to invisible
+              </p>
+            )}
+            <p className="mt-4">
+              Are you sure you want to proceed with duplicating the selected
+              contest?
+            </p>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex justify-end gap-2">
+          <AlertDialogCancel className="rounded-md px-4 py-2">
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="rounded-md bg-blue-500 px-4 py-2 text-white"
+            onClick={duplicateContestById}
+          >
+            Duplicate
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
+++ b/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
@@ -93,8 +93,8 @@ function EnabledDuplicateButton({
         })
         table.resetRowSelection()
       },
-      onError: (error) => {
-        console.log(error)
+      onError: () => {
+        toast.error('Failed to duplicate the contest')
       }
     })
   }

--- a/apps/frontend/app/admin/contest/_components/ImportProblemButton.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemButton.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@/components/ui/button'
+import { useDataTable } from '../../_components/table/context'
+import type { ContestProblem } from '../utils'
+import type { DataTableProblem } from './ImportProblemTableColumns'
+
+interface ImportProblemButtonProps {
+  onSelectedExport: (data: ContestProblem[]) => void
+}
+
+export default function ImportProblemButton({
+  onSelectedExport
+}: ImportProblemButtonProps) {
+  const { table } = useDataTable<DataTableProblem>()
+
+  const handleImportProblems = () => {
+    const selectedRows = table
+      .getSelectedRowModel()
+      .rows.map((row) => row.original)
+
+    const problems = selectedRows
+      .map((problem) => ({
+        ...problem,
+        score: problem?.score ?? 0,
+        order: problem?.order ?? Number.MAX_SAFE_INTEGER
+      }))
+      .sort((a, b) => a.order - b.order)
+
+    let order = 0
+    const exportedProblems = problems.map((problem, index, arr) => {
+      if (
+        index > 0 &&
+        // NOTE: 만약 현재 요소가 새로 추가된 문제이거나 새로 추가된 문제가 아니라면 이전 문제와 기존 순서가 다를 때
+        (arr[index].order === Number.MAX_SAFE_INTEGER ||
+          arr[index - 1].order !== arr[index].order)
+      ) {
+        order++
+      }
+      return {
+        ...problem,
+        order
+      }
+    })
+    onSelectedExport(exportedProblems)
+  }
+
+  return (
+    <Button onClick={handleImportProblems} className="ml-auto">
+      Import / Edit
+    </Button>
+  )
+}

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -14,7 +14,6 @@ import ImportProblemButton from './ImportProblemButton'
 import {
   columns,
   DEFAULT_PAGE_SIZE,
-  DEFAULT_SORTING,
   ERROR_MESSAGE,
   MAX_SELECTED_ROW_COUNT
 } from './ImportProblemTableColumns'
@@ -68,7 +67,7 @@ export function ImportProblemTable({
       columns={columns}
       selectedRowIds={selectedProblemIds}
       defaultPageSize={DEFAULT_PAGE_SIZE}
-      defaultSortState={DEFAULT_SORTING}
+      defaultSortState={[{ id: 'select', desc: true }]}
     >
       <div className="flex gap-4">
         <DataTableSearchBar columndId="title" />
@@ -84,7 +83,7 @@ export function ImportProblemTable({
             row.getIsSelected()
           ) {
             row.toggleSelected()
-            table.setSorting(DEFAULT_SORTING) // NOTE: force to trigger sortingFn
+            table.setSorting([{ id: 'select', desc: true }]) // NOTE: force to trigger sortingFn
           } else {
             toast.error(ERROR_MESSAGE)
           }

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@/components/ui/button'
 import { GET_PROBLEMS } from '@/graphql/problem/queries'
 import { useSuspenseQuery } from '@apollo/client'
 import { Language, Level } from '@generated/graphql'
@@ -10,14 +9,14 @@ import DataTableLevelFilter from '../../_components/table/DataTableLevelFilter'
 import DataTablePagination from '../../_components/table/DataTablePagination'
 import DataTableRoot from '../../_components/table/DataTableRoot'
 import DataTableSearchBar from '../../_components/table/DataTableSearchBar'
-import { useDataTable } from '../../_components/table/context'
 import type { ContestProblem } from '../utils'
+import ImportProblemButton from './ImportProblemButton'
 import {
   columns,
   DEFAULT_PAGE_SIZE,
+  DEFAULT_SORTING,
   ERROR_MESSAGE,
-  MAX_SELECTED_ROW_COUNT,
-  type DataTableProblem
+  MAX_SELECTED_ROW_COUNT
 } from './ImportProblemTableColumns'
 
 export function ImportProblemTable({
@@ -69,7 +68,7 @@ export function ImportProblemTable({
       columns={columns}
       selectedRowIds={selectedProblemIds}
       defaultPageSize={DEFAULT_PAGE_SIZE}
-      defaultSortState={[{ id: 'select', desc: true }]}
+      defaultSortState={DEFAULT_SORTING}
     >
       <div className="flex gap-4">
         <DataTableSearchBar columndId="title" />
@@ -85,6 +84,7 @@ export function ImportProblemTable({
             row.getIsSelected()
           ) {
             row.toggleSelected()
+            table.setSorting(DEFAULT_SORTING) // NOTE: force to trigger sortingFn
           } else {
             toast.error(ERROR_MESSAGE)
           }
@@ -92,51 +92,6 @@ export function ImportProblemTable({
       />
       <DataTablePagination showSelection showRowsPerPage={false} />
     </DataTableRoot>
-  )
-}
-
-interface ImportProblemButtonProps {
-  onSelectedExport: (data: ContestProblem[]) => void
-}
-
-function ImportProblemButton({ onSelectedExport }: ImportProblemButtonProps) {
-  const { table } = useDataTable<DataTableProblem>()
-
-  const handleImportProblems = () => {
-    const selectedRows = table
-      .getSelectedRowModel()
-      .rows.map((row) => row.original)
-
-    const problems = selectedRows
-      .map((problem) => ({
-        ...problem,
-        score: problem?.score ?? 0,
-        order: problem?.order ?? Number.MAX_SAFE_INTEGER
-      }))
-      .sort((a, b) => a.order - b.order)
-
-    let order = 0
-    const exportedProblems = problems.map((problem, index, arr) => {
-      if (
-        index > 0 &&
-        // NOTE: 만약 현재 요소가 새로 추가된 문제이거나 새로 추가된 문제가 아니라면 이전 문제와 기존 순서가 다를 때
-        (arr[index].order === Number.MAX_SAFE_INTEGER ||
-          arr[index - 1].order !== arr[index].order)
-      ) {
-        order++
-      }
-      return {
-        ...problem,
-        order
-      }
-    })
-    onSelectedExport(exportedProblems)
-  }
-
-  return (
-    <Button onClick={handleImportProblems} className="ml-auto">
-      Import / Edit
-    </Button>
   )
 }
 

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
@@ -1,11 +1,11 @@
-import { DataTableColumnHeader } from '@/components/DataTableColumnHeader'
+import DataTableColumnHeader from '@/app/admin/_components/table/DataTableColumnHeader'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import type { Level } from '@/types/type'
 import type { ColumnDef } from '@tanstack/react-table'
 import { toast } from 'sonner'
 
-interface DataTableProblem {
+export interface DataTableProblem {
   id: number
   title: string
   updateTime: string
@@ -14,22 +14,32 @@ interface DataTableProblem {
   acceptedRate: number
   languages: string[]
   score?: number
+  order?: number
 }
 
+export const DEFAULT_PAGE_SIZE = 5
+export const MAX_SELECTED_ROW_COUNT = 20
+export const ERROR_MESSAGE = `You can only import up to ${MAX_SELECTED_ROW_COUNT} problems in a contest`
 export const columns: ColumnDef<DataTableProblem>[] = [
   {
     accessorKey: 'select',
     header: ({ table }) => (
       <Checkbox
         checked={table.getIsAllPageRowsSelected()}
-        onCheckedChange={(value) => {
-          const currentPageRows = table.getRowModel().rows
-          const currentSelectedCount = currentPageRows.filter((row) =>
-            row.getIsSelected()
-          ).length
-          table.getSelectedRowModel().rows.length - currentSelectedCount > 15
-            ? toast.error('You can only import up to 20 problems in a contest')
-            : table.toggleAllPageRowsSelected(!!value)
+        onCheckedChange={() => {
+          const currentPageNotSelectedCount = table
+            .getRowModel()
+            .rows.filter((row) => !row.getIsSelected()).length
+          const selectedRowCount = table.getSelectedRowModel().rows.length
+
+          if (
+            selectedRowCount + currentPageNotSelectedCount <=
+            MAX_SELECTED_ROW_COUNT
+          ) {
+            table.toggleAllPageRowsSelected()
+          } else {
+            toast.error(ERROR_MESSAGE)
+          }
         }}
         aria-label="Select all"
         className="translate-y-[2px]"

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
@@ -18,7 +18,6 @@ export interface DataTableProblem {
 }
 
 export const DEFAULT_PAGE_SIZE = 5
-export const DEFAULT_SORTING = [{ id: 'select', desc: true }]
 export const MAX_SELECTED_ROW_COUNT = 20
 export const ERROR_MESSAGE = `You can only import up to ${MAX_SELECTED_ROW_COUNT} problems in a contest`
 export const columns: ColumnDef<DataTableProblem>[] = [
@@ -38,7 +37,7 @@ export const columns: ColumnDef<DataTableProblem>[] = [
             MAX_SELECTED_ROW_COUNT
           ) {
             table.toggleAllPageRowsSelected()
-            table.setSorting(DEFAULT_SORTING) // NOTE: force to trigger sortingFn
+            table.setSorting([{ id: 'select', desc: true }]) // NOTE: force to trigger sortingFn
           } else {
             toast.error(ERROR_MESSAGE)
           }

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTableColumns.tsx
@@ -18,6 +18,7 @@ export interface DataTableProblem {
 }
 
 export const DEFAULT_PAGE_SIZE = 5
+export const DEFAULT_SORTING = [{ id: 'select', desc: true }]
 export const MAX_SELECTED_ROW_COUNT = 20
 export const ERROR_MESSAGE = `You can only import up to ${MAX_SELECTED_ROW_COUNT} problems in a contest`
 export const columns: ColumnDef<DataTableProblem>[] = [
@@ -37,6 +38,7 @@ export const columns: ColumnDef<DataTableProblem>[] = [
             MAX_SELECTED_ROW_COUNT
           ) {
             table.toggleAllPageRowsSelected()
+            table.setSorting(DEFAULT_SORTING) // NOTE: force to trigger sortingFn
           } else {
             toast.error(ERROR_MESSAGE)
           }

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { DataTableAdmin } from '@/components/DataTableAdmin'
 import {
   AlertDialog,
   AlertDialogTrigger,
@@ -31,7 +30,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { PlusCircleIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useState, useRef } from 'react'
+import { useState, useRef, Suspense } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { FaAngleLeft } from 'react-icons/fa6'
 import { IoMdCheckmarkCircleOutline } from 'react-icons/io'
@@ -41,9 +40,12 @@ import DescriptionForm from '../../_components/DescriptionForm'
 import FormSection from '../../_components/FormSection'
 import SwitchField from '../../_components/SwitchField'
 import TitleForm from '../../_components/TitleForm'
-import { columns } from '../[id]/_components/Columns'
 import ContestProblemListLabel from '../_components/ContestProblemListLabel'
-import ImportProblemTable from '../_components/ImportProblemTable'
+import ContestProblemTable from '../_components/ContestProblemTable'
+import {
+  ImportProblemTable,
+  ImportProblemTableFallback
+} from '../_components/ImportProblemTable'
 import TimeForm from '../_components/TimeForm'
 import { type ContestProblem, createSchema } from '../utils'
 
@@ -230,22 +232,22 @@ export default function Page() {
                     <DialogHeader>
                       <DialogTitle>Import Problem</DialogTitle>
                     </DialogHeader>
-                    <ImportProblemTable
-                      checkedProblems={problems as ContestProblem[]}
-                      onSelectedExport={(problems) =>
-                        setProblems(problems as ContestProblem[])
-                      }
-                      onCloseDialog={() => setShowImportDialog(false)}
-                    />
+                    <Suspense fallback={<ImportProblemTableFallback />}>
+                      <ImportProblemTable
+                        checkedProblems={problems}
+                        onSelectedExport={(problems) => {
+                          setProblems(problems)
+                          setShowImportDialog(false)
+                        }}
+                      />
+                    </Suspense>
                   </DialogContent>
                 </Dialog>
               </div>
-              <DataTableAdmin
-                columns={columns(problems, setProblems, false)}
-                data={problems as ContestProblem[]}
-                defaultSortColumn={{ id: 'order', desc: false }}
-                enableFooter={true}
-                defaultPageSize={20}
+              <ContestProblemTable
+                problems={problems}
+                setProblems={setProblems}
+                disableInput={false}
               />
             </div>
             <Button

--- a/apps/frontend/app/admin/contest/page.tsx
+++ b/apps/frontend/app/admin/contest/page.tsx
@@ -1,78 +1,29 @@
-'use client'
-
-import { DataTableAdmin } from '@/components/DataTableAdmin'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
-import { Skeleton } from '@/components/ui/skeleton'
-import { GET_CONTESTS } from '@/graphql/contest/queries'
-import { useQuery } from '@apollo/client'
 import { PlusCircleIcon } from 'lucide-react'
 import Link from 'next/link'
-import { columns } from './_components/Columns'
+import { Suspense } from 'react'
+import { ContestTable, ContestTableFallback } from './_components/ContestTable'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page() {
-  const { data, loading } = useQuery(GET_CONTESTS, {
-    variables: {
-      groupId: 1,
-      take: 300
-    }
-  })
-
-  const contests =
-    data?.getContests.map((contest) => ({
-      ...contest,
-      id: Number(contest.id)
-    })) || []
-
   return (
-    <ScrollArea className="shrink-0">
-      <div className="container mx-auto space-y-5 py-10">
-        <div className="flex justify-between">
-          <div>
-            <p className="text-4xl font-bold">Contest List</p>
-            <p className="text-lg text-slate-500">
-              Here&apos;s a list you made
-            </p>
-          </div>
-          <Button variant="default" asChild>
-            <Link href="/admin/contest/create">
-              <PlusCircleIcon className="mr-2 h-4 w-4" />
-              Create
-            </Link>
-          </Button>
+    <div className="container mx-auto space-y-5 py-10">
+      <div className="flex justify-between">
+        <div>
+          <p className="text-4xl font-bold">Contest List</p>
+          <p className="text-lg text-slate-500">Here&apos;s a list you made</p>
         </div>
-        {loading ? (
-          <>
-            <div className="mb-16 flex gap-4">
-              <span className="w-2/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-            </div>
-            {[...Array(8)].map((_, i) => (
-              <Skeleton key={i} className="my-2 flex h-12 w-full rounded-xl" />
-            ))}
-          </>
-        ) : (
-          <DataTableAdmin
-            columns={columns}
-            data={contests}
-            enableSearch={true}
-            enableDelete={true}
-            enablePagination={true}
-            headerStyle={{
-              select: '',
-              title: 'w-3/5',
-              startTime: 'px-0 w-1/5',
-              participants: 'px-0 w-1/12',
-              isVisible: 'px-0 w-1/12'
-            }}
-            enableDuplicate={true}
-            defaultSortColumn={{ id: 'startTime', desc: true }}
-          />
-        )}
+        <Button variant="default" asChild>
+          <Link href="/admin/contest/create">
+            <PlusCircleIcon className="mr-2 h-4 w-4" />
+            Create
+          </Link>
+        </Button>
       </div>
-    </ScrollArea>
+      <Suspense fallback={<ContestTableFallback />}>
+        <ContestTable />
+      </Suspense>
+    </div>
   )
 }

--- a/apps/frontend/app/admin/layout.tsx
+++ b/apps/frontend/app/admin/layout.tsx
@@ -32,8 +32,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           </Link> */}
         </nav>
         <Separator orientation="vertical" />
-
-        <div className="relative w-full overflow-y-auto">{children}</div>
+        {/*NOTE: full width - sidebar width */}
+        <div className="relative w-[calc(100%-15rem)] overflow-y-auto">
+          {children}
+        </div>
       </div>
     </ClientApolloProvider>
   )

--- a/apps/frontend/app/admin/problem/_components/ContainedContests.tsx
+++ b/apps/frontend/app/admin/problem/_components/ContainedContests.tsx
@@ -4,14 +4,16 @@ import {
   DialogContent,
   DialogHeader
 } from '@/components/ui/dialog'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger
 } from '@/components/ui/tooltip'
+import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
 import FileInfoIcon from '@/public/24_compile.svg'
-import type { GetContestsByProblemIdQuery } from '@generated/graphql'
+import { useQuery } from '@apollo/client'
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import Image from 'next/image'
 import { useState } from 'react'
@@ -38,20 +40,31 @@ function ContestSection({
 }
 
 export default function ContainedContests({
-  data
+  problemId
 }: {
-  data: GetContestsByProblemIdQuery
+  problemId: number
 }) {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false)
-  const contestData = data.getContestsByProblemId
+  const { data, loading } = useQuery(GET_BELONGED_CONTESTS, {
+    variables: {
+      problemId
+    }
+  })
 
-  return (
+  const contestData = data?.getContestsByProblemId
+
+  if (loading) {
+    return <Skeleton className="size-[25px]" />
+  }
+
+  return contestData ? (
     <Dialog onOpenChange={() => setIsTooltipOpen(false)}>
       <TooltipProvider>
         <Tooltip>
           <DialogTrigger asChild>
             <TooltipTrigger asChild>
               <button
+                type="button"
                 className="justify-centert flex items-center"
                 onClick={(e) => {
                   e.stopPropagation()
@@ -75,10 +88,7 @@ export default function ContainedContests({
         </Tooltip>
       </TooltipProvider>
       <div onClick={(e) => e.stopPropagation()}>
-        <DialogContent
-          className="sm:max-w-[425px]"
-          onClick={(e) => e.stopPropagation()}
-        >
+        <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <p className="text-lg font-semibold">
               Contests which include this problem
@@ -99,5 +109,5 @@ export default function ContainedContests({
         </DialogContent>
       </div>
     </Dialog>
-  )
+  ) : null
 }

--- a/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
@@ -1,0 +1,124 @@
+import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
+import { DELETE_PROBLEM } from '@/graphql/problem/mutations'
+import { GET_PROBLEMS } from '@/graphql/problem/queries'
+import {
+  useApolloClient,
+  useLazyQuery,
+  useMutation,
+  useSuspenseQuery
+} from '@apollo/client'
+import { Language, Level } from '@generated/graphql'
+import { toast } from 'sonner'
+import DataTable from '../../_components/table/DataTable'
+import DataTableDeleteButton from '../../_components/table/DataTableDeleteButton'
+import DataTableFallback from '../../_components/table/DataTableFallback'
+import DataTableLangFilter from '../../_components/table/DataTableLangFilter'
+import DataTableLevelFilter from '../../_components/table/DataTableLevelFilter'
+import DataTablePagination from '../../_components/table/DataTablePagination'
+import DataTableRoot from '../../_components/table/DataTableRoot'
+import DataTableSearchBar from '../../_components/table/DataTableSearchBar'
+import { columns, type DataTableProblem } from './ProblemTableColumns'
+
+export function ProblemTable() {
+  const { data } = useSuspenseQuery(GET_PROBLEMS, {
+    variables: {
+      groupId: 1,
+      take: 500,
+      input: {
+        difficulty: [
+          Level.Level1,
+          Level.Level2,
+          Level.Level3,
+          Level.Level4,
+          Level.Level5
+        ],
+        languages: [Language.C, Language.Cpp, Language.Java, Language.Python3]
+      }
+    }
+  })
+
+  const problems = data.getProblems.map((problem) => ({
+    ...problem,
+    id: Number(problem.id),
+    isVisible: problem.isVisible !== undefined ? problem.isVisible : null,
+    languages: problem.languages ?? [],
+    tag: problem.tag.map(({ id, tag }) => ({
+      id: +id,
+      tag: {
+        ...tag,
+        id: Number(tag.id)
+      }
+    }))
+  }))
+
+  return (
+    <DataTableRoot
+      data={problems}
+      columns={columns}
+      defaultSortState={[{ id: 'updateTime', desc: true }]}
+    >
+      <div className="flex gap-4">
+        <DataTableSearchBar columndId="title" />
+        <DataTableLangFilter />
+        <DataTableLevelFilter />
+        <ProblemsDeleteButton />
+      </div>
+      <DataTable getHref={(data) => `/admin/problem/${data.id}`} />
+      <DataTablePagination showSelection />
+    </DataTableRoot>
+  )
+}
+
+function ProblemsDeleteButton() {
+  const client = useApolloClient()
+  const [deleteProblem] = useMutation(DELETE_PROBLEM)
+  const [fetchContests] = useLazyQuery(GET_BELONGED_CONTESTS)
+
+  const getCanDelete = async (data: DataTableProblem[]) => {
+    const promises = data.map((item) =>
+      fetchContests({
+        variables: {
+          problemId: Number(item.id)
+        }
+      })
+    )
+    const results = await Promise.all(promises)
+    const isAllSafe = results.every(({ data }) => data === undefined)
+
+    if (isAllSafe) {
+      return true
+    }
+
+    toast.error('Failed: Problem included in the contest')
+    return false
+  }
+
+  const deleteTarget = (id: number) => {
+    return deleteProblem({
+      variables: {
+        groupId: 1,
+        id
+      }
+    })
+  }
+
+  const onSuccess = () => {
+    client.refetchQueries({
+      include: [GET_PROBLEMS]
+    })
+  }
+
+  return (
+    <DataTableDeleteButton
+      target="problem"
+      getCanDelete={getCanDelete}
+      deleteTarget={deleteTarget}
+      onSuccess={onSuccess}
+      className="ml-auto"
+    />
+  )
+}
+
+export function ProblemTableFallback() {
+  return <DataTableFallback columns={columns} />
+}

--- a/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
@@ -1,23 +1,15 @@
-import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
-import { DELETE_PROBLEM } from '@/graphql/problem/mutations'
 import { GET_PROBLEMS } from '@/graphql/problem/queries'
-import {
-  useApolloClient,
-  useLazyQuery,
-  useMutation,
-  useSuspenseQuery
-} from '@apollo/client'
+import { useSuspenseQuery } from '@apollo/client'
 import { Language, Level } from '@generated/graphql'
-import { toast } from 'sonner'
 import DataTable from '../../_components/table/DataTable'
-import DataTableDeleteButton from '../../_components/table/DataTableDeleteButton'
 import DataTableFallback from '../../_components/table/DataTableFallback'
 import DataTableLangFilter from '../../_components/table/DataTableLangFilter'
 import DataTableLevelFilter from '../../_components/table/DataTableLevelFilter'
 import DataTablePagination from '../../_components/table/DataTablePagination'
 import DataTableRoot from '../../_components/table/DataTableRoot'
 import DataTableSearchBar from '../../_components/table/DataTableSearchBar'
-import { columns, type DataTableProblem } from './ProblemTableColumns'
+import { columns } from './ProblemTableColumns'
+import ProblemsDeleteButton from './ProblemsDeleteButton'
 
 export function ProblemTable() {
   const { data } = useSuspenseQuery(GET_PROBLEMS, {
@@ -66,56 +58,6 @@ export function ProblemTable() {
       <DataTable getHref={(data) => `/admin/problem/${data.id}`} />
       <DataTablePagination showSelection />
     </DataTableRoot>
-  )
-}
-
-function ProblemsDeleteButton() {
-  const client = useApolloClient()
-  const [deleteProblem] = useMutation(DELETE_PROBLEM)
-  const [fetchContests] = useLazyQuery(GET_BELONGED_CONTESTS)
-
-  const getCanDelete = async (data: DataTableProblem[]) => {
-    const promises = data.map((item) =>
-      fetchContests({
-        variables: {
-          problemId: Number(item.id)
-        }
-      })
-    )
-    const results = await Promise.all(promises)
-    const isAllSafe = results.every(({ data }) => data === undefined)
-
-    if (isAllSafe) {
-      return true
-    }
-
-    toast.error('Failed: Problem included in the contest')
-    return false
-  }
-
-  const deleteTarget = (id: number) => {
-    return deleteProblem({
-      variables: {
-        groupId: 1,
-        id
-      }
-    })
-  }
-
-  const onSuccess = () => {
-    client.refetchQueries({
-      include: [GET_PROBLEMS]
-    })
-  }
-
-  return (
-    <DataTableDeleteButton
-      target="problem"
-      getCanDelete={getCanDelete}
-      deleteTarget={deleteTarget}
-      onSuccess={onSuccess}
-      className="ml-auto"
-    />
   )
 }
 

--- a/apps/frontend/app/admin/problem/_components/ProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemTableColumns.tsx
@@ -1,11 +1,10 @@
-import { DataTableColumnHeader } from '@/components/DataTableColumnHeader'
+import DataTableColumnHeader from '@/app/admin/_components/table/DataTableColumnHeader'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
-import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
 import { UPDATE_PROBLEM_VISIBLE } from '@/graphql/problem/mutations'
 import type { Level } from '@/types/type'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation } from '@apollo/client'
 import type { ColumnDef, Row } from '@tanstack/react-table'
 import ContainedContests from './ContainedContests'
 
@@ -14,7 +13,7 @@ interface Tag {
   name: string
 }
 
-interface DataTableProblem {
+export interface DataTableProblem {
   id: number
   title: string
   updateTime: string
@@ -28,11 +27,7 @@ interface DataTableProblem {
 
 function VisibleCell({ row }: { row: Row<DataTableProblem> }) {
   const [updateVisible] = useMutation(UPDATE_PROBLEM_VISIBLE)
-  const contestData = useQuery(GET_BELONGED_CONTESTS, {
-    variables: {
-      problemId: Number(row.original.id)
-    }
-  }).data
+
   return (
     <div className="ml-8 flex items-center space-x-2">
       <Switch
@@ -53,7 +48,7 @@ function VisibleCell({ row }: { row: Row<DataTableProblem> }) {
           })
         }}
       />
-      {contestData && <ContainedContests data={contestData} />}
+      <ContainedContests problemId={row.original.id} />
     </div>
   )
 }

--- a/apps/frontend/app/admin/problem/_components/ProblemsDeleteButton.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemsDeleteButton.tsx
@@ -1,0 +1,58 @@
+import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
+import { DELETE_PROBLEM } from '@/graphql/problem/mutations'
+import { GET_PROBLEMS } from '@/graphql/problem/queries'
+import { useApolloClient, useLazyQuery, useMutation } from '@apollo/client'
+import { toast } from 'sonner'
+import DataTableDeleteButton from '../../_components/table/DataTableDeleteButton'
+import type { DataTableProblem } from './ProblemTableColumns'
+
+export default function ProblemsDeleteButton() {
+  const client = useApolloClient()
+  const [deleteProblem] = useMutation(DELETE_PROBLEM)
+  const [fetchContests] = useLazyQuery(GET_BELONGED_CONTESTS)
+
+  const getCanDelete = async (data: DataTableProblem[]) => {
+    const promises = data.map((item) =>
+      fetchContests({
+        variables: {
+          problemId: Number(item.id)
+        }
+      })
+    )
+
+    const results = await Promise.all(promises)
+    const isAllSafe = results.every(({ data }) => data === undefined)
+
+    if (isAllSafe) {
+      return true
+    }
+
+    toast.error('Failed: Problem included in the contest')
+    return false
+  }
+
+  const deleteTarget = (id: number) => {
+    return deleteProblem({
+      variables: {
+        groupId: 1,
+        id
+      }
+    })
+  }
+
+  const onSuccess = () => {
+    client.refetchQueries({
+      include: [GET_PROBLEMS]
+    })
+  }
+
+  return (
+    <DataTableDeleteButton
+      target="problem"
+      getCanDelete={getCanDelete}
+      deleteTarget={deleteTarget}
+      onSuccess={onSuccess}
+      className="ml-auto"
+    />
+  )
+}

--- a/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
+++ b/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
@@ -6,7 +6,8 @@ import {
   DialogTrigger
 } from '@/components/ui/dialog'
 import { UPLOAD_PROBLEMS } from '@/graphql/problem/mutations'
-import { useMutation } from '@apollo/client'
+import { GET_PROBLEMS } from '@/graphql/problem/queries'
+import { useApolloClient, useMutation } from '@apollo/client'
 import { UploadIcon, UploadCloudIcon } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -14,11 +15,8 @@ import { RiFileExcel2Fill } from 'react-icons/ri'
 import { useDrop } from 'react-use'
 import { toast } from 'sonner'
 
-interface Props {
-  refetch: () => Promise<unknown>
-}
-
-export default function UploadDialog({ refetch }: Props) {
+export default function UploadDialog() {
+  const client = useApolloClient()
   const [file, setFile] = useState<File | null>(null)
   const fileRef = useRef<HTMLInputElement | null>(null)
 
@@ -62,14 +60,15 @@ export default function UploadDialog({ refetch }: Props) {
           }
         }
       })
+      toast.success('File uploaded successfully')
+      document.getElementById('closeDialog')?.click()
+      resetFile()
+      client.refetchQueries({
+        include: [GET_PROBLEMS]
+      })
     } catch (error) {
       toast.error('Failed to upload file')
-      return
     }
-    toast.success('File uploaded successfully')
-    document.getElementById('closeDialog')?.click()
-    resetFile()
-    await refetch()
   }
 
   return (

--- a/apps/frontend/app/admin/problem/page.tsx
+++ b/apps/frontend/app/admin/problem/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { DataTableAdmin } from '@/components/DataTableAdmin'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,15 +10,10 @@ import {
   DialogTitle,
   DialogClose
 } from '@/components/ui/dialog'
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
-import { Skeleton } from '@/components/ui/skeleton'
-import { GET_PROBLEMS } from '@/graphql/problem/queries'
-import { useQuery } from '@apollo/client'
-import { Language, Level } from '@generated/graphql'
 import { PlusCircleIcon } from 'lucide-react'
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
-import { columns } from './_components/Columns'
+import { useState, useEffect, Suspense } from 'react'
+import { ProblemTable, ProblemTableFallback } from './_components/ProblemTable'
 import UploadDialog from './_components/UploadDialog'
 
 export default function Page({
@@ -36,40 +30,33 @@ export default function Page({
   }, [searchParams.import])
 
   const importProblem = searchParams.import
-  const { data, loading, refetch } = useQuery(GET_PROBLEMS, {
-    variables: {
-      groupId: 1,
-      take: 500,
-      input: {
-        difficulty: [
-          Level.Level1,
-          Level.Level2,
-          Level.Level3,
-          Level.Level4,
-          Level.Level5
-        ],
-        languages: [Language.C, Language.Cpp, Language.Java, Language.Python3]
-      }
-    }
-  })
-
-  const problems =
-    data?.getProblems.map((problem) => ({
-      ...problem,
-      id: Number(problem.id),
-      isVisible: problem.isVisible !== undefined ? problem.isVisible : null,
-      languages: problem.languages ?? [],
-      tag: problem.tag.map(({ id, tag }) => ({
-        id: +id,
-        tag: {
-          ...tag,
-          id: +tag.id
-        }
-      }))
-    })) ?? []
 
   return (
-    <ScrollArea className="shrink-0">
+    <>
+      <div className="container mx-auto space-y-5 py-10">
+        <div className="flex justify-between">
+          <div>
+            <p className="text-4xl font-bold">Problem List</p>
+            <p className="flex text-lg text-slate-500">
+              Here&apos;s a list you made
+            </p>
+          </div>
+          {importProblem ? null : (
+            <div className="flex gap-2">
+              <UploadDialog />
+              <Link href="/admin/problem/create">
+                <Button variant="default">
+                  <PlusCircleIcon className="mr-2 h-4 w-4" />
+                  Create
+                </Button>
+              </Link>
+            </div>
+          )}
+        </div>
+        <Suspense fallback={<ProblemTableFallback />}>
+          <ProblemTable />
+        </Suspense>
+      </div>
       <Dialog open={openDialog} onOpenChange={setOpenDialog}>
         <DialogContent className="p-8">
           <DialogHeader className="gap-2">
@@ -88,56 +75,6 @@ export default function Page({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div className="container mx-auto space-y-5 py-10">
-        <div className="flex justify-between">
-          <div>
-            <p className="text-4xl font-bold">Problem List</p>
-            <p className="flex text-lg text-slate-500">
-              Here&apos;s a list you made
-            </p>
-          </div>
-          {importProblem ? null : (
-            <div className="flex gap-2">
-              <UploadDialog refetch={refetch} />
-              <Link href="/admin/problem/create">
-                <Button variant="default">
-                  <PlusCircleIcon className="mr-2 h-4 w-4" />
-                  Create
-                </Button>
-              </Link>
-            </div>
-          )}
-        </div>
-        {loading ? (
-          <>
-            <div className="mb-16 flex gap-4">
-              <span className="w-2/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-              <span className="w-1/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-              <span className="w-1/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-            </div>
-            {[...Array(10)].map((_, i) => (
-              <Skeleton key={i} className="my-2 flex h-12 w-full rounded-xl" />
-            ))}
-          </>
-        ) : (
-          <DataTableAdmin
-            columns={columns}
-            data={problems}
-            enableSearch={true}
-            enableFilter={true}
-            enableDelete={true}
-            enablePagination={true}
-            defaultSortColumn={{ id: 'updateTime', desc: true }}
-          />
-        )}
-      </div>
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+    </>
   )
 }

--- a/apps/frontend/app/admin/user/_components/Columns.tsx
+++ b/apps/frontend/app/admin/user/_components/Columns.tsx
@@ -1,6 +1,7 @@
 import type { ColumnDef } from '@tanstack/react-table'
 
 interface DataTableUser {
+  id: number
   username: string
   userId: number
   name: string

--- a/apps/frontend/app/admin/user/_components/UserTable.tsx
+++ b/apps/frontend/app/admin/user/_components/UserTable.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { GET_GROUP_MEMBERS } from '@/graphql/user/queries'
+import { useSuspenseQuery } from '@apollo/client'
+import DataTable from '../../_components/table/DataTable'
+import DataTableFallback from '../../_components/table/DataTableFallback'
+import DataTablePagination from '../../_components/table/DataTablePagination'
+import DataTableRoot from '../../_components/table/DataTableRoot'
+import { columns } from './Columns'
+
+export function UserTable() {
+  const { data } = useSuspenseQuery(GET_GROUP_MEMBERS, {
+    variables: {
+      groupId: 1,
+      cursor: 1,
+      take: 1000,
+      leaderOnly: false
+    }
+  })
+  const users = data.getGroupMembers.map((member) => ({
+    ...member,
+    id: member.userId
+  }))
+
+  return (
+    <DataTableRoot data={users} columns={columns}>
+      <DataTable />
+      <DataTablePagination />
+    </DataTableRoot>
+  )
+}
+
+export function UserTableFallback() {
+  return <DataTableFallback withSearchBar={false} columns={columns} />
+}

--- a/apps/frontend/app/admin/user/page.tsx
+++ b/apps/frontend/app/admin/user/page.tsx
@@ -1,63 +1,17 @@
-'use client'
+import { Suspense } from 'react'
+import { UserTable, UserTableFallback } from './_components/UserTable'
 
-import { DataTableAdmin } from '@/components/DataTableAdmin'
-import { ScrollBar } from '@/components/ui/scroll-area'
-import { Skeleton } from '@/components/ui/skeleton'
-import { GET_GROUP_MEMBERS } from '@/graphql/user/queries'
-import { useQuery } from '@apollo/client'
-import { ScrollArea } from '@radix-ui/react-scroll-area'
-import { columns } from './_components/Columns'
+export const dynamic = 'force-dynamic'
 
 export default function User() {
-  const { data, loading } = useQuery(GET_GROUP_MEMBERS, {
-    variables: {
-      groupId: 1,
-      cursor: 1,
-      take: 1000,
-      leaderOnly: false
-    }
-  })
   return (
-    <ScrollArea className="shrink-0">
-      <div className="container mx-auto space-y-5 py-10">
-        <div className="flex justify-between">
-          <h1 className="text-4xl font-bold">User List</h1>
-        </div>
-        {loading ? (
-          <>
-            <div className="mb-16 flex gap-4">
-              <span className="w-2/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-              <span className="w-1/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-              <span className="w-1/12">
-                <Skeleton className="h-10 w-full" />
-              </span>
-            </div>
-            {[...Array(10)].map((_, i) => (
-              <Skeleton key={i} className="my-2 flex h-12 w-full rounded-xl" />
-            ))}
-          </>
-        ) : (
-          <DataTableAdmin
-            columns={columns}
-            data={
-              data?.getGroupMembers.map((member) => {
-                return {
-                  username: member.username,
-                  userId: member.userId,
-                  name: member.name,
-                  email: member.email
-                }
-              }) ?? []
-            }
-            enablePagination
-          />
-        )}
+    <div className="container mx-auto space-y-5 py-10">
+      <div className="flex justify-between">
+        <h1 className="text-4xl font-bold">User List</h1>
       </div>
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+      <Suspense fallback={<UserTableFallback />}>
+        <UserTable />
+      </Suspense>
+    </div>
   )
 }


### PR DESCRIPTION
### Description

아래 컴포넌트들 리팩토링했습니다. 아래 순서대로 보시는게 리뷰하기 편할거예요!
- User table (`/admin/user`)
- Contest table (`/admin/contest`)
- Problem table (`/admin/problem`)
- Import problem table (`/admin/contest/create`, `/admin/contest/edit`)
- Contest problem table (`/admin/contest/create`, `/admin/contest/edit`)

자잘한 픽스들
- 어드민 페이지 레이아웃 픽스
- 필터 적용 시 페이지 인덱스 초기화 안되는 거 수정 (기존 data table admin에서도 안됐음)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
