### PR TITLE
fix(fe): fix bug with user testcases remaining in the contest

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -97,6 +97,7 @@ export default function EditorMainResizablePanel({
         <div className="grid-rows-editor grid h-full">
           <TestcaseStoreProvider
             problemId={problem.id}
+            contestId={contestId}
             problemTestcase={problem.problemTestcase}
           >
             <TestPollingStoreProvider>

--- a/apps/frontend/app/(client)/(code-editor)/_components/context/TestcaseStoreProvider.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/context/TestcaseStoreProvider.tsx
@@ -13,9 +13,12 @@ interface TestcaseState {
 
 const createTestcaseStore = (
   problemId: number,
-  sampleTestcases: TestcaseItem[]
+  sampleTestcases: TestcaseItem[],
+  contestId?: number
 ) => {
-  const storageKey = `user_testcase_${problemId}`
+  const storageKey = contestId
+    ? `user_testcase_${problemId}_${contestId}`
+    : `user_testcase_${problemId}`
 
   return createStore<TestcaseState>()(
     persist(
@@ -54,16 +57,22 @@ const TestcaseStoreContext = createContext<TestcaseStore | null>(null)
 
 export function TestcaseStoreProvider({
   problemId,
+  contestId,
   problemTestcase,
   children
 }: {
   problemId: number
+  contestId?: number
   problemTestcase: TestcaseItem[]
   children: ReactNode
 }) {
   const storeRef = useRef<TestcaseStore>()
   if (!storeRef.current) {
-    storeRef.current = createTestcaseStore(problemId, problemTestcase)
+    storeRef.current = createTestcaseStore(
+      problemId,
+      problemTestcase,
+      contestId
+    )
   }
 
   return (


### PR DESCRIPTION
### Description

유저 테스트케이스가 저장될 localStorage key에 contestId 값을 추가해 contest가 다를 경우 user testcase를 공유하지 않도록 합니다.


> 시험에 연습했던 problem이 그대로 출제되었을 경우에 user testcase가 그대로 남아있는 문제가 생길 수 있으므로, contest가 다를 경우 user testcase를 공유하지 않도록 수정해주시면 감사하겠습니다


closes TAS-1070

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
