### PR TITLE
fix(fe): fix score sum bug

### DIFF
--- a/apps/frontend/app/admin/contest/_components/ContestProblemColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestProblemColumns.tsx
@@ -92,7 +92,7 @@ export const createColumns = (
         <Input
           disabled={true}
           className="w-[70px] focus-visible:ring-0"
-          defaultValue={table
+          value={table
             .getCoreRowModel()
             .rows.map((row) => row.original)
             .reduce((total, problem) => total + problem.score, 0)}


### PR DESCRIPTION
### Description
### 문제 요약
- Contest Create 및 Edit에서 score sum이 계산이 안됨
- 근데 새로고침을 하니까 갑자기 계산이 됨


![image](https://github.com/user-attachments/assets/ee11c691-d519-45e4-bcb8-f4ee81022483)

### 해결 방법
Input에 들어가는 `defaultValue`를 `value`로 수정하니 해결되었습니다
`defaultValue`는 첫 렌더링 때만 유효하고
`value`는 필드 값이 상태에 따라 변경되기 때문에
점수가 불러와지거나 수정될 때 바로바로 반영됩니다!
![image](https://github.com/user-attachments/assets/5863a870-3c79-458c-b2d0-2a5c64c69345)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes TAS-1060
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
