### PR TITLE
feat(be): make update contest probelm score api

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -380,11 +380,6 @@ export class ContestService {
     if (!contest) {
       throw new EntityNotExistException('contest')
     }
-    if (contest.submission.length) {
-      throw new UnprocessableDataException(
-        'Cannot import problems if submission exists'
-      )
-    }
 
     const contestProblems: ContestProblem[] = []
 
@@ -467,11 +462,6 @@ export class ContestService {
     })
     if (!contest) {
       throw new EntityNotExistException('contest')
-    }
-    if (contest.submission.length) {
-      throw new UnprocessableDataException(
-        'Cannot delete problems if submission exists'
-      )
     }
 
     const contestProblems: ContestProblem[] = []

--- a/apps/backend/apps/admin/src/problem/problem.resolver.ts
+++ b/apps/backend/apps/admin/src/problem/problem.resolver.ts
@@ -26,7 +26,7 @@ import {
 } from '@generated'
 import { Prisma } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
-import { AuthenticatedRequest, UseRolesGuard } from '@libs/auth'
+import { AuthenticatedRequest } from '@libs/auth'
 import { OPEN_SPACE_ID } from '@libs/constants'
 import {
   ConflictFoundException,
@@ -295,31 +295,17 @@ export class ContestProblemResolver {
   }
 
   @Mutation(() => [ContestProblem])
-  @UseRolesGuard()
   async updateContestProblemsScore(
     @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,
     @Args('contestId', { type: () => Int }) contestId: number,
     @Args('problemIdsWithScore', { type: () => [ProblemScoreInput] })
     problemIdsWithScore: ProblemScoreInput[]
   ) {
-    try {
-      return await this.problemService.updateConsteProblemsScore(
-        groupId,
-        contestId,
-        problemIdsWithScore
-      )
-    } catch (error) {
-      if (
-        error instanceof UnprocessableDataException ||
-        error instanceof ForbiddenAccessException
-      ) {
-        throw error.convert2HTTPException()
-      } else if (error.code == 'P2025') {
-        throw new NotFoundException(error.message)
-      }
-      this.logger.error(error)
-      throw new InternalServerErrorException(error.message)
-    }
+    return await this.problemService.updateContestProblemsScore(
+      groupId,
+      contestId,
+      problemIdsWithScore
+    )
   }
 
   @Mutation(() => [ContestProblem])

--- a/apps/backend/apps/admin/src/problem/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.ts
@@ -604,7 +604,7 @@ export class ProblemService {
     return contestProblems
   }
 
-  async updateConsteProblemsScore(
+  async updateContestProblemsScore(
     groupId: number,
     contestId: number,
     problemIdsWithScore: ProblemScoreInput[]

--- a/apps/backend/apps/admin/src/problem/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.ts
@@ -23,6 +23,7 @@ import {
   UnprocessableFileDataException
 } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
+import type { ProblemScoreInput } from '@admin/contest/model/problem-score.input'
 import { StorageService } from '@admin/storage/storage.service'
 import { ImportedProblemHeader } from './model/problem.constants'
 import type {
@@ -601,6 +602,31 @@ export class ProblemService {
       where: { contestId }
     })
     return contestProblems
+  }
+
+  async updateConsteProblemsScore(
+    groupId: number,
+    contestId: number,
+    problemIdsWithScore: ProblemScoreInput[]
+  ): Promise<Partial<ContestProblem>[]> {
+    await this.prisma.contest.findFirstOrThrow({
+      where: { id: contestId, groupId }
+    })
+
+    const queries = problemIdsWithScore.map((record) => {
+      return this.prisma.contestProblem.update({
+        where: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          contestId_problemId: {
+            contestId,
+            problemId: record.problemId
+          }
+        },
+        data: { score: record.score }
+      })
+    })
+
+    return await this.prisma.$transaction(queries)
   }
 
   async updateContestProblemsOrder(

--- a/collection/admin/Problem/Update ContestProblems Scores/Succeed.bru
+++ b/collection/admin/Problem/Update ContestProblems Scores/Succeed.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Succeed
+  type: graphql
+  seq: 1
+}
+
+post {
+  url: {{gqlUrl}}
+  body: graphql
+  auth: none
+}
+
+body:graphql {
+  mutation UpdateContestProblemsScore($groupId: Int!, $contestId: Int!, $problemIdsWithScore: [ProblemScoreInput!]!) {
+    updateContestProblemsScore(groupId: $groupId, contestId: $contestId, problemIdsWithScore: $problemIdsWithScore) {
+      contestId
+      problemId
+      score
+      order
+    }
+  }
+  
+}
+
+body:graphql:vars {
+  {
+    "groupId": 1,
+    "contestId": 1,
+    "problemIdsWithScore": [
+      {
+        "problemId": 1,
+        "score": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description

contest problem을 수정하는 API가 존재하지 않아 이를 수정하는 API 만드는 작업을 하였습니다
order를 수정하는 api는 이미 있고, score말고 수정해야 하는 필드가 없어서 score만 수정하는 방식으로 구현하였습니다.

### Additional context

UseRolesGuard 필요할 것 같아서 일단 적용시켜놨는데 밑에 order같은 경우에는 UseRolesGuard 없어서 이거 관련해서 좀 알려주세요

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
