### PR TITLE
fix(iris): enforce sandbox child process belongs to nobody-user(65534…

### DIFF
--- a/apps/iris/src/common/constants/constants.go
+++ b/apps/iris/src/common/constants/constants.go
@@ -53,3 +53,6 @@ const (
 	EXCHANGE   = "judger-exchange"
 	RESULT_KEY = "result"
 )
+
+const DEFAULT_UID = 65534 // nobody user
+const DEFAULT_GID = 65534 // nobody group

--- a/apps/iris/src/service/sandbox/langConfig.go
+++ b/apps/iris/src/service/sandbox/langConfig.go
@@ -262,6 +262,8 @@ func (l *langConfig) ToRunExecArgs(dir string, language Language, order int, lim
 		ErrorPath:       errorPath, // byte buffer로
 		LogPath:         constants.RUN_LOG_PATH,
 		SeccompRuleName: c.SeccompRule,
+		Uid:             constants.DEFAULT_UID,
+		Gid:             constants.DEFAULT_GID,
 		Args:            argSlice,
 	}, nil
 }


### PR DESCRIPTION
### Description
Iris에서 sanbox로 보내는 args중 uid gid를 nobody user(65534)로 설정하여
사용자가 제출한 코드가 Iris 컨테이너 내 파일에 접근하는 것을 제한합니다.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
