### PR TITLE
fix: fix duplicate contest bugs

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -664,7 +664,8 @@ export class ContestService {
                 data: {
                   order: contestProblem.order,
                   contestId: newContest.id,
-                  problemId: contestProblem.problemId
+                  problemId: contestProblem.problemId,
+                  score: contestProblem.score
                 }
               })
             )

--- a/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
+++ b/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
@@ -47,8 +47,8 @@ function DisabledDuplicateButton() {
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <Button className="ml-auto" variant="default" size="default" disabled>
+        <TooltipTrigger className="ml-auto cursor-not-allowed self-end">
+          <Button variant="default" size="default" disabled>
             <CopyIcon className="mr-2 h-4 w-4" />
             Duplicate
           </Button>

--- a/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
+++ b/apps/frontend/app/admin/contest/_components/DuplicateContestButton.tsx
@@ -47,11 +47,13 @@ function DisabledDuplicateButton() {
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger className="ml-auto cursor-not-allowed self-end">
-          <Button variant="default" size="default" disabled>
-            <CopyIcon className="mr-2 h-4 w-4" />
-            Duplicate
-          </Button>
+        <TooltipTrigger asChild>
+          <span tabIndex={0} className="ml-auto cursor-not-allowed self-end">
+            <Button variant="default" size="default" disabled>
+              <CopyIcon className="mr-2 h-4 w-4" />
+              Duplicate
+            </Button>
+          </span>
         </TooltipTrigger>
         <TooltipContent>
           <p> Select only one contest to duplicate</p>


### PR DESCRIPTION
### Description

Frontend change: duplicate contest button이 disabled 되었을 때 tooltip이 제대로 적용되지 않는 문제를 해결합니다.
참고: https://github.com/shadcn-ui/ui/issues/1022

Backend change: duplicate contest를 할 때 contest problem Score도 같이 복제합니다. 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
