### PR TITLE
fix(fe): add fetch policy to useSuspenseQuery

### DIFF
--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/BelongedContestTable.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/BelongedContestTable.tsx
@@ -24,7 +24,9 @@ export function BelongedContestTable({
   const { data } = useSuspenseQuery(GET_BELONGED_CONTESTS, {
     variables: {
       problemId
-    }
+    },
+    // TODO: 필요시 refetch 하도록 수정
+    fetchPolicy: 'network-only'
   })
 
   useEffect(() => {

--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/ScoreCautionDialog.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/ScoreCautionDialog.tsx
@@ -7,7 +7,6 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/shadcn/dialog'
-import { GET_BELONGED_CONTESTS } from '@/graphql/contest/queries'
 import { UPDATE_CONTEST_PROBLEMS_SCORES } from '@/graphql/problem/mutations'
 import { useMutation } from '@apollo/client'
 import { Suspense, useState } from 'react'
@@ -30,15 +29,7 @@ export function ScoreCautionDialog({
   problemId
 }: ScoreCautionDialogProps) {
   const [updateContestsProblemsScores] = useMutation(
-    UPDATE_CONTEST_PROBLEMS_SCORES,
-    {
-      refetchQueries: [
-        {
-          query: GET_BELONGED_CONTESTS,
-          variables: { problemId }
-        }
-      ]
-    }
+    UPDATE_CONTEST_PROBLEMS_SCORES
   )
 
   const [zeroSetContests, setZeroSetContests] = useState<number[]>([])


### PR DESCRIPTION
### Description

refetchQueries 가 갑자기 안된다. 다시 fetch policy 추가 함

### Additional context


### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
