### PR TITLE
fix(fe): fix user testcase judging bug

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
@@ -64,7 +64,11 @@ export default function RunTestButton({
                 locked: false
               }
             ],
-            userTestcases: testcases
+            userTestcases: testcases.map((testcase) => ({
+              id: testcase.id,
+              in: testcase.input,
+              out: testcase.output
+            }))
           },
           searchParams: {
             problemId


### PR DESCRIPTION
### Description
```
    "userTestcases": [
      {
        "id": 1,
        "in": "1 1",
        "out": "2"
      }
    ]
```
`input` `output`이 아닌 `in` `out` 이었습니당..

![image](https://github.com/user-attachments/assets/5b80bfac-2070-4253-a792-4a1b8d3a16c3)
이제 정상적으로 채점되는 것을 확인할 수 있습니다!
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-1068
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
