### PR TITLE
fix(fe): fix excel export

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -65,13 +65,8 @@ export default function ContestOverallTabs({
 
   const formatScore = (score: number): string => {
     const fixedScore = Math.floor(score * 1000) / 1000
-    return fixedScore % 1 === 0
-      ? fixedScore.toFixed(0)
-      : Math.floor(fixedScore * 10) % 10 === 0
-        ? (Math.floor(fixedScore * 10) / 10).toFixed(1)
-        : fixedScore.toString()
+    return fixedScore.toString()
   }
-
   const contestTitle = contestData?.getContests.find(
     (contest) => contest.id === contestId
   )?.title

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -124,8 +124,10 @@ export default function ContestOverallTabs({
       }
     }) || []
 
-  const isCurrentTab = (tab: string) =>
-    pathname.startsWith(`/admin/contest/${id}/${tab}`)
+  const isCurrentTab = (tab: string) => {
+    if (tab === '') return pathname === `/admin/contest/${id}`
+    return pathname.startsWith(`/admin/contest/${id}/${tab}`)
+  }
 
   return (
     <div className="flex items-center justify-between">

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -64,12 +64,12 @@ export default function ContestOverallTabs({
   })
 
   const formatScore = (score: number): string => {
-    const truncatedScore = Math.floor(score * 1000) / 1000
-    return truncatedScore % 1 === 0
-      ? truncatedScore.toFixed(0)
-      : Math.floor(truncatedScore * 10) % 10 === 0
-        ? (Math.floor(truncatedScore * 10) / 10).toFixed(1)
-        : truncatedScore.toString()
+    const fixedScore = Math.floor(score * 1000) / 1000
+    return fixedScore % 1 === 0
+      ? fixedScore.toFixed(0)
+      : Math.floor(fixedScore * 10) % 10 === 0
+        ? (Math.floor(fixedScore * 10) / 10).toFixed(1)
+        : fixedScore.toString()
   }
 
   const contestTitle = contestData?.getContests.find(
@@ -125,7 +125,7 @@ export default function ContestOverallTabs({
         )
 
         return {
-          maxScore: scoreData ? formatScore(scoreData.score) : '-' // formatScore 적용
+          maxScore: scoreData ? formatScore(scoreData.score) : '-'
         }
       })
 

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -15,6 +15,7 @@ import { usePathname } from 'next/navigation'
 import { CSVLink } from 'react-csv'
 
 interface ScoreSummary {
+  username: string
   realName: string
   studentId: string
   userContestScore: number
@@ -92,6 +93,7 @@ export default function ContestOverallTabs({
   const headers = [
     { label: '전공', key: 'major' },
     { label: '이름', key: 'realName' },
+    { label: '아이디', key: 'username' },
     { label: '학번', key: 'studentId' },
     {
       label: `총 획득 점수(만점 ${scoreData?.getContestScoreSummaries[0]?.contestPerfectScore || 0})`,
@@ -121,6 +123,7 @@ export default function ContestOverallTabs({
         major: user.major,
         studentId: user.studentId,
         realName: user.realName,
+        username: user.username,
         problemRatio: user.submittedProblemCount
           ? `${user.submittedProblemCount}`
           : '-',

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -84,7 +84,7 @@ export default function ContestOverallTabs({
   const problemHeaders = problemList.map((problem, index) => {
     const problemLabel = String.fromCharCode(65 + index)
     return {
-      label: problemLabel,
+      label: `${problemLabel}(배점 ${problem.maxScore})`,
       key: `problems[${index}].maxScore`
     }
   })
@@ -93,8 +93,14 @@ export default function ContestOverallTabs({
     { label: '전공', key: 'major' },
     { label: '이름', key: 'realName' },
     { label: '학번', key: 'studentId' },
-    { label: '총 획득 점수/총점', key: 'scoreRatio' },
-    { label: '제출 문제 수/총 문제 수', key: 'problemRatio' },
+    {
+      label: `총 획득 점수(만점 ${scoreData?.getContestScoreSummaries[0]?.contestPerfectScore || 0})`,
+      key: 'score'
+    },
+    {
+      label: `제출 문제 수(총 ${scoreData?.getContestScoreSummaries[0]?.totalProblemCount || 0})`,
+      key: 'problemRatio'
+    },
 
     ...problemHeaders
   ]
@@ -107,19 +113,18 @@ export default function ContestOverallTabs({
         )
 
         return {
-          maxScore: `${scoreData ? scoreData.score : 0}/${problem.maxScore}`
+          maxScore: `${scoreData ? scoreData.score : '-'}`
         }
       })
 
       return {
         major: user.major,
-        realName: user.realName,
         studentId: user.studentId,
-        scoreRatio: `${user.userContestScore}/${user.contestPerfectScore}`,
-        problemRatio:
-          user.submittedProblemCount === user.totalProblemCount
-            ? 'Submit'
-            : `${user.submittedProblemCount}/${user.totalProblemCount}`,
+        realName: user.realName,
+        problemRatio: user.submittedProblemCount
+          ? `${user.submittedProblemCount}`
+          : '-',
+        score: user.userContestScore,
         problems: userProblemScores
       }
     }) || []

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -67,10 +67,11 @@ export default function ContestOverallTabs({
     const truncatedScore = Math.floor(score * 1000) / 1000
     return truncatedScore % 1 === 0
       ? truncatedScore.toFixed(0)
-      : (truncatedScore * 10) % 1 === 0
-        ? truncatedScore.toFixed(1)
+      : Math.floor(truncatedScore * 10) % 10 === 0
+        ? (Math.floor(truncatedScore * 10) / 10).toFixed(1)
         : truncatedScore.toString()
   }
+
   const contestTitle = contestData?.getContests.find(
     (contest) => contest.id === contestId
   )?.title

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -63,6 +63,14 @@ export default function ContestOverallTabs({
     skip: !contestId
   })
 
+  const formatScore = (score: number): string => {
+    const truncatedScore = Math.floor(score * 1000) / 1000
+    return truncatedScore % 1 === 0
+      ? truncatedScore.toFixed(0)
+      : (truncatedScore * 10) % 1 === 0
+        ? truncatedScore.toFixed(1)
+        : truncatedScore.toString()
+  }
   const contestTitle = contestData?.getContests.find(
     (contest) => contest.id === contestId
   )?.title
@@ -116,7 +124,7 @@ export default function ContestOverallTabs({
         )
 
         return {
-          maxScore: `${scoreData ? scoreData.score : '-'}`
+          maxScore: scoreData ? formatScore(scoreData.score) : '-' // formatScore 적용
         }
       })
 
@@ -128,7 +136,7 @@ export default function ContestOverallTabs({
         problemRatio: user.submittedProblemCount
           ? `${user.submittedProblemCount}`
           : '-',
-        score: user.userContestScore,
+        score: formatScore(user.userContestScore),
         problems: userProblemScores
       }
     }) || []

--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -91,17 +91,18 @@ export default function ContestOverallTabs({
   })
 
   const headers = [
+    { label: '학번', key: 'studentId' },
+
     { label: '전공', key: 'major' },
     { label: '이름', key: 'realName' },
     { label: '아이디', key: 'username' },
-    { label: '학번', key: 'studentId' },
-    {
-      label: `총 획득 점수(만점 ${scoreData?.getContestScoreSummaries[0]?.contestPerfectScore || 0})`,
-      key: 'score'
-    },
     {
       label: `제출 문제 수(총 ${scoreData?.getContestScoreSummaries[0]?.totalProblemCount || 0})`,
       key: 'problemRatio'
+    },
+    {
+      label: `총 획득 점수(만점 ${scoreData?.getContestScoreSummaries[0]?.contestPerfectScore || 0})`,
+      key: 'score'
     },
 
     ...problemHeaders
@@ -120,8 +121,8 @@ export default function ContestOverallTabs({
       })
 
       return {
-        major: user.major,
         studentId: user.studentId,
+        major: user.major,
         realName: user.realName,
         username: user.username,
         problemRatio: user.submittedProblemCount


### PR DESCRIPTION
### Description

**<디자인&버튼 관련>** 
- isCurrentTab return 부분 편집으로 인한 Contest Overall tab UI 선택 표기 오류를 해결하였습니다.

**<헤더 관련>** 
- Excel 파일 추출 내역에 username을 추가하였습니다. 
- Excel 파일 추출 헤더 순서를 Contest Overall 페이지에서 보이는 순서와 일치시켰습니다. 
- 헤더 부분 표기에 만점/총/배점 정보를 추가하였습니다. 이로 인해 csvData에는 해당 점수만 표시합니다.

**<csvData 관련>**
- 제출 전부 완료 시 별도의 Submit 텍스트가 아니라, 제출한 개수를 동일하게 표시합니다. 
- 제출하지 않은 문제의 경우 '0'이 아니라 '-'로 미제출을 표시합니다. 
- 총 획득 점수와 세부 problem 점수의 경우 _1. 소수점 3자리까지 2. 반올림 없이_ 표시합니다. 


### Additional context
<img width="768" alt="image" src="https://github.com/user-attachments/assets/3c02e75c-89d1-4d92-b867-14b914938582">



closes TAS-1054
closes TAS-1056
closes TAS-1063


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
