### PR TITLE
refactor(fe): use tanstack query for client-side data fetching

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorDescription.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorDescription.tsx
@@ -17,8 +17,7 @@ import {
 } from '@/components/shadcn/dialog'
 import { convertToLetter } from '@/libs/utils'
 import compileIcon from '@/public/icons/compile-version.svg'
-import type { ContestProblem, ProblemDetail } from '@/types/type'
-import type { Level } from '@/types/type'
+import type { ProblemDetail } from '@/types/type'
 import { sanitize } from 'isomorphic-dompurify'
 import { FileText } from 'lucide-react'
 import Image from 'next/image'
@@ -27,24 +26,23 @@ import { WhitespaceVisualizer } from './WhitespaceVisualizer'
 
 export function EditorDescription({
   problem,
-  contestProblems,
   isContest = false
 }: {
   problem: ProblemDetail
-  contestProblems?: ContestProblem[]
   isContest?: boolean
 }) {
   const level = problem.difficulty
   const levelNumber = level.slice(-1)
+
   return (
     <div className="dark flex h-full flex-col gap-6 bg-[#222939] py-6 text-lg">
       <div className="px-6">
         <div className="flex max-h-24 justify-between gap-4">
-          <h1 className="mb-3 overflow-hidden text-ellipsis whitespace-nowrap text-xl font-bold">{`#${contestProblems ? convertToLetter(contestProblems.find((item) => item.id === problem.id)?.order as number) : problem.id}. ${problem.title}`}</h1>
+          <h1 className="mb-3 overflow-hidden text-ellipsis whitespace-nowrap text-xl font-bold">{`#${problem?.order !== undefined ? convertToLetter(problem.order) : problem.id}. ${problem.title}`}</h1>
           {!isContest && (
             <Badge
               className="h-6 w-[52px] whitespace-nowrap rounded-[4px] bg-neutral-500 p-[6px] text-xs font-medium hover:bg-neutral-500"
-              textColors={level as Level}
+              textColors={level}
             >
               {`Level ${levelNumber}`}
             </Badge>

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { contestProblemQueries } from '@/app/(client)/_libs/queries/contestProblem'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -189,9 +190,11 @@ export default function Editor({
       storeCodeToLocalStorage(code)
       const submission: Submission = await res.json()
       setSubmissionId(submission.id)
-      queryClient.refetchQueries({
-        queryKey: ['contest', contestId, 'problems']
-      })
+      if (contestId) {
+        queryClient.invalidateQueries({
+          queryKey: contestProblemQueries.lists(contestId)
+        })
+      }
     } else {
       setIsSubmitting(false)
       if (res.status === 401) {

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorLayout.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorLayout.tsx
@@ -7,11 +7,8 @@ import type { Contest, ProblemDetail } from '@/types/type'
 import Image from 'next/image'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { Suspense } from 'react'
 import type { GetContestProblemDetailResponse } from '../../_libs/apis/contestProblem'
-import ContestProblemDropdown, {
-  ContestProblemDropdownFallback
-} from './ContestProblemDropdown'
+import ContestProblemDropdown from './ContestProblemDropdown'
 import EditorMainResizablePanel from './EditorResizablePanel'
 
 interface EditorLayoutProps {
@@ -64,19 +61,10 @@ export default async function EditorLayout({
               <>
                 <Link href={`/contest/${contest.id}`}>{contest.title}</Link>
                 <p className="mx-2"> / </p>
-                {/**TODO: add error boundary */}
-                <Suspense
-                  fallback={
-                    <ContestProblemDropdownFallback
-                      problemTitle={problem.title}
-                    />
-                  }
-                >
-                  <ContestProblemDropdown
-                    problem={problem}
-                    contestId={contest.id}
-                  />
-                </Suspense>
+                <ContestProblemDropdown
+                  problem={problem}
+                  contestId={contest.id}
+                />
               </>
             ) : (
               <h1 className="w-[1024px] overflow-hidden text-ellipsis whitespace-nowrap text-lg font-medium text-white">{`#${problem.id}. ${problem.title}`}</h1>

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorLayout.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorLayout.tsx
@@ -4,11 +4,14 @@ import { auth } from '@/libs/auth'
 import { fetcher, fetcherWithAuth } from '@/libs/utils'
 import codedangLogo from '@/public/logos/codedang-editor.svg'
 import type { Contest, ProblemDetail } from '@/types/type'
-import type { Route } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import ContestProblemDropdown from './ContestProblemDropdown'
+import { Suspense } from 'react'
+import type { GetContestProblemDetailResponse } from '../../_libs/apis/contestProblem'
+import ContestProblemDropdown, {
+  ContestProblemDropdownFallback
+} from './ContestProblemDropdown'
 import EditorMainResizablePanel from './EditorResizablePanel'
 
 interface EditorLayoutProps {
@@ -23,26 +26,27 @@ export default async function EditorLayout({
   children
 }: EditorLayoutProps) {
   let contest: Contest | undefined
-  let problem: ProblemDetail
+  let problem: Required<ProblemDetail>
 
   if (contestId) {
     // for getting contest info and problems list
+
+    // TODO: use `getContestProblemDetail` from _libs/apis folder & use error boundary
     const res = await fetcherWithAuth(
       `contest/${contestId}/problem/${problemId}`
     )
-
     if (!res.ok && res.status === 403) {
       redirect(`/contest/${contestId}/finished/problem/${problemId}`)
     }
-    const ContestProblem: { problem: ProblemDetail } = await res.json()
-    problem = ContestProblem.problem
+
+    const contestProblem = await res.json<GetContestProblemDetailResponse>()
+    problem = { ...contestProblem.problem, order: contestProblem.order }
+
     contest = await fetcher(`contest/${contestId}`).json()
     contest ? (contest.status = 'ongoing') : null // TODO: refactor this after change status interactively
   } else {
     problem = await fetcher(`problem/${problemId}`).json()
   }
-
-  // for getting problem detail
 
   const session = await auth()
 
@@ -56,17 +60,23 @@ export default async function EditorLayout({
           <div className="flex items-center gap-1 font-medium">
             {contest ? <>Contest</> : <Link href="/problem">Problem</Link>}
             <p className="mx-2"> / </p>
-            {contest && contestId ? (
+            {contest ? (
               <>
-                <Link href={`/contest/${contestId}` as Route}>
-                  {contest.title}
-                </Link>
+                <Link href={`/contest/${contest.id}`}>{contest.title}</Link>
                 <p className="mx-2"> / </p>
-                <ContestProblemDropdown
-                  problem={problem}
-                  problemId={problemId}
-                  contestId={contestId}
-                />
+                {/**TODO: add error boundary */}
+                <Suspense
+                  fallback={
+                    <ContestProblemDropdownFallback
+                      problemTitle={problem.title}
+                    />
+                  }
+                >
+                  <ContestProblemDropdown
+                    problem={problem}
+                    contestId={contest.id}
+                  />
+                </Suspense>
               </>
             ) : (
               <h1 className="w-[1024px] overflow-hidden text-ellipsis whitespace-nowrap text-lg font-medium text-white">{`#${problem.id}. ${problem.title}`}</h1>

--- a/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/layout.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/layout.tsx
@@ -4,13 +4,13 @@ export default async function layout({
   params,
   children
 }: {
-  params: { problemId: number; contestId: number }
+  params: { problemId: string; contestId: string }
   children: React.ReactNode
 }) {
   const { problemId, contestId } = params
 
   return (
-    <EditorLayout problemId={problemId} contestId={contestId}>
+    <EditorLayout problemId={Number(problemId)} contestId={Number(contestId)}>
       {children}
     </EditorLayout>
   )

--- a/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/page.tsx
@@ -1,30 +1,22 @@
 import { EditorDescription } from '@/app/(client)/(code-editor)/_components/EditorDescription'
+import type { GetContestProblemDetailResponse } from '@/app/(client)/_libs/apis/contestProblem'
 import { fetcherWithAuth } from '@/libs/utils'
-import type { ContestProblem, ProblemDetail } from '@/types/type'
 import { redirect } from 'next/navigation'
 
 export default async function DescriptionPage({
   params
 }: {
-  params: { problemId: number; contestId: number }
+  params: { problemId: string; contestId: string }
 }) {
   const { problemId, contestId } = params
-  const res = await fetcherWithAuth(`contest/${contestId}/problem/${problemId}`)
 
+  // TODO: use `getContestProblemDetail` from _libs/apis folder & use error boundary
+  const res = await fetcherWithAuth(`contest/${contestId}/problem/${problemId}`)
   if (!res.ok && res.status === 403) {
     redirect(`/contest/${contestId}/finished/problem/${problemId}`)
   }
 
-  const contestProblem: { problem: ProblemDetail } = await res.json()
+  const { problem, order } = await res.json<GetContestProblemDetailResponse>()
 
-  const contestProblems: { problems: ContestProblem[] } = await fetcherWithAuth(
-    `contest/${params.contestId}/problem`
-  ).json()
-  return (
-    <EditorDescription
-      problem={contestProblem.problem}
-      contestProblems={contestProblems.problems}
-      isContest={true}
-    />
-  )
+  return <EditorDescription problem={{ ...problem, order }} isContest={true} />
 }

--- a/apps/frontend/app/(client)/(code-editor)/problem/[problemId]/layout.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/problem/[problemId]/layout.tsx
@@ -4,10 +4,10 @@ export default async function layout({
   params,
   children
 }: {
-  params: { problemId: number }
+  params: { problemId: string }
   children: React.ReactNode
 }) {
   const { problemId } = params
 
-  return <EditorLayout problemId={problemId}>{children}</EditorLayout>
+  return <EditorLayout problemId={Number(problemId)}>{children}</EditorLayout>
 }

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/_components/GoToFirstProblemButton.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/_components/GoToFirstProblemButton.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { contestProblemQueries } from '@/app/(client)/_libs/queries/contestProblem'
+import { Button } from '@/components/shadcn/button'
+import { Skeleton } from '@/components/shadcn/skeleton'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+
+interface GoToFirstProblemButtonProps {
+  contestId: number
+}
+
+export function GoToFirstProblemButton({
+  contestId
+}: GoToFirstProblemButtonProps) {
+  const router = useRouter()
+  const { data: firstProblemId } = useSuspenseQuery({
+    ...contestProblemQueries.list({ contestId, take: 1 }),
+    select: (data) => data.data.at(0)?.id
+  })
+
+  return (
+    <Button
+      className="px-12 py-6 text-lg font-light"
+      onClick={() =>
+        router.push(`/contest/${contestId}/problem/${firstProblemId}`)
+      }
+    >
+      Go To First Problem!
+    </Button>
+  )
+}
+
+export function GoToFirstProblemButtonFallback() {
+  return <Skeleton className="h-12 w-60" />
+}

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/_components/RegisterButton.tsx
@@ -12,7 +12,6 @@ import { Input } from '@/components/shadcn/input'
 import { cn, fetcherWithAuth } from '@/libs/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
@@ -25,30 +24,17 @@ const schema = z.object({
   invitationCode: z.string().length(6)
 })
 
-const getFirstProblemId = async (contestId: string) => {
-  const { problems }: { problems: { id: string }[] } = await fetcherWithAuth
-    .get(`contest/${contestId}/problem`, {
-      searchParams: { take: 1 }
-    })
-    .json()
-  return problems?.at(0)?.id
-}
-
 export default function RegisterButton({
   id,
-  registered,
   state,
   title,
   invitationCodeExists
 }: {
   id: string
-  registered: boolean
   state: string
   title: string
   invitationCodeExists: boolean
 }) {
-  const [firstProblemId, setFirstProblemId] = useState('')
-  // const buttonColor = registered ? 'bg-secondary' : 'bg-primary'
   const router = useRouter()
   const clickRegister = async (contestId: string) => {
     await fetcherWithAuth
@@ -73,29 +59,6 @@ export default function RegisterButton({
       })
       .catch((err) => console.log(err))
   }
-  // const clickDeregister = async (contestId: string) => {
-  //   await fetcherWithAuth
-  //     .delete(`contest/${contestId}/participation`, {
-  //       searchParams: { groupId: 1 }
-  //     })
-  //     .then((res) => {
-  //       res.json()
-  //       router.refresh()
-  //     })
-  //     .catch((err) => console.log(err))
-  // }
-
-  useEffect(() => {
-    async function fetchFirstProblemId() {
-      if (registered && state === 'Ongoing') {
-        const firstId = await getFirstProblemId(id)
-        setFirstProblemId(firstId ?? '')
-      } else {
-        setFirstProblemId('')
-      }
-    }
-    fetchFirstProblemId()
-  }, [registered, state, id])
 
   const {
     handleSubmit,
@@ -111,96 +74,57 @@ export default function RegisterButton({
     clickRegister(id)
   }
 
-  return (
-    <>
-      {registered ? (
-        // Case 1) User registered for the contest
-        <>
-          {/* {state === 'Upcoming' ? (
-            <Button
-              className={`px-12 py-6 text-lg font-light ${buttonColor} hover:${buttonColor}`}
-              onClick={() => {
-                clickDeregister(id)
-                toast.success('Deregistered Upcoming test successfully')
-              }}
-            >
-              Deregister
-            </Button>
-          ) : (
-            <> */}
-          {firstProblemId && (
-            <Button
-              className="px-12 py-6 text-lg font-light"
-              onClick={() =>
-                router.push(`/contest/${id}/problem/${firstProblemId}`)
-              }
-            >
-              Go To First Problem!
-            </Button>
-          )}
-          {/* </>
-          )} */}
-        </>
-      ) : !invitationCodeExists ? (
-        // Case 2) User not registered and no invitation code required
+  return !invitationCodeExists ? (
+    // User not registered and no invitation code required
+    <Button
+      className="px-12 py-6 text-lg disabled:bg-gray-300 disabled:text-gray-600"
+      disabled={state === 'Upcoming'}
+      onClick={onSubmit}
+    >
+      Register Now
+    </Button>
+  ) : (
+    // User not registered and invitation code required
+    <Dialog>
+      <DialogTrigger asChild>
         <Button
           className="px-12 py-6 text-lg disabled:bg-gray-300 disabled:text-gray-600"
           disabled={state === 'Upcoming'}
-          onClick={() => {
-            clickRegister(id)
-          }}
         >
           Register Now
         </Button>
-      ) : (
-        // Case 3) User not registered and invitation code required
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button
-              className="px-12 py-6 text-lg disabled:bg-gray-300 disabled:text-gray-600"
-              disabled={state === 'Upcoming'}
-            >
-              Register Now
+      </DialogTrigger>
+      <DialogContent className="flex w-[416px] flex-col gap-6 p-10">
+        <DialogHeader>
+          <DialogTitle className="line-clamp-2 text-xl">{title}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
+          <div className="flex flex-col gap-1">
+            <Input
+              placeholder="Invitation Code"
+              {...register('invitationCode', {
+                onChange: () => trigger('invitationCode')
+              })}
+              type="number"
+              className={cn(
+                'hide-spin-button h-12 w-full',
+                errors.invitationCode &&
+                  'border-red-500 focus-visible:ring-red-500'
+              )}
+            />
+            {errors.invitationCode && (
+              <p className="text-xs text-red-500">
+                Register Code must be a 6-digit number
+              </p>
+            )}
+          </div>
+          <div className="flex justify-center">
+            <Button type="submit" className="w-24">
+              Register
             </Button>
-          </DialogTrigger>
-          <DialogContent className="flex w-[416px] flex-col gap-6 p-10">
-            <DialogHeader>
-              <DialogTitle className="line-clamp-2 text-xl">
-                {title}
-              </DialogTitle>
-            </DialogHeader>
-            <form
-              onSubmit={handleSubmit(onSubmit)}
-              className="flex flex-col gap-6"
-            >
-              <div className="flex flex-col gap-1">
-                <Input
-                  placeholder="Invitation Code"
-                  {...register('invitationCode', {
-                    onChange: () => trigger('invitationCode')
-                  })}
-                  type="number"
-                  className={cn(
-                    'hide-spin-button h-12 w-full',
-                    errors.invitationCode &&
-                      'border-red-500 focus-visible:ring-red-500'
-                  )}
-                />
-                {errors.invitationCode && (
-                  <p className="text-xs text-red-500">
-                    Register Code must be a 6-digit number
-                  </p>
-                )}
-              </div>
-              <div className="flex justify-center">
-                <Button type="submit" className="w-24">
-                  Register
-                </Button>
-              </div>
-            </form>
-          </DialogContent>
-        </Dialog>
-      )}
-    </>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/page.tsx
@@ -1,6 +1,11 @@
 import KatexContent from '@/components/KatexContent'
 import { auth } from '@/libs/auth'
 import { fetcherWithAuth } from '@/libs/utils'
+import { Suspense } from 'react'
+import {
+  GoToFirstProblemButton,
+  GoToFirstProblemButtonFallback
+} from './_components/GoToFirstProblemButton'
 import RegisterButton from './_components/RegisterButton'
 
 interface ContestTop {
@@ -43,13 +48,19 @@ export default async function ContestTop({ params }: ContestTopProps) {
       />
       {session && state !== 'Finished' && (
         <div className="mt-10 flex justify-center">
-          <RegisterButton
-            id={contestId}
-            registered={data.isRegistered}
-            state={state}
-            title={data.title}
-            invitationCodeExists={data.invitationCodeExists}
-          />
+          {data.isRegistered ? (
+            // TODO: add error boundary
+            <Suspense fallback={<GoToFirstProblemButtonFallback />}>
+              <GoToFirstProblemButton contestId={Number(contestId)} />
+            </Suspense>
+          ) : (
+            <RegisterButton
+              id={contestId}
+              state={state}
+              title={data.title}
+              invitationCodeExists={data.invitationCodeExists}
+            />
+          )}
         </div>
       )}
     </>

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/problem/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/problem/page.tsx
@@ -17,12 +17,15 @@ interface ContestApiResponse {
 
 export default async function ContestProblem({ params }: ContestProblemProps) {
   const { contestId } = params
+
+  // TODO: use `getContestProblemList` from _libs/apis folder
   const res = await fetcherWithAuth.get(`contest/${contestId}/problem`, {
     searchParams: {
       take: 20
     }
   })
 
+  // TODO: use error boundary
   if (!res.ok) {
     const { statusCode }: { statusCode: number } = await res.json()
 

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/_libs/utils.ts
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/_libs/utils.ts
@@ -1,15 +1,10 @@
-import { safeFetcherWithAuth } from '@/libs/utils'
-import type { ContestProblem } from '@/types/type'
-
-interface ContestProblemsApiRes {
-  data: ContestProblem[]
-}
+import { getContestProblemList } from '@/app/(client)/_libs/apis/contestProblem'
 
 const calculateContestScore = async ({ contestId }: { contestId: string }) => {
   try {
-    const contestProblems: ContestProblemsApiRes = await safeFetcherWithAuth
-      .get(`contest/${contestId}/problem`)
-      .json()
+    const contestProblems = await getContestProblemList({
+      contestId: Number(contestId)
+    })
 
     const { totalScore, totalMaxScore } = contestProblems.data.reduce(
       (acc, curr) => {

--- a/apps/frontend/app/(client)/_libs/apis/contestProblem.ts
+++ b/apps/frontend/app/(client)/_libs/apis/contestProblem.ts
@@ -1,0 +1,58 @@
+import { safeFetcherWithAuth } from '@/libs/utils'
+import type { ContestProblem, ProblemDetail } from '@/types/type'
+import type { PaginationQueryParams } from './types'
+
+export interface GetContestProblemListRequest extends PaginationQueryParams {
+  groupId?: number
+  contestId: number
+}
+
+export interface GetContestProblemListResponse {
+  data: ContestProblem[]
+  total: number
+}
+
+export const getContestProblemList = async ({
+  contestId,
+  ...searchParams
+}: GetContestProblemListRequest) => {
+  const response = await safeFetcherWithAuth.get(
+    `contest/${contestId}/problem`,
+    {
+      searchParams
+    }
+  )
+
+  const data = response.json<GetContestProblemListResponse>()
+
+  return data
+}
+
+// --------------------------------------------------------------------
+
+export interface GetContestProblemDetailRequest {
+  contestId: number
+  problemId: number
+}
+
+export interface GetContestProblemDetailResponse {
+  order: number
+  problem: ProblemDetail
+}
+
+export const getContestProblemDetail = async ({
+  contestId,
+  problemId,
+  ...searchParams
+}: GetContestProblemDetailRequest) => {
+  const response = await safeFetcherWithAuth.get(
+    `contest/${contestId}/problem/${problemId}`,
+    {
+      searchParams
+    }
+  )
+
+  const data = await response.json<GetContestProblemDetailResponse>()
+
+  return data
+}

--- a/apps/frontend/app/(client)/_libs/apis/types.ts
+++ b/apps/frontend/app/(client)/_libs/apis/types.ts
@@ -1,0 +1,4 @@
+export interface PaginationQueryParams {
+  cursor?: number
+  take?: number
+}

--- a/apps/frontend/app/(client)/_libs/queries/contestProblem.ts
+++ b/apps/frontend/app/(client)/_libs/queries/contestProblem.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from '@tanstack/react-query'
+import {
+  getContestProblemList,
+  type GetContestProblemListRequest
+} from '../apis/contestProblem'
+
+export const contestProblemQueries = {
+  all: (contestId: number) => ['contest', contestId, 'problem'] as const,
+  lists: (contestId: number) =>
+    [...contestProblemQueries.all(contestId), 'list'] as const,
+  list: ({ contestId, ...searchParams }: GetContestProblemListRequest) =>
+    queryOptions({
+      queryKey: [
+        ...contestProblemQueries.lists(contestId),
+        { ...searchParams }
+      ] as const,
+      queryFn: () => getContestProblemList({ contestId, ...searchParams })
+    })
+}

--- a/apps/frontend/app/(client)/layout.tsx
+++ b/apps/frontend/app/(client)/layout.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 export default function MainLayout({
   children
@@ -16,6 +17,11 @@ export default function MainLayout({
   })
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryClientProvider>
   )
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -92,6 +92,7 @@
     "@graphql-codegen/cli": "^5.0.3",
     "@graphql-codegen/client-preset": "^4.5.0",
     "@graphql-typed-document-node/core": "^3.2.0",
+    "@tanstack/react-query-devtools": "^5.61.0",
     "@testing-library/react": "^16.0.1",
     "@types/apollo-upload-client": "^18.0.0",
     "@types/katex": "^0.16.7",

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -48,8 +48,8 @@ export interface WorkbookProblem extends Omit<Problem, 'tags' | 'info'> {
 export interface ContestProblem extends Omit<Problem, 'tags' | 'info'> {
   order: number
   maxScore: number
-  score?: string
-  submissionTime?: Date
+  score: string | null
+  submissionTime: string | null
 }
 
 export interface TestcaseItem {
@@ -73,6 +73,7 @@ export interface ProblemDetail {
   hint: string
   template: string[]
   difficulty: Level
+  order?: number
 }
 
 // Contest type definition

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,19 +79,19 @@ importers:
         version: 3.687.0(@aws-sdk/client-sso-oidc@3.687.0(@aws-sdk/client-sts@3.687.0))(@aws-sdk/client-sts@3.687.0)
       '@golevelup/nestjs-rabbitmq':
         specifier: ^5.6.1
-        version: 5.6.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)
+        version: 5.6.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs-modules/mailer':
         specifier: ^2.0.2
-        version: 2.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(nodemailer@6.9.16)
+        version: 2.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(nodemailer@6.9.16)
       '@nestjs/apollo':
         specifier: ^12.2.1
-        version: 12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/graphql@12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0))(graphql@16.9.0)
+        version: 12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/graphql@12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0))(graphql@16.9.0)
       '@nestjs/axios':
         specifier: ^3.1.2
         version: 3.1.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(axios@1.7.7)(rxjs@7.8.1)
       '@nestjs/cache-manager':
         specifier: ^2.3.0
-        version: 2.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(cache-manager@5.7.6)(rxjs@7.8.1)
+        version: 2.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(cache-manager@5.7.6)(rxjs@7.8.1)
       '@nestjs/common':
         specifier: ^10.4.7
         version: 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -103,7 +103,7 @@ importers:
         version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/graphql':
         specifier: ^12.2.1
-        version: 12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0)
+        version: 12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0)
       '@nestjs/jwt':
         specifier: ^10.2.0
         version: 10.2.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))
@@ -115,7 +115,7 @@ importers:
         version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
       '@nestjs/swagger':
         specifier: ^7.4.2
-        version: 7.4.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+        version: 7.4.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@opentelemetry/api':
         specifier: ~1.9.0
         version: 1.9.0
@@ -211,7 +211,7 @@ importers:
         version: 4.7.8
       nestjs-otel:
         specifier: ^6.1.1
-        version: 6.1.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))
+        version: 6.1.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
       nestjs-pino:
         specifier: ^4.1.0
         version: 4.1.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(pino-http@10.3.0)
@@ -263,7 +263,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.6.3)
       '@nestjs/testing':
         specifier: ^10.4.7
-        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7))
+        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)
       '@swc-node/register':
         specifier: ^1.10.9
         version: 1.10.9(@swc/core@1.9.2(@swc/helpers@0.5.13))(@swc/types@0.1.15)(typescript@5.6.3)
@@ -446,10 +446,10 @@ importers:
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^8.38.0
-        version: 8.38.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@14.2.17(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.96.1(@swc/core@1.9.2))
+        version: 8.38.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@14.2.17(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13)))
       '@tailwindcss/typography':
         specifier: ^0.5.15
-        version: 0.5.15(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3)))
+        version: 0.5.15(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3)))
       '@tanstack/react-query':
         specifier: ^5.59.20
         version: 5.59.20(react@18.3.1)
@@ -592,6 +592,9 @@ importers:
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.9.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.61.0
+        version: 5.61.0(@tanstack/react-query@5.59.20(react@18.3.1))(react@18.3.1)
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -648,10 +651,10 @@ importers:
         version: 2.5.4
       tailwindcss:
         specifier: ^3.4.14
-        version: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3))
+        version: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3)))
+        version: 1.0.7(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3)))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -4340,6 +4343,15 @@ packages:
 
   '@tanstack/query-core@5.59.20':
     resolution: {integrity: sha512-e8vw0lf7KwfGe1if4uPFhvZRWULqHjFcz3K8AebtieXvnMOz5FSzlZe3mTLlPuUBcydCnBRqYs2YJ5ys68wwLg==}
+
+  '@tanstack/query-devtools@5.59.20':
+    resolution: {integrity: sha512-vxhuQ+8VV4YWQSFxQLsuM+dnEKRY7VeRzpNabFXdhEwsBYLrjXlF1pM38A8WyKNLqZy8JjyRO8oP4Wd/oKHwuQ==}
+
+  '@tanstack/react-query-devtools@5.61.0':
+    resolution: {integrity: sha512-hd3yXl+KV+OGQmAw946qHAFp6DygcXcYN+1ai9idYddx6uEQyCwYk3jyIBOQEUw9uzN5DOGJLBsgd/QcimDQsA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.61.0
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.59.20':
     resolution: {integrity: sha512-Zly0egsK0tFdfSbh5/mapSa+Zfc3Et0Zkar7Wo5sQkFzWyB3p3uZWOHR2wrlAEEV2L953eLuDBtbgFvMYiLvUw==}
@@ -12492,7 +12504,7 @@ snapshots:
       lodash: 4.17.21
       nanoid: 3.3.7
 
-  '@golevelup/nestjs-discovery@4.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))':
+  '@golevelup/nestjs-discovery@4.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)':
     dependencies:
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -12504,10 +12516,10 @@ snapshots:
       lodash: 4.17.21
       rxjs: 7.8.1
 
-  '@golevelup/nestjs-rabbitmq@5.6.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)':
+  '@golevelup/nestjs-rabbitmq@5.6.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
       '@golevelup/nestjs-common': 2.0.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))
-      '@golevelup/nestjs-discovery': 4.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))
+      '@golevelup/nestjs-discovery': 4.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
       '@golevelup/nestjs-modules': 0.7.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -13377,7 +13389,7 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@nestjs-modules/mailer@2.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(nodemailer@6.9.16)':
+  '@nestjs-modules/mailer@2.0.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(nodemailer@6.9.16)':
     dependencies:
       '@css-inline/css-inline': 0.14.1
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -13397,13 +13409,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/apollo@12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/graphql@12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0))(graphql@16.9.0)':
+  '@nestjs/apollo@12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/graphql@12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0))(graphql@16.9.0)':
     dependencies:
       '@apollo/server': 4.11.2(graphql@16.9.0)
       '@apollo/server-plugin-landing-page-graphql-playground': 4.0.0(@apollo/server@4.11.2(graphql@16.9.0))
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/graphql': 12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0)
+      '@nestjs/graphql': 12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0)
       graphql: 16.9.0
       iterall: 1.3.0
       lodash.omit: 4.5.0
@@ -13415,7 +13427,7 @@ snapshots:
       axios: 1.7.7
       rxjs: 7.8.1
 
-  '@nestjs/cache-manager@2.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(cache-manager@5.7.6)(rxjs@7.8.1)':
+  '@nestjs/cache-manager@2.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(cache-manager@5.7.6)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -13486,7 +13498,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/graphql@12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0)':
+  '@nestjs/graphql@12.2.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@16.0.0)':
     dependencies:
       '@graphql-tools/merge': 9.0.8(graphql@16.9.0)
       '@graphql-tools/schema': 10.0.7(graphql@16.9.0)
@@ -13556,7 +13568,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@7.4.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@7.4.2(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -13571,7 +13583,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.1
 
-  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7))':
+  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)':
     dependencies:
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -15063,7 +15075,7 @@ snapshots:
       '@sentry/types': 8.38.0
       '@sentry/utils': 8.38.0
 
