### PR TITLE
fix(fe): truncate huge size output

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/AddUserTestcaseDialog.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/AddUserTestcaseDialog.tsx
@@ -154,7 +154,7 @@ function SampleTestcaseItem({
   return (
     <div
       className={cn(
-        'flex h-[80px] w-full rounded-md border border-[#313744] bg-[#222939] font-mono shadow-sm'
+        'flex min-h-[80px] w-full rounded-md border border-[#313744] bg-[#222939] font-mono shadow-sm'
       )}
     >
       <div className="relative flex-1">

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -35,13 +35,13 @@ export default function TestcasePanel() {
     }
   }
 
-  const maxOutputLength = 100000
+  const MAX_OUTPUT_LENGTH = 100000
   const testResults = useTestResults()
   const processedData = testResults.map((testcase) => ({
     ...testcase,
     output:
-      testcase.output.length > maxOutputLength
-        ? testcase.output.slice(0, maxOutputLength)
+      testcase.output.length > MAX_OUTPUT_LENGTH
+        ? testcase.output.slice(0, MAX_OUTPUT_LENGTH)
         : testcase.output
   }))
   const summaryData = processedData.map(({ id, result, isUserTestcase }) => ({

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -35,8 +35,16 @@ export default function TestcasePanel() {
     }
   }
 
+  const maxOutputLength = 100000
   const testResults = useTestResults()
-  const summaryData = testResults.map(({ id, result, isUserTestcase }) => ({
+  const processedData = testResults.map((testcase) => ({
+    ...testcase,
+    output:
+      testcase.output.length > maxOutputLength
+        ? testcase.output.slice(0, maxOutputLength)
+        : testcase.output
+  }))
+  const summaryData = processedData.map(({ id, result, isUserTestcase }) => ({
     id,
     result,
     isUserTestcase
@@ -103,13 +111,13 @@ export default function TestcasePanel() {
           <div className="flex flex-col gap-6 p-5 pb-14">
             <TestSummary data={summaryData} />
             <TestcaseTable
-              data={testResults}
+              data={processedData}
               moveToDetailTab={moveToDetailTab}
             />
           </div>
         ) : (
           <TestResultDetail
-            data={testResults.find((item) => item.id === currentTab)}
+            data={processedData.find((item) => item.id === currentTab)}
           />
         )}
       </ScrollArea>

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -36,6 +36,11 @@ export default function TestcasePanel() {
   }
 
   const testResults = useTestResults()
+  const summaryData = testResults.map(({ id, result, isUserTestcase }) => ({
+    id,
+    result,
+    isUserTestcase
+  }))
 
   return (
     <>
@@ -96,7 +101,7 @@ export default function TestcasePanel() {
       <ScrollArea className="h-full">
         {currentTab === 0 ? (
           <div className="flex flex-col gap-6 p-5 pb-14">
-            <TestSummary data={testResults} />
+            <TestSummary data={summaryData} />
             <TestcaseTable
               data={testResults}
               moveToDetailTab={moveToDetailTab}
@@ -175,15 +180,23 @@ function TestcaseTab({
   )
 }
 
-function TestSummary({ data }: { data: TestResultDetail[] }) {
+function TestSummary({
+  data
+}: {
+  data: { id: number; result: string; isUserTestcase: boolean }[]
+}) {
   const acceptedCount = data.filter(
     (testcase) => testcase.result === 'Accepted'
   ).length
 
   const total = data.length
 
-  const notAcceptedIndexes = data
-    .map((testcase, index) => (testcase.result !== 'Accepted' ? index : -1))
+  const notAcceptedTestcases = data
+    .map((testcase, index) =>
+      testcase.result !== 'Accepted'
+        ? `${testcase.isUserTestcase ? 'User' : 'Sample'} #${index + 1}`
+        : -1
+    )
     .filter((index) => index !== -1)
 
   return (
@@ -195,15 +208,13 @@ function TestSummary({ data }: { data: TestResultDetail[] }) {
             {acceptedCount}/{total}
           </td>
         </tr>
-        {notAcceptedIndexes.length > 0 && (
+        {notAcceptedTestcases.length > 0 && (
           <tr>
             <td className="w-52 py-1 align-top text-slate-400">
               Wrong Testcase Number:
             </td>
             <td className="py-1 text-white">
-              {notAcceptedIndexes
-                .map((index) => `Sample #${index + 1}`)
-                .join(', ')}
+              {notAcceptedTestcases.join(', ')}
             </td>
           </tr>
         )}

--- a/apps/frontend/app/(client)/(code-editor)/_components/WhitespaceVisualizer.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/WhitespaceVisualizer.tsx
@@ -12,10 +12,13 @@ export function WhitespaceVisualizer({
 }) {
   const whitespaceStyle =
     'color: rgb(53, 129, 250); min-width: 0.5em; display: inline-block;'
-  const highlightedWhitespaceText = text
-    .replaceAll(/ /g, `<span style="${whitespaceStyle}">␣</span>`)
-    .replaceAll(/\n/g, `<span style="${whitespaceStyle}">↵</span>\n`)
-    .replaceAll(/\t/g, `<span style="${whitespaceStyle}">↹</span>`)
+  const highlightedWhitespaceText =
+    text.length >= 100000
+      ? text
+      : text
+          .replaceAll(/ /g, `<span style="${whitespaceStyle}">␣</span>`)
+          .replaceAll(/\n/g, `<span style="${whitespaceStyle}">↵</span>\n`)
+          .replaceAll(/\t/g, `<span style="${whitespaceStyle}">↹</span>`)
 
   const lines = highlightedWhitespaceText.split('\n')
   const visibleLines = lines.slice(0, 3).join('\n')

--- a/apps/frontend/app/(client)/(code-editor)/_components/WhitespaceVisualizer.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/WhitespaceVisualizer.tsx
@@ -12,6 +12,8 @@ export function WhitespaceVisualizer({
 }) {
   const whitespaceStyle =
     'color: rgb(53, 129, 250); min-width: 0.5em; display: inline-block;'
+
+  // NOTE: Skip highlighting if text exceeds 100,000 characters to avoid performance issues.
   const highlightedWhitespaceText =
     text.length >= 100000
       ? text


### PR DESCRIPTION
### Description
## Output이 너무 커질 때 truncate
무한 루프로 print 하는 등 output이 너무 커질 경우, 
길이 제한을 두어 클라이언트가 터지는 것을 방지했습니다.
현재 기준은 10만자로 설정했으며, 기획팀과 논의 후 확정되면 수정하겠습니다.

추가로 10만자가 넘어가면 Input Output 상관 없이
WhitespaceVisualizer에서 visualize 과정을 skip 합니다.

정리하자면 Test 기능에서 Output의 경우에만 10만자를 넘어가면 10만자까지만 slice 해서 보여주고
모든 곳에서 사용하는 WhitespaceVisualizer에서 10만자를 넘어가는 경우 visualize를 안합니다.

## Minor Changes
- Wrong Testcase Number에서 Sample / User 구분하도록 수정
![image](https://github.com/user-attachments/assets/fa58ca5d-5560-4dbf-b403-c47e764bf224)
- AddTestcaseModal에서 Sample Testcase resize 안되던 버그 해결
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
