### PR TITLE
fix(fe): differentiate sample and user id

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -44,20 +44,11 @@ export default function TestcasePanel() {
         ? testcase.output.slice(0, MAX_OUTPUT_LENGTH)
         : testcase.output
   }))
-  let usertestcaseCnt = 1
-  let sampletestcaseCnt = 1
-  const summaryData = processedData.map(({ id, result, isUserTestcase }) => {
-    if (isUserTestcase) {
-      id = usertestcaseCnt++
-    } else {
-      id = sampletestcaseCnt++
-    }
-    return {
-      id,
-      result,
-      isUserTestcase
-    }
-  })
+  const summaryData = processedData.map(({ id, result, isUserTestcase }) => ({
+    id,
+    result,
+    isUserTestcase
+  }))
 
   return (
     <>
@@ -65,7 +56,7 @@ export default function TestcasePanel() {
         <TestcaseTab
           currentTab={currentTab}
           onClickTab={() => setCurrentTab(0)}
-          nextTab={testcaseTabList[0]?.id}
+          nextTab={testcaseTabList[0]?.originalId}
           className="flex-shrink-0"
         >
           {testcaseTabList.length < 7 ? 'Testcase Result' : 'TC Res'}
@@ -126,7 +117,7 @@ export default function TestcasePanel() {
           </div>
         ) : (
           <TestResultDetail
-            data={processedData.find((item) => item.originalId === currentTab)}
+            data={processedData.find((item) => item.id === currentTab)}
           />
         )}
       </ScrollArea>

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -20,15 +20,15 @@ export default function TestcasePanel() {
         .concat(result)
         .filter(
           (item, index, self) =>
-            index === self.findIndex((t) => t.id === item.id)
+            index === self.findIndex((t) => t.originalId === item.originalId)
         )
     )
-    setCurrentTab(result.id)
+    setCurrentTab(result.originalId)
   }
 
   const removeTab = (testcaseId: number) => {
     setTestcaseTabList((state) =>
-      state.filter((item) => item.id !== testcaseId)
+      state.filter((item) => item.originalId !== testcaseId)
     )
     if (currentTab === testcaseId) {
       setCurrentTab(0)
@@ -44,11 +44,20 @@ export default function TestcasePanel() {
         ? testcase.output.slice(0, MAX_OUTPUT_LENGTH)
         : testcase.output
   }))
