### PR TITLE
fix(fe): change finished contest exit to route contest problem list

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/finished/problem/[problemId]/page.tsx
@@ -51,7 +51,7 @@ export default async function ContestFinishedPage({
               </Button>
             </Link>
           )}
-          <Link href={`/contest/${contestId}`}>
+          <Link href={`/contest/${contestId}/problem`}>
             <Button
               size="icon"
               className="ml-4 h-10 w-24 shrink-0 gap-[5px] rounded-[4px] bg-blue-500 font-sans hover:bg-blue-700"


### PR DESCRIPTION
### Description

대회가 끝나서 exit 버튼을 누르면 contest main page가 아닌 contest problem list로 가도록 변경합니다. 
closes TAS-1062

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
