### PR TITLE
fix(fe): add temporary tabs for contest page

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
@@ -1,0 +1,3 @@
+export default function ContestLeaderBoard() {
+  return <div>Temporary LeaderBoard Tab</div>
+}

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/notice/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/notice/page.tsx
@@ -1,0 +1,3 @@
+export default function ContestNotice() {
+  return <div>Temporary Notice Tab</div>
+}

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/page.tsx
@@ -1,0 +1,3 @@
+export default function ContestQna() {
+  return <div>Temporary Q&A Tab</div>
+}

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/statistics/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/statistics/page.tsx
@@ -1,0 +1,3 @@
+export default function ContestStatistics() {
+  return <div>Temporary Statistics Tab</div>
+}

--- a/apps/frontend/app/(client)/(main)/contest/_components/ContestTabs.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/_components/ContestTabs.tsx
@@ -18,17 +18,53 @@ export default function ContestTabs({ contestId }: { contestId: string }) {
 
   return (
     <div className="flex justify-center gap-[130px] border-b-2 border-gray-300 pb-4">
-      <div className="flex w-full md:w-3/5">
+      <div className="flex w-full text-[#333333] md:w-3/5">
         <Link
           href={`/contest/${id}` as Route}
           className={cn(
-            'flex w-1/2 justify-center text-lg text-gray-400',
+            'flex w-1/2 justify-center text-lg',
             isCurrentTab('') && 'text-primary'
           )}
         >
-          Info
+          Overview
         </Link>
         <Link
+          href={`/contest/${id}/notice` as Route}
+          className={cn(
+            'flex w-1/2 justify-center text-lg',
+            isCurrentTab('notice') && 'text-primary'
+          )}
+        >
+          Notice
+        </Link>
+        <Link
+          href={`/contest/${id}/leaderboard` as Route}
+          className={cn(
+            'flex w-1/2 justify-center text-lg',
+            isCurrentTab('leaderboard') && 'text-primary'
+          )}
+        >
+          Leaderboard
+        </Link>
+        <Link
+          href={`/contest/${id}/statistics` as Route}
+          className={cn(
+            'flex w-1/2 justify-center text-lg',
+            isCurrentTab('statistics') && 'text-primary'
+          )}
+        >
+          Statistics
+        </Link>
+        <Link
+          href={`/contest/${id}/qna` as Route}
+          className={cn(
+            'flex w-1/2 justify-center text-lg',
+            isCurrentTab('qna') && 'text-primary'
+          )}
+        >
+          Q&A
+        </Link>
+        {/* <Link
           href={`/contest/${id}/problem` as Route}
           className={cn(
             'flex w-1/2 justify-center text-lg text-gray-400',
@@ -36,7 +72,7 @@ export default function ContestTabs({ contestId }: { contestId: string }) {
           )}
         >
           Problem
-        </Link>
+        </Link> */}
         {/* <Link
           href={`/contest/${id}/announcement` as Route}
           className={cn(


### PR DESCRIPTION
### Description

- Contest user 페이지 새로운 디자인 반영을 위해서 우선 Contest Tabs 5개로 늘림
  - Overview, Notice, Leaderboard, Statistics, Q&A
- 우선 Overview 먼저 작업 예정이라서 나머지 4개의 탭은 밑에와 같이 임시로 'Temporary ~~' 문구 추가해놓았습니다.
<img width="1728" alt="스크린샷 2025-01-13 오후 9 48 00" src="https://github.com/user-attachments/assets/8a763e63-d0e6-4e89-b273-eb5ef7995f2d" />

### Additional context

closes TAS-1177

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
