### PR TITLE
fix(fe): resolve bug blocking contest creation without invitation code

### DIFF
--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -64,6 +64,7 @@ export default function Page() {
   const methods = useForm<CreateContestInput>({
     resolver: valibotResolver(createSchema),
     defaultValues: {
+      invitationCode: null,
       isRankVisible: true,
       isVisible: true,
       enableCopyPaste: false,


### PR DESCRIPTION
### Description
문제 상황
create contest 스키마에서 `invitationCode`가 `nullable`로 설정되어 있었지만, 
초기값이 없어 `undefined`로 처리되고 있었습니다. 
이로 인해 `invitationCode`가 없을 때, 유효성 검사가 통과되지 못합니다.

해결 방법
초기에는 `nullable`을 `nullish`로 변경하는 방법을 고려했으나,
`invitationCode`의 초기값을 명시적으로 `null`로 설정하는 방식으로 해결했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
