### PR TITLE
fix(infra): change iris spec for stability in parellel grading

### DIFF
--- a/apps/infra/production/codedang/codedang_iris.tf
+++ b/apps/infra/production/codedang/codedang_iris.tf
@@ -12,7 +12,7 @@ module "codedang_iris" {
   autoscaling_group = {
     name             = "Codedang-AutoScalingGroup-Iris"
     max_size         = 4
-    desired_capacity = 1
+    desired_capacity = 2
   }
 
   autoscaling_policy = {

--- a/apps/infra/production/codedang/codedang_service_iris.tf
+++ b/apps/infra/production/codedang/codedang_service_iris.tf
@@ -31,7 +31,7 @@ module "iris" {
   task_definition = {
     family = "Codedang-Iris-Api"
     cpu    = 512
-    memory = 512
+    memory = 1700
 
     container_definitions = jsonencode([
       jsondecode(templatefile("container_definitions/iris.json", {

--- a/apps/infra/production/codedang/modules/service_autoscaling/appautoscaling_scale_up.tf
+++ b/apps/infra/production/codedang/modules/service_autoscaling/appautoscaling_scale_up.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
   evaluation_periods  = 1
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = 60
+  period              = 30
   statistic           = var.scale_up.cloudwatch_metric_alarm.statistic
   threshold           = var.scale_up.cloudwatch_metric_alarm.threshold
 


### PR DESCRIPTION
### Description
가정 : 128MB 메모리제한 문제, 시간제한 2~3초, 테스트케이스 10개 이내. 
128MB 메모리제한이고 테스트케이스 10개를 가진 문제에 대해 안정적인 채점을 체공하려면, **IRIS 컨테이너는 1.28GB 이상의 메모리를 가져야 합니다.** 

이에 따라 IRIS 컨테이너 스펙을 조정합니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
