### PR TITLE
fix(fe): fix json parsing error in the code editor

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -24,7 +24,12 @@ import { auth } from '@/lib/auth'
 import { fetcherWithAuth } from '@/lib/utils'
 import submitIcon from '@/public/icons/submit.svg'
 import useAuthModalStore from '@/stores/authModal'
-import { useLanguageStore, useCodeStore, getKey } from '@/stores/editor'
+import {
+  useLanguageStore,
+  useCodeStore,
+  getStorageKey,
+  getCodeFromLocalStorage
+} from '@/stores/editor'
 import type {
   Language,
   ProblemDetail,
@@ -69,7 +74,9 @@ export default function Editor({
   const router = useRouter()
   const pathname = usePathname()
   const confetti = typeof window !== 'undefined' ? new JSConfetti() : null
-  const storageKey = useRef(getKey(language, problem.id, userName, contestId))
+  const storageKey = useRef(
+    getStorageKey(language, problem.id, userName, contestId)
+  )
   const { currentModal, showSignIn } = useAuthModalStore((state) => state)
   const [showModal, setShowModal] = useState<boolean>(false)
   const pushed = useRef(false)
@@ -126,10 +133,15 @@ export default function Editor({
   }, [language])
 
   useEffect(() => {
-    storageKey.current = getKey(language, problem.id, userName, contestId)
+    storageKey.current = getStorageKey(
+      language,
+      problem.id,
+      userName,
+      contestId
+    )
     if (storageKey.current !== undefined) {
-      const storedCode = localStorage.getItem(storageKey.current)
-      setCode(storedCode ?? templateCode ?? '')
+      const storedCode = getCodeFromLocalStorage(storageKey.current)
+      setCode(storedCode || (templateCode ?? ''))
     }
   }, [userName, problem, contestId, language, templateCode])
 
@@ -208,8 +220,8 @@ export default function Editor({
   const checkSaved = () => {
     const code = getCode()
     if (storageKey.current !== undefined) {
-      const storedCode = localStorage.getItem(storageKey.current) ?? ''
-      if (storedCode && JSON.parse(storedCode) === code) return true
+      const storedCode = getCodeFromLocalStorage(storageKey.current)
+      if (storedCode && storedCode === code) return true
       else if (!storedCode && templateCode === code) return true
       else return false
     }
@@ -224,7 +236,12 @@ export default function Editor({
   }
 
   useEffect(() => {
-    storageKey.current = getKey(language, problem.id, userName, contestId)
+    storageKey.current = getStorageKey(
+      language,
+      problem.id,
+      userName,
+      contestId
+    )
 
     const handlePopState = () => {
       if (!checkSaved()) {

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/AddUserTestcaseDialog.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/AddUserTestcaseDialog.tsx
@@ -87,12 +87,14 @@ export default function AddUserTestcaseDialog() {
                       {...register(`testcases.${index}.input`, {
                         required: true
                       })}
+                      placeholder="Input"
                       className="z-10 resize-none border-0 px-4 py-0 text-black shadow-none placeholder:text-[#3333334D] focus-visible:ring-0"
                     />
                     <Textarea
                       {...register(`testcases.${index}.output`, {
                         required: true
                       })}
+                      placeholder="Output"
                       className="z-10 min-h-[80px] rounded-none border-l border-transparent border-l-gray-200 px-4 py-0 text-black shadow-none placeholder:text-[#3333334D] focus-visible:ring-0"
                     />
                     <button

--- a/apps/frontend/stores/editor.ts
+++ b/apps/frontend/stores/editor.ts
@@ -37,7 +37,7 @@ export const useCodeStore = create<CodeState>((set, get) => ({
   getCode: () => get().code
 }))
 
-export const getKey = (
+export const getStorageKey = (
   language: Language,
   problemId: number,
   userName: string,
@@ -46,4 +46,12 @@ export const getKey = (
   if (userName === '') return undefined
   const problemKey = `${userName}_${problemId}${contestId ? `_${contestId}` : ''}_${language}`
   return problemKey
+}
+
+export const getCodeFromLocalStorage = (key: string) => {
+  const storedCode = localStorage.getItem(key) ?? ''
+  const parsed = storedCode.replaceAll('"', '')
+  localStorage.setItem(key, parsed)
+
+  return parsed
 }

--- a/apps/frontend/stores/editor.ts
+++ b/apps/frontend/stores/editor.ts
@@ -50,8 +50,12 @@ export const getStorageKey = (
 
 export const getCodeFromLocalStorage = (key: string) => {
   const storedCode = localStorage.getItem(key) ?? ''
-  const parsed = storedCode.replaceAll('"', '')
-  localStorage.setItem(key, parsed)
 
-  return parsed
+  try {
+    const parsed = JSON.parse(storedCode)
+    localStorage.setItem(key, parsed)
+    return parsed
+  } catch {
+    return storedCode
+  }
 }


### PR DESCRIPTION
### Description

- 브라우저 뒤로가기 버튼 눌렀을 때 json parsing error 발생하는 거 수정
- 코드 저장 방식 변경됨에 따라 이전에 local storage에 저장된 코드 가져오는 방식 수정

+) user testcase textarea placeholder 추가

### Additional context

기존 코드 저장 방식: `JSON.stringify`, `JSON.parse` 사용 (asdf => "asdf" 이렇게 저장됨)
하지만 code가 문자열인데 애초에 stringify 처리할 필요가 없었고 없앴더니 "asdf" 이렇게 표시됨.
local storage 버저닝보다는 `JSON.parse`를 호출해 코드 저장 방식 바뀌기 전에 저장된 코드인지 확인하여 처리


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
