### PR TITLE
fix(fe): add fetch policy to useSuspenseQuery

### DIFF
--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/BelongedContestTable.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/BelongedContestTable.tsx
@@ -24,7 +24,8 @@ export function BelongedContestTable({
   const { data } = useSuspenseQuery(GET_BELONGED_CONTESTS, {
     variables: {
       problemId
-    }
+    },
+    fetchPolicy: 'network-only'
   })
 
   useEffect(() => {

--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/BelongedContestTable.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/BelongedContestTable.tsx
@@ -24,8 +24,7 @@ export function BelongedContestTable({
   const { data } = useSuspenseQuery(GET_BELONGED_CONTESTS, {
     variables: {
       problemId
-    },
-    fetchPolicy: 'network-only'
+    }
   })
 
   useEffect(() => {

--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/ScoreCautionDialog.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/ScoreCautionDialog.tsx
@@ -34,7 +34,7 @@ export function ScoreCautionDialog({
     {
       refetchQueries: [
         {
-          GET_BELONGED_CONTESTS,
+          query: GET_BELONGED_CONTESTS,
           variables: { problemId }
         }
       ]

--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/ScoreCautionDialog.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/ScoreCautionDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/shadcn/dialog'
+import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
 import { UPDATE_CONTEST_PROBLEMS_SCORES } from '@/graphql/problem/mutations'
 import { useMutation } from '@apollo/client'
 import { Suspense, useState } from 'react'
@@ -29,7 +30,15 @@ export function ScoreCautionDialog({
   problemId
 }: ScoreCautionDialogProps) {
   const [updateContestsProblemsScores] = useMutation(
-    UPDATE_CONTEST_PROBLEMS_SCORES
+    UPDATE_CONTEST_PROBLEMS_SCORES,
+    {
+      refetchQueries: [
+        {
+          GET_BELONGED_CONTESTS,
+          variables: { problemId }
+        }
+      ]
+    }
   )
 
   const [zeroSetContests, setZeroSetContests] = useState<number[]>([])


### PR DESCRIPTION
### Description
**문제 상황**

1. 문제의 테스트 케이스 별 점수 수정 후, 해당 문제를 포함하는 contest에서의 배점을 0점으로 설정
2. 다시 문제의 테스트 케이스 별 점수 수정 후 ScoreCautionDialog이 나왔을 때 위의 단계에서 0점으로 설정했던 contest가 여전히 수정 전 배점으로 표시됨

**문제 원인 및 해결 방안**

해당 데이터를 가져오는 api가 ScoreCautionDialog에 2번째 접근 시에는 호출되지 않았기 때문이다. 이 API는 useSuspenseQuery를 통해 호출되고 있었다. 

https://github.com/apollographql/apollo-client/issues/10478

위의 issue를 보면 useSuspenseQuery 가 cache 업데이트를 감지하지 못하는 문제가 있어서 해결했음을 확인할 수 있다. 현재 우리가 사용하는 apollo/client 버전에서 적용이 되어야 맞다. 왜 지금도 안되는지 모르겠지만 빠른 문제 해결을 위해 `fetchPolicy: 'network-only'` 를 추가했다.

### Additional context

close TAS-1073

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
