### PR TITLE
refactor(fe): change problem cards component to server component

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/ProblemCard.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/ProblemCard.tsx
@@ -1,8 +1,8 @@
 import '@/components/shadcn/card'
-import type { WorkbookProblem } from '@/types/type'
+import type { Problem } from '@/types/type'
 
 interface Props {
-  problem: WorkbookProblem
+  problem: Problem
 }
 
 export default function ProblemCard({ problem }: Props) {
@@ -14,7 +14,7 @@ export default function ProblemCard({ problem }: Props) {
           {problem.title}
         </div>
       </div>
-      <div className="border-t-2"></div>
+      <div className="border-t-2" />
       <div className="grid grid-cols-1 text-xs text-gray-500 min-[400px]:grid-cols-2">
         <div className="flex flex-col items-center gap-2 py-4">
           <p className="text-sm font-medium">Level</p>

--- a/apps/frontend/app/(client)/(main)/_components/ProblemCards.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/ProblemCards.tsx
@@ -1,78 +1,36 @@
-'use client'
-
-import { Skeleton } from '@/components/shadcn/skeleton'
-import { fetcher } from '@/libs/utils'
-import type { WorkbookProblem } from '@/types/type'
-import type { Route } from 'next'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { getProblemList } from '../../_libs/apis/problem'
 import ProblemCard from './ProblemCard'
 
-interface ProblemCardsProps {
-  data: WorkbookProblem[]
-  total: number
-}
-
-const getProblems = async () => {
-  const problemRes: ProblemCardsProps = await fetcher
-    .get('problem', {
-      searchParams: {
-        take: 3,
-        order: 'submit-desc'
-        // workbookId: 1
-      }
-    })
-    .json()
-
-  problemRes.data ?? console.error('4.getProblem', problemRes)
-  return problemRes.data ?? problemRes
-}
-
-export default function ProblemCards() {
-  const [problems, setProblems] = useState<WorkbookProblem[]>([])
-  const [loading, setLoading] = useState(true)
-  useEffect(() => {
-    getProblems().then((res) => {
-      setProblems(res)
-      setLoading(false)
-    })
-  }, [])
+export default async function ProblemCards() {
+  const { data: problems } = await getProblemList({
+    take: 3,
+    order: 'submit-desc'
+  })
 
   return (
     <>
       <div className="flex justify-start gap-5 md:hidden">
-        {loading
-          ? [...Array(2)].map((_, i) => (
-              <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
-            ))
-          : problems.slice(0, 2).map((problem) => {
-              return (
-                <Link
-                  key={problem.id}
-                  href={`/problem/${problem.id}` as Route}
-                  className="inline-block w-1/2"
-                >
-                  <ProblemCard problem={problem} />
-                </Link>
-              )
-            })}
+        {problems.slice(0, 2).map((problem) => (
+          <Link
+            key={problem.id}
+            href={`/problem/${problem.id}`}
+            className="inline-block w-1/2"
+          >
+            <ProblemCard problem={problem} />
+          </Link>
+        ))}
       </div>
       <div className="hidden justify-start gap-5 md:flex">
-        {loading
-          ? [...Array(3)].map((_, i) => (
-              <Skeleton key={i} className="flex h-[120px] w-full rounded-xl" />
-            ))
-          : problems.map((problem) => {
-              return (
-                <Link
-                  key={problem.id}
-                  href={`/problem/${problem.id}` as Route}
-                  className="inline-block w-1/3"
-                >
-                  <ProblemCard problem={problem} />
-                </Link>
-              )
-            })}
+        {problems.map((problem) => (
+          <Link
+            key={problem.id}
+            href={`/problem/${problem.id}`}
+            className="inline-block w-1/3"
+          >
+            <ProblemCard problem={problem} />
+          </Link>
+        ))}
       </div>
     </>
   )

--- a/apps/frontend/app/(client)/(main)/page.tsx
+++ b/apps/frontend/app/(client)/(main)/page.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@/components/shadcn/button'
-import type { Route } from 'next'
 import Link from 'next/link'
 import Carousel from './_components/Carousel'
 import ContestCards from './_components/ContestCards'
@@ -62,7 +61,7 @@ export default function Home() {
       <div className="flex w-full flex-col gap-6">
         <div className="flex items-center justify-between text-gray-700">
           <p className="text-2xl font-bold">Contest 🏆</p>
-          <Link href={'/contest' as Route}>
+          <Link href={'/contest'}>
             <Button variant="ghost" className="h-8 px-3">
               See More
             </Button>
@@ -74,12 +73,13 @@ export default function Home() {
       <div className="flex w-full flex-col gap-6">
         <div className="flex items-center justify-between text-gray-700">
           <p className="text-2xl font-bold">Problem ✨</p>
-          <Link href={'/problem' as Route}>
+          <Link href={'/problem'}>
             <Button variant="ghost" className="h-8 px-3">
               See More
             </Button>
           </Link>
         </div>
+        {/**TODO: add error boundary */}
         <ProblemCards />
       </div>
     </div>

--- a/apps/frontend/app/(client)/(main)/problem/_components/Columns.tsx
+++ b/apps/frontend/app/(client)/(main)/problem/_components/Columns.tsx
@@ -33,10 +33,5 @@ export const columns: ColumnDef<Problem>[] = [
     header: () => <SortButton order="acrate">Success Rate</SortButton>,
     accessorKey: 'acceptedRate',
     cell: ({ row }) => `${(row.original.acceptedRate * 100).toFixed(2)}%`
-  },
-  {
-    header: 'Info',
-    accessorKey: 'info',
-    cell: ({ row }) => row.original.info
   }
 ]

--- a/apps/frontend/app/(client)/_libs/apis/problem.ts
+++ b/apps/frontend/app/(client)/_libs/apis/problem.ts
@@ -4,7 +4,7 @@ import type { PaginationQueryParams } from './types'
 
 export interface GetProblemListRequest extends PaginationQueryParams {
   search?: string
-  order?: string
+  order: string
 }
 
 export interface GetProblemListResponse {
@@ -14,7 +14,7 @@ export interface GetProblemListResponse {
 
 export const getProblemList = async ({
   ...searchParams
-}: GetProblemListRequest = {}) => {
+}: GetProblemListRequest) => {
   const response = await safeFetcher.get('problem', {
     searchParams
   })

--- a/apps/frontend/app/(client)/_libs/apis/problem.ts
+++ b/apps/frontend/app/(client)/_libs/apis/problem.ts
@@ -1,0 +1,24 @@
+import { safeFetcher } from '@/libs/utils'
+import type { Problem } from '@/types/type'
+import type { PaginationQueryParams } from './types'
+
+export interface GetProblemListRequest extends PaginationQueryParams {
+  search?: string
+  order?: string
+}
+
+export interface GetProblemListResponse {
+  data: Problem[]
+  total: number
+}
+
+export const getProblemList = async ({
+  ...searchParams
+}: GetProblemListRequest = {}) => {
+  const response = await safeFetcher.get('problem', {
+    searchParams
+  })
+  const data = await response.json<GetProblemListResponse>()
+
+  return data
+}

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -32,8 +32,9 @@ export interface Problem {
   difficulty: Level
   submissionCount: number
   acceptedRate: number
-  tags?: Tag[]
-  info?: string
+  tags: Tag[]
+  languages: Language[]
+  hasPassed: boolean | null
 }
 
 /**
@@ -45,11 +46,16 @@ export interface WorkbookProblem extends Omit<Problem, 'tags' | 'info'> {
   order: number
 }
 
-export interface ContestProblem extends Omit<Problem, 'tags' | 'info'> {
+export interface ContestProblem {
+  id: number
+  title: number
+  difficulty: Level
   order: number
+  submissionCount: number
   maxScore: number
   score: string | null
   submissionTime: string | null
+  acceptedRate: number
 }
 
 export interface TestcaseItem {


### PR DESCRIPTION
### Description

- `ProblemCards` 컴포넌트를 서버 컴포넌트로 변경합니다. (`useEffect` 제거)
- 타입 수정: `Problem` 타입과 `ContestProblem` 타입이 서로 의존하지 않도록 분리하고, Bruno에서 테스트한 대로 타입 수정합니다.
- Problem 테이블에서 info 컬럼 삭제합니다. (백엔드 응답에 `info`가 없고, 피그마에도 이 컬럼이 없어서 삭제했습니다.)


closes TAS-1094

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
