### PR TITLE
feat(fe): fix excel export score data

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -84,7 +84,7 @@ export default function ContestOverallTabs({
   const problemHeaders = completeProblemList.map((problem, index) => {
     const problemLabel = String.fromCharCode(65 + index) // A, B, C, ...
     return {
-      label: `${problemLabel}. ${problem.title}`,
+      label: problemLabel,
       key: `problems[${index}].maxScore`
     }
   })

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -70,7 +70,7 @@ export default function ContestOverallTabs({
     ? `${contestTitle.replace(/\s+/g, '_')}.csv`
     : `contest-${id}-participants.csv`
 
-  const completeProblemList =
+  const problemList =
     problemData?.getContestProblems
       .slice()
       .sort((a, b) => a.order - b.order)
@@ -81,7 +81,7 @@ export default function ContestOverallTabs({
         order: problem.order
       })) || []
 
-  const problemHeaders = completeProblemList.map((problem, index) => {
+  const problemHeaders = problemList.map((problem, index) => {
     const problemLabel = String.fromCharCode(65 + index)
     return {
       label: problemLabel,
@@ -101,7 +101,7 @@ export default function ContestOverallTabs({
 
   const csvData =
     scoreData?.getContestScoreSummaries.map((user) => {
-      const userProblemScores = completeProblemList.map((problem) => {
+      const userProblemScores = problemList.map((problem) => {
         const scoreData = user.problemScores.find(
           (ps) => ps.problemId === problem.problemId
         )

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -82,7 +82,7 @@ export default function ContestOverallTabs({
       })) || []
 
   const problemHeaders = completeProblemList.map((problem, index) => {
-    const problemLabel = String.fromCharCode(65 + index) // A, B, C, ...
+    const problemLabel = String.fromCharCode(65 + index)
     return {
       label: problemLabel,
       key: `problems[${index}].maxScore`


### PR DESCRIPTION
### Description

 - Excel 파일 문제별 점수가 모두 추출되지 않는 문제 발생
 - 해당 문제 발생 이유: scoreData를 사용해서 problemId를 가져오기에 user가 제출하지 않은 경우 배열에 problemId 포함 X 

- GET_CONTEST_PROBLEMS에서 problemId를 가져오는 방식으로 수정

### Additional context




[문제 해결]
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/705259b8-2fd2-4781-baf9-71f3bb25cfad">

<화면>

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/c3ad9c0a-6848-469d-a96f-197fef662a79">

<엑셀 파일>


closes TAS-1055


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