-  '@sentry/nextjs@8.38.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@14.2.17(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.96.1(@swc/core@1.9.2))':
+  '@sentry/nextjs@8.38.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(next@14.2.17(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13)))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
@@ -15077,7 +15089,7 @@ snapshots:
       '@sentry/types': 8.38.0
       '@sentry/utils': 8.38.0
       '@sentry/vercel-edge': 8.38.0
-      '@sentry/webpack-plugin': 2.22.6(webpack@5.96.1(@swc/core@1.9.2))
+      '@sentry/webpack-plugin': 2.22.6(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13)))
       chalk: 3.0.0
       next: 14.2.17(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
@@ -15167,12 +15179,12 @@ snapshots:
       '@sentry/types': 8.38.0
       '@sentry/utils': 8.38.0
 
-  '@sentry/webpack-plugin@2.22.6(webpack@5.96.1(@swc/core@1.9.2))':
+  '@sentry/webpack-plugin@2.22.6(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13)))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.6
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.96.1(@swc/core@1.9.2)
+      webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13))
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15638,15 +15650,23 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3)))':
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3))
+      tailwindcss: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3))
 
   '@tanstack/query-core@5.59.20': {}
+
+  '@tanstack/query-devtools@5.59.20': {}
+
+  '@tanstack/react-query-devtools@5.61.0(@tanstack/react-query@5.59.20(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.59.20
+      '@tanstack/react-query': 5.59.20(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.59.20(react@18.3.1)':
     dependencies:
@@ -18057,7 +18077,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -18070,7 +18090,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18092,7 +18112,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -20440,7 +20460,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nestjs-otel@6.1.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)):
+  nestjs-otel@6.1.1(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7):
     dependencies:
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -21056,7 +21076,7 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.0
@@ -22309,11 +22329,11 @@ snapshots:
 
   tailwind-merge@2.5.4: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3))):
     dependencies:
