### PR TITLE
feat(fe): add testcase judge results not available alert when testcase is outdated

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/_components/SubmissionDetailAdmin.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/SubmissionDetailAdmin.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import CodeEditor from '@/components/CodeEditor'
+import { Alert, AlertDescription, AlertTitle } from '@/components/shadcn/alert'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
 import {
   Table,
@@ -15,6 +16,7 @@ import { GET_SUBMISSION } from '@/graphql/submission/queries'
 import { dateFormatter, getResultColor } from '@/libs/utils'
 import type { Language } from '@/types/type'
 import { useLazyQuery, useQuery } from '@apollo/client'
+import { IoWarning } from 'react-icons/io5'
 
 export default function SubmissionDetailAdmin({
   submissionId
@@ -125,9 +127,10 @@ export default function SubmissionDetailAdmin({
             </div>
             <ScrollBar orientation="horizontal" />
           </ScrollArea>
-          {submission?.testcaseResult.length !== 0 && (
-            <div>
-              <h2 className="font-bold">Testcase</h2>
+
+          <h2 className="mt-4 font-bold">Testcase</h2>
+          {submission?.testcaseResult.length !== 0 ? (
+            <div className="flex flex-col gap-4">
               <table>
                 <tbody className="text-sm font-light">
                   <tr>
@@ -201,16 +204,22 @@ export default function SubmissionDetailAdmin({
                 </TableBody>
               </Table>
             </div>
+          ) : (
+            <Alert variant="default">
+              <IoWarning className="mr-2 h-4 w-4" />
+              <AlertTitle>Testcase Judge Results Not Available</AlertTitle>
+              <AlertDescription>
+                The testcases have been recently updated and are now outdated.
+              </AlertDescription>
+            </Alert>
           )}
-          <div>
-            <h2 className="mb-3 font-bold">Source Code</h2>
-            <CodeEditor
-              value={submission?.code}
-              language={submission?.language as Language}
-              readOnly
-              className="max-h-96 min-h-16 w-full"
-            />
-          </div>
+          <h2 className="mt-4 font-bold">Source Code</h2>
+          <CodeEditor
+            value={submission?.code}
+            language={submission?.language as Language}
+            readOnly
+            className="max-h-96 min-h-16 w-full"
+          />
         </div>
       )}
     </ScrollArea>

--- a/apps/frontend/components/shadcn/alert.tsx
+++ b/apps/frontend/components/shadcn/alert.tsx
@@ -1,0 +1,58 @@
+import { cn } from '@/libs/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border border-gray-200 px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-gray-950 [&>svg~*]:pl-7 dark:border-gray-800 dark:[&>svg]:text-gray-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-white text-gray-950 dark:bg-gray-950 dark:text-gray-50',
+        destructive:
+          'border-red-500/50 text-red-500 dark:border-red-500 [&>svg]:text-red-500 dark:border-red-900/50 dark:text-red-900 dark:dark:border-red-900 dark:[&>svg]:text-red-900'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = 'Alert'
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = 'AlertTitle'
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = 'AlertDescription'
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
### Description

Testcase가 수정되면, 기존 Testcase는 삭제되고 새로운 Testcase가 생성되게 됩니다.

이때 기존 Submission들의 Testcase Judge Results(SubmissionResult model) 는 모두 삭제되므로 (Cascade 설정), 채점 결과를 불러오더라도 Testcase별 채점 결과를 볼 수 없습니다.

이때, Testcase Judge Results Not Available이를 Alert 박스 안에 보여주어 사용자가 인지할 수 있도록 합니다.

AdminSubmissionDetail 모달의 Layout도 약간 조정하였습니다. 

사진 참고해주세요
![image](https://github.com/user-attachments/assets/137ec0d8-56c7-4fd0-9977-4dba3be1e963)

closes TAS-1078
closes TAS-1078

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
