### PR TITLE
fix(fe): fix wrong testcase summary ui

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -201,11 +201,11 @@ function TestSummary({
 
   const notAcceptedTestcases = data
     .map((testcase) =>
-      testcase.result !== 'Accepted'
+      testcase.result !== 'Accepted' && testcase.result !== 'Judging'
         ? `${testcase.isUserTestcase ? 'User' : 'Sample'} #${testcase.id}`
-        : -1
+        : undefined
     )
-    .filter((index) => index !== -1)
+    .filter(Boolean)
 
   return (
     <table className="min-w-full">
@@ -216,16 +216,16 @@ function TestSummary({
             {acceptedCount}/{total}
           </td>
         </tr>
-        {notAcceptedTestcases.length > 0 && (
-          <tr>
-            <td className="w-52 py-1 align-top text-slate-400">
-              Wrong Testcase Number:
-            </td>
-            <td className="py-1 text-white">
-              {notAcceptedTestcases.join(', ')}
-            </td>
-          </tr>
-        )}
+        <tr>
+          <td className="w-52 py-1 align-top text-slate-400">
+            Wrong Testcase Number:
+          </td>
+          <td className="py-1 text-white">
+            {notAcceptedTestcases.length > 0
+              ? notAcceptedTestcases.join(', ')
+              : '-'}
+          </td>
+        </tr>
       </tbody>
     </table>
   )


### PR DESCRIPTION
### Description

Wrong Testcase Number를 보여줄 때 Judging 상태인 testcase들도 표시되는 문제를 픽스합니다.

**AS-IS**

https://github.com/user-attachments/assets/498cd529-1051-4f92-8bd7-bb3cbe7e39d7


**TO-BE**


https://github.com/user-attachments/assets/90bc4fef-1429-485e-8af2-4d8cda9a4b62



closes TAS-1087

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