-      tailwindcss: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3))
+      tailwindcss: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3))
 
-  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3)):
+  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -22332,7 +22352,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@20.17.6)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.13))(@types/node@20.17.6)(typescript@5.6.3))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -22358,17 +22378,6 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.36.0
       webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13))
-    optionalDependencies:
-      '@swc/core': 1.9.2(@swc/helpers@0.5.13)
-
-  terser-webpack-plugin@5.3.10(@swc/core@1.9.2)(webpack@5.96.1(@swc/core@1.9.2)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.9.2)
     optionalDependencies:
       '@swc/core': 1.9.2(@swc/helpers@0.5.13)
 
@@ -22895,36 +22904,6 @@ snapshots:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.13))(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.13)))
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.96.1(@swc/core@1.9.2):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.14.0
-      browserslist: 4.24.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.9.2)(webpack@5.96.1(@swc/core@1.9.2))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

```
app/(client)/_libs
- apis
   - contestProblem.ts
   - problem.ts 
   - contest.ts
   - notice.ts
   - submission.ts
   - type.ts (공용 타입)
- queries
  - contestProblem.ts 
```

**`apis` 폴더**
- API 호출 함수, request params 타입 관리, response 타입 관리
- 여기저기서 선언되던 api response 타입들을 한 곳에서 관리합니다.
- API 호출 함수를 사용함으로써 따로 타입 선언을 하지 않아도 됩니다.
- 만약 백엔드 API 응답이 수정되면 한 곳에서만 타입 수정하고, 나머지 타입 에러들을 고치면 됩니다.
- 리팩토링 하면서 실제 백엔드 API 응답과 다르게 선언된 타입들을 고칠 수 있었습니다.
- 여기서 선언된 API 호출 함수들은 `safeFetcher(WithAuth)`를 사용해야 합니다.