-  const summaryData = processedData.map(({ id, result, isUserTestcase }) => ({
-    id,
-    result,
-    isUserTestcase
-  }))
+  let usertestcaseCnt = 1
+  let sampletestcaseCnt = 1
+  const summaryData = processedData.map(({ id, result, isUserTestcase }) => {
+    if (isUserTestcase) {
+      id = usertestcaseCnt++
+    } else {
+      id = sampletestcaseCnt++
+    }
+    return {
+      id,
+      result,
+      isUserTestcase
+    }
+  })
 
   return (
     <>
@@ -72,12 +81,12 @@ export default function TestcasePanel() {
             {testcaseTabList.map((testcase, index) => (
               <TestcaseTab
                 currentTab={currentTab}
-                prevTab={testcaseTabList[index - 1]?.id}
-                nextTab={testcaseTabList[index + 1]?.id}
-                onClickTab={() => setCurrentTab(testcase.id)}
-                onClickCloseButton={() => removeTab(testcase.id)}
-                testcaseId={testcase.id}
-                key={testcase.id}
+                prevTab={testcaseTabList[index - 1]?.originalId}
+                nextTab={testcaseTabList[index + 1]?.originalId}
+                onClickTab={() => setCurrentTab(testcase.originalId)}
+                onClickCloseButton={() => removeTab(testcase.originalId)}
+                testcaseId={testcase.originalId}
+                key={testcase.originalId}
               >
                 {
                   (testcaseTabList.length < 7
@@ -117,7 +126,7 @@ export default function TestcasePanel() {
           </div>
         ) : (
           <TestResultDetail
-            data={processedData.find((item) => item.id === currentTab)}
+            data={processedData.find((item) => item.originalId === currentTab)}
           />
         )}
       </ScrollArea>
@@ -200,9 +209,9 @@ function TestSummary({
   const total = data.length
 
   const notAcceptedTestcases = data
-    .map((testcase, index) =>
+    .map((testcase) =>
       testcase.result !== 'Accepted'
-        ? `${testcase.isUserTestcase ? 'User' : 'Sample'} #${index + 1}`
+        ? `${testcase.isUserTestcase ? 'User' : 'Sample'} #${testcase.id}`
         : -1
     )
     .filter((index) => index !== -1)

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -117,7 +117,7 @@ export default function TestcasePanel() {
           </div>
         ) : (
           <TestResultDetail
-            data={processedData.find((item) => item.id === currentTab)}
+            data={processedData.find((item) => item.originalId === currentTab)}
           />
         )}
       </ScrollArea>

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcaseTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcaseTable.tsx
@@ -17,6 +17,15 @@ export default function TestcaseTable({
   data: TestResultDetail[]
   moveToDetailTab: (tab: TestResultDetail) => void
 }) {
+  let usertestcaseCnt = 1
+  let sampletestcaseCnt = 1
+  data.map((testResult) => {
+    if (testResult.isUserTestcase) {
+      testResult.id = usertestcaseCnt++
+    } else {
+      testResult.id = sampletestcaseCnt++
+    }
+  })
   return (
     <Table className="rounded-t-md">
       <TableHeader className="bg-[#121728] [&_tr]:border-b-slate-600">

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcaseTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcaseTable.tsx
@@ -17,15 +17,6 @@ export default function TestcaseTable({
   data: TestResultDetail[]
   moveToDetailTab: (tab: TestResultDetail) => void
 }) {
-  let usertestcaseCnt = 1
-  let sampletestcaseCnt = 1
-  data.map((testResult) => {
-    if (testResult.isUserTestcase) {
-      testResult.id = usertestcaseCnt++
-    } else {
-      testResult.id = sampletestcaseCnt++
-    }
-  })
   return (
     <Table className="rounded-t-md">
       <TableHeader className="bg-[#121728] [&_tr]:border-b-slate-600">

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useTestResults.ts
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useTestResults.ts
@@ -83,16 +83,16 @@ export const useTestResults = () => {
   })
 
   const testcases = useTestcaseStore((state) => state.getTestcases())
-  let usertestcaseCount = 1
-  let sampletestcaseCount = 1
+  let userTestcaseCount = 1
+  let sampleTestcaseCount = 1
   const testResults =
     data.length > 0
       ? testcases.map((testcase, index) => {
           const testResult = data.find((item) => item.id === testcase.id)
           if (testcase.isUserTestcase) {
-            testcase.id = usertestcaseCount++
+            testcase.id = userTestcaseCount++
           } else {
-            testcase.id = sampletestcaseCount++
+            testcase.id = sampleTestcaseCount++
           }
           return {
             id: testcase.id,

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useTestResults.ts
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useTestResults.ts
@@ -83,13 +83,20 @@ export const useTestResults = () => {
   })
 
   const testcases = useTestcaseStore((state) => state.getTestcases())
+  let usertestcaseCount = 1
+  let sampletestcaseCount = 1
   const testResults =
     data.length > 0
       ? testcases.map((testcase, index) => {
           const testResult = data.find((item) => item.id === testcase.id)
+          if (testcase.isUserTestcase) {
+            testcase.id = usertestcaseCount++
+          } else {
+            testcase.id = sampletestcaseCount++
+          }
           return {
-            id: index + 1,
-            originalId: testcase.id,
+            id: testcase.id,
+            originalId: index + 1,
             input: testcase.input,
             expectedOutput: testcase.output,
             output: testResult?.output ?? '',

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -184,6 +184,7 @@ export interface TestResultDetail extends TestResult {
   input: string
   expectedOutput: string
   isUserTestcase: boolean
+  originalId: number
 }
 
 export interface SettingsFormat {


### PR DESCRIPTION
### Description
<img width="943" alt="스크린샷 2024-11-18 오후 7 05 03" src="https://github.com/user-attachments/assets/8cb2dce4-c183-40dd-ab2a-7118648d35b9">
User testcase id와 기존에 존재하던 Sample testcase id가 함께 관리되어 발생하는 id문제를 해결하였다. 예로, Sample testcase가 2개 추가된 상태에서 User testcase를 추가하면 #3번째 id가 부여되는 문제를 User testcase는 따로 #1부터 시작하도록 하였다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
closes TAS-1057
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
