### PR TITLE
fix(fe): show "Judging" text while testing

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcaseTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcaseTable.tsx
@@ -9,6 +9,7 @@ import {
 import { cn, getResultColor } from '@/libs/utils'
 import type { TestResultDetail } from '@/types/type'
 import { WhitespaceVisualizer } from '../WhitespaceVisualizer'
+import { useTestPollingStore } from '../context/TestPollingStoreProvider'
 
 export default function TestcaseTable({
   data,
@@ -17,6 +18,7 @@ export default function TestcaseTable({
   data: TestResultDetail[]
   moveToDetailTab: (tab: TestResultDetail) => void
 }) {
+  const isTesting = useTestPollingStore((state) => state.isTesting)
   return (
     <Table className="rounded-t-md">
       <TableHeader className="bg-[#121728] [&_tr]:border-b-slate-600">
@@ -62,10 +64,10 @@ export default function TestcaseTable({
             <TableCell
               className={cn(
                 'p-3 text-left md:p-3',
-                getResultColor(testResult.result)
+                getResultColor(isTesting ? null : testResult.result)
               )}
             >
-              {testResult.result}
+              {isTesting ? 'Judging' : testResult.result}
             </TableCell>
           </TableRow>
         ))}

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useTestResults.ts
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useTestResults.ts
@@ -31,6 +31,7 @@ const useGetTestResult = (type: 'sample' | 'user') => {
 
     if (allJudged) {
       // Test execution is finished
+      attempts.current = 0
       setIsTesting(false)
       stopPolling(type)
     } else if (attempts.current < MAX_ATTEMPTS) {
@@ -38,6 +39,7 @@ const useGetTestResult = (type: 'sample' | 'user') => {
       attempts.current += 1
     } else {
       // No more retry
+      attempts.current = 0
       setIsTesting(false)
       stopPolling(type)
       toast.error('Judging took too long. Please try again later.')
@@ -62,7 +64,7 @@ export const useTestResults = () => {
   const { data, isError } = useQueries({
     queries: [
       {
-        queryKey: ['submittion', 'test'],
+        queryKey: ['submission', 'test'],
         queryFn: getSampleTestResult,
         throwOnError: false,
         refetchInterval: REFETCH_INTERVAL,


### PR DESCRIPTION
### Description

- 확인된 문제: 테스트 시 모든 테스트 케이스들이 채점이 되는데 백엔드 응답 속도가 빨라서 (특히, user testcase 결과 가져올 때) 채점이 안된 것처럼 보일 수 있음. 😮 
- 해결 방법: 테스트 중이라면 Judging 텍스트를 보이도록 해 테스트 했다는 것을 사용자가 인지할 수 있게 함.

closes TAS-1071


+) 추가 버그 수정: polling 시도 횟수 초기화





### Additional context


https://github.com/user-attachments/assets/9a33b186-80c8-4c69-a331-786c3c78aa93



---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
