### PR TITLE
revert(cd): revert node image version from 20.18.1 to 20.18.0

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -5,7 +5,7 @@
 ARG target=client
 ARG app_env=production
 
-FROM node:20.18.1-alpine AS builder
+FROM node:20.18.0-alpine AS builder
 ARG target
 
 COPY . /build
@@ -19,7 +19,7 @@ RUN npx prisma generate
 RUN npm run build ${target}
 
 ### PRODUCTION ###
-FROM node:20.18.1-alpine
+FROM node:20.18.0-alpine
 ARG target
 ARG app_env
 


### PR DESCRIPTION
### Description
Alpine Linux 3.21를 base image로 하는 node 20.18.1-alpine version과 
prisma 5.x 호환성 문제로 node.20.18.0으로 revert합니다.
관련 이슈: https://github.com/prisma/prisma/issues/25817

prisma 6.x에서 문제가 해결되었으며, 
https://github.com/skkuding/codedang/pull/2275 에서 node 버전도 같이 업그레이드할 수 있게 하겠습니다.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