**`queries` 폴더**
- query 옵션 관리
- 쿼리 키는 계층적 구조를 따릅니다. 자세한 내용은 아래 블로그를 참고해주세요~
- 참고: [Query Keys를 관리하는 기준과 방법](https://velog.io/@bo-like-chicken/Query-Keys%EB%A5%BC-%EA%B4%80%EB%A6%AC%ED%95%98%EB%8A%94-%EA%B8%B0%EC%A4%80%EA%B3%BC-%EB%B0%A9%EB%B2%95)
- `RegisterButton` 컴포넌트 리팩토링 (`useEffect` -> Tanstack Query)
   1. API 호출 함수, 요청/응답 타입 추가
   2. 쿼리 옵션 추가 (앞서 추가한 API 호출 함수 사용)
   3. 쿼리 옵션과 `useQuery` or `useSuspenseQuery` 사용해 리팩토링 
- 커스텀 훅으로 관리하지 않는 이유?: 커스텀 훅 내부에서 `useQuery` 혹은 `useSuspenseQuery`를 사용할지 결정해야 하는데, 이건 컴포넌트가 별도의 loading UI를 보여줘야 하냐 마냐에 따라서 결정될 수 있는 거라서 간단하게 쿼리 옵션만 관리하는 방법을 선택했습니다.
- 로컬 개발 환경에서 React Query가 내부에서 어떻게 관리하고 있는지 확인할 수 있도록 dev tool을 추가했습니다.

![image](https://github.com/user-attachments/assets/2b29d0ea-84bd-42ef-8202-f07260adc6d9)



> 💡 캐시 전략을 사용하기 때문에 사용자 액션으로 인해서 (제출, 테스트) 서버 데이터가 변경되었을 때 어떤 쿼리 캐시를  무효화시킬지 파악하는 것이 중요해집니다!

**Minor changes**

- NextJS가 `page.tsx`와 `layout.tsx` 에 제공하는 params prop의 프로퍼티 타입들은 무조건 string 입니다!! `string`인데 `number`로 선언되어 있는 부분들이 꽤 있는 것 같은데 다 수정하진 않았어요... 잘못된 타입 선언으로 인해 쿼리 키가 일치하지 않아서 삽질했습니다...  😢  (`["contest", 74, "problem", "list"] !== ["contest", "74", "problem", "list"]`)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
