### PR TITLE
feat(fe): improve editor problems dropdown list ui

### DIFF
--- a/apps/frontend/components/EditorLayout.tsx
+++ b/apps/frontend/components/EditorLayout.tsx
@@ -1,6 +1,7 @@
 import HeaderAuthPanel from '@/components/auth/HeaderAuthPanel'
 import { auth } from '@/lib/auth'
-import { convertToLetter, fetcher, fetcherWithAuth } from '@/lib/utils'
+import { cn, convertToLetter, fetcher, fetcherWithAuth } from '@/lib/utils'
+import checkIcon from '@/public/icons/check-green.svg'
 import codedangLogo from '@/public/logos/codedang-editor.svg'
 import type { Contest, ContestProblem, ProblemDetail } from '@/types/type'
 import type { Route } from 'next'
@@ -82,8 +83,24 @@ export default async function EditorLayout({
                         key={p.id}
                         href={`/contest/${contestId}/problem/${p.id}` as Route}
                       >
-                        <DropdownMenuItem className="text-white hover:cursor-pointer focus:bg-slate-800 focus:text-white">
+                        <DropdownMenuItem
+                          className={cn(
+                            'flex justify-between text-white hover:cursor-pointer focus:bg-slate-800 focus:text-white',
+                            problem.id === p.id &&
+                              'text-primary-light focus:text-primary-light'
+                          )}
+                        >
                           {`${convertToLetter(p.order)}. ${p.title}`}
+                          {p.submissionTime && (
+                            <div className="flex items-center justify-center pl-2">
+                              <Image
+                                src={checkIcon}
+                                alt="check"
+                                width={16}
+                                height={16}
+                              />
+                            </div>
+                          )}
                         </DropdownMenuItem>
                       </Link>
                     ))}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

contest editor의 문제 dropdown list에서 현재 풀고 있는 문제의 글자 색상을 변경하고 submit한 문제들의 오른쪽에 check icon을 표시하도록 개선하였습니다. figma에는 아이콘의 크기가 12px이라고 명시되어 있으나 margin 차이 문제인지 비교했을 때 너무 작아서 일단 제 임의대로 16px로 설정했습니다.

![image](https://github.com/user-attachments/assets/05a1f1fd-f0bb-42a2-8a81-834e6e1769a9)

closes TAS-1014

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
