### PR TITLE
fix(be): update redis test key for race condition

### DIFF
--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -78,6 +78,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
   async handleRunMessage(msg: JudgerResponse, userId: number): Promise<void> {
     const status = Status(msg.resultCode)
     const testcaseId = msg.judgeResult?.testcaseId
+    const output = this.parseError(msg, status)
     if (!testcaseId) {
       const key = userTestcasesKey(userId)
       const testcaseIds = (await this.cacheManager.get<number[]>(key)) ?? []
@@ -85,7 +86,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       for (const testcaseId of testcaseIds) {
         await this.cacheManager.set(
           testKey(userId, testcaseId),
-          { id: testcaseId, result: status },
+          { id: testcaseId, result: status, output },
           TEST_SUBMISSION_EXPIRE_TIME
         )
       }
@@ -93,8 +94,6 @@ export class SubmissionSubscriptionService implements OnModuleInit {
     }
 
     const key = testKey(userId, testcaseId)
-    const output = this.parseError(msg, status)
-
     const testcase = await this.cacheManager.get<{
       id: number
       result: ResultStatus

--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -78,14 +78,14 @@ export class SubmissionSubscriptionService implements OnModuleInit {
   async handleRunMessage(msg: JudgerResponse, userId: number): Promise<void> {
     const status = Status(msg.resultCode)
     const testcaseId = msg.judgeResult?.testcaseId
-    if (testcaseId === undefined) {
+    if (!testcaseId) {
       const key = userTestcasesKey(userId)
       const testcaseIds = (await this.cacheManager.get<number[]>(key)) ?? []
 
       for (const testcaseId of testcaseIds) {
         await this.cacheManager.set(
           testKey(userId, testcaseId),
-          { id: testcaseId, result: 'CompileError' },
+          { id: testcaseId, result: status },
           TEST_SUBMISSION_EXPIRE_TIME
         )
       }

--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -10,7 +10,7 @@ import type { Cache } from 'cache-manager'
 import { plainToInstance } from 'class-transformer'
 import { validateOrReject, ValidationError } from 'class-validator'
 import { Span } from 'nestjs-otel'
-import { testKey } from '@libs/cache'
+import { testKey, userTestcasesKey } from '@libs/cache'
 import {
   CONSUME_CHANNEL,
   EXCHANGE,
@@ -76,28 +76,37 @@ export class SubmissionSubscriptionService implements OnModuleInit {
   }
 
   async handleRunMessage(msg: JudgerResponse, userId: number): Promise<void> {
-    const key = testKey(userId)
     const status = Status(msg.resultCode)
     const testcaseId = msg.judgeResult?.testcaseId
+    if (testcaseId === undefined) {
+      const key = userTestcasesKey(userId)
+      const testcaseIds = (await this.cacheManager.get<number[]>(key)) ?? []
+
+      for (const testcaseId of testcaseIds) {
+        await this.cacheManager.set(
+          testKey(userId, testcaseId),
+          { id: testcaseId, result: 'CompileError' },
+          TEST_SUBMISSION_EXPIRE_TIME
+        )
+      }
+      return
+    }
+
+    const key = testKey(userId, testcaseId)
     const output = this.parseError(msg, status)
 
-    const testcases =
-      (await this.cacheManager.get<
-        {
-          id: number
-          result: ResultStatus
-          output?: string
-        }[]
-      >(key)) ?? []
+    const testcase = await this.cacheManager.get<{
+      id: number
+      result: ResultStatus
+      output?: string
+    }>(key)
+    if (testcase) {
+      testcase.id = testcaseId
+      testcase.result = status
+      testcase.output = output
+    }
 
-    testcases.forEach((tc) => {
-      if (!testcaseId || tc.id === testcaseId) {
-        tc.result = status
-        tc.output = output
-      }
-    })
-
-    await this.cacheManager.set(key, testcases, TEST_SUBMISSION_EXPIRE_TIME)
+    await this.cacheManager.set(key, testcase, TEST_SUBMISSION_EXPIRE_TIME)
   }
 
   parseError(msg: JudgerResponse, status: ResultStatus): string {

--- a/apps/backend/libs/cache/src/keys.ts
+++ b/apps/backend/libs/cache/src/keys.ts
@@ -9,4 +9,6 @@ export const joinGroupCacheKey = (groupId: number) => `group:${groupId}`
 export const invitationCodeKey = (code: string) => `invite:${code}`
 export const invitationGroupKey = (groupId: number) => `invite:to:${groupId}`
 
-export const testKey = (userId: number) => `test:user:${userId}`
+export const testKey = (userId: number, testcaseId: number) =>
+  `test:user:${userId}:testcase:${testcaseId}`
+export const userTestcasesKey = (userId: number) => `test:user:${userId}`


### PR DESCRIPTION
### Description

Closes TAS-1008

기존 Test API 에서 각 테스트 케이스 결과를 반환하는 Redis key 가 unique 하지 않음을 발견했습니다. 이 때문에 API 서버 확장 시 공유 자원에 대한 경합이 발생하는 문제가 있었습니다. 이를 해결하기 위해 Redis key 를 unique 하게 구성하여 각 테스트 케이스 결과가 독립적으로 저장되도록 수정했습니다.

[특이사항]
프론트에서 polling 하고 있는 getTestResult API 는 기존에는 O(1) 의 비용으로 접근하였습니다. 이 PR 이 적용된다면 테스트케이스 개수가 k 일 때, O(k)의 비용이 발생하게 됩니다. 이는 여러 테스트 케이스의 결과를 개별적으로 접근해야 하기 때문입니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
