### PR TITLE
refactor(fe): use tanstack query for settings page

### DIFF
--- a/apps/frontend/app/(client)/(main)/settings/_components/MajorSection.tsx
+++ b/apps/frontend/app/(client)/(main)/settings/_components/MajorSection.tsx
@@ -19,12 +19,15 @@ import React from 'react'
 import { FaChevronDown, FaCheck } from 'react-icons/fa6'
 import { useSettingsContext } from './context'
 
-export default function MajorSection() {
+interface MajorSectionProps {
+  major: string
+}
+
+export default function MajorSection({ major }: MajorSectionProps) {
   const {
     isLoading,
     updateNow,
-    majorState: { majorOpen, setMajorOpen, majorValue, setMajorValue },
-    defaultProfileValues
+    majorState: { majorOpen, setMajorOpen, majorValue, setMajorValue }
   } = useSettingsContext()
 
   const getMajorDisplayValue = () => {
@@ -34,7 +37,7 @@ export default function MajorSection() {
         : majorValue
     }
 
-    return majorValue || defaultProfileValues.major
+    return majorValue || major // 외부에서 받은 major를 사용
   }
 
   return (
@@ -55,7 +58,7 @@ export default function MajorSection() {
                       ? 'border-red-500 text-neutral-400'
                       : 'border-primary'
                   }
-                  return majorValue === defaultProfileValues.major
+                  return majorValue === major
                     ? 'text-neutral-400'
                     : 'border-primary'
                 })()

--- a/apps/frontend/app/(client)/(main)/settings/_components/SaveButton.tsx
+++ b/apps/frontend/app/(client)/(main)/settings/_components/SaveButton.tsx
@@ -4,11 +4,13 @@ import { useSettingsContext } from './context'
 interface SaveButtonProps {
   saveAbleUpdateNow: boolean
   saveAble: boolean
+  isLoading: boolean // 로딩 상태 추가
   onSubmitClick: () => void
 }
 
 export default function SaveButton({
   saveAbleUpdateNow,
+  isLoading,
   saveAble,
   onSubmitClick
 }: SaveButtonProps) {
@@ -22,7 +24,8 @@ export default function SaveButton({
         className="font-semibold disabled:bg-neutral-300 disabled:text-neutral-500"
         onClick={onSubmitClick}
       >
-        Save
+        {isLoading ? 'Saving...' : 'Save'}{' '}
+        {/* 로딩 상태에 따라 버튼 텍스트 변경 */}
       </Button>
     </div>
   )

--- a/apps/frontend/app/(client)/(main)/settings/page.tsx
+++ b/apps/frontend/app/(client)/(main)/settings/page.tsx
@@ -1,14 +1,10 @@
 'use client'
 
-//import { safeFetcherWithAuth } from '@/libs/utils'
 import type { SettingsFormat } from '@/types/type'
 import { zodResolver } from '@hookform/resolvers/zod'
-//import { useSuspenseQuery, useMutation } from '@tanstack/react-query'
 import { useRouter, useSearchParams } from 'next/navigation'
-//import { useEffect, useRef } from 'react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
-//import type { UseFormRegister } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   useFetchUserProfileSuspense,
@@ -53,7 +49,7 @@ export default function Page() {
   } = useForm<SettingsFormat>({
     resolver: zodResolver(schemaSettings(Boolean(updateNow))),
     mode: 'onChange',
-    defaultValues: {} // 초기 값을 비워둠
+    defaultValues: {}
   })
 
   const realName = watch('realName')
@@ -69,7 +65,7 @@ export default function Page() {
     setValue('newPassword', '')
     setValue('confirmPassword', '')
   }
-  // 패스워드 상태 관리
+
   const [passwordShow, setPasswordShow] = useState(false)
   const [newPasswordShow, setNewPasswordShow] = useState(false)
   const [confirmPasswordShow, setConfirmPasswordShow] = useState(false)
@@ -82,7 +78,6 @@ export default function Page() {
   } = useCheckPassword(defaultProfileValues, currentPassword)
   const isPasswordsMatch = newPassword === confirmPassword && newPassword !== ''
 
-  // Context value 정의
   const settingsContextValue: SettingsContextType = {
     defaultProfileValues,
     passwordState: {
@@ -100,8 +95,8 @@ export default function Page() {
       setMajorValue: () => {}
     },
     formState: {
-      register, // useForm에서 가져온 register
-      errors // useForm에서 가져온 errors
+      register,
+      errors
     },
     updateNow: Boolean(updateNow),
     isLoading: false
@@ -177,9 +172,9 @@ export default function Page() {
             <StudentIdSection studentId={studentId} />
             <MajorSection major={defaultProfileValues?.major ?? ''} />
             <SaveButton
-              saveAbleUpdateNow={Boolean(realName || studentId)} // 업데이트 가능한지 여부
+              saveAbleUpdateNow={Boolean(realName || studentId)}
               saveAble={Boolean(realName || studentId)}
-              isLoading={isLoading} // 로딩 상태 전달
+              isLoading={isLoading}
               onSubmitClick={() => console.log('Submitting form...')}
             />
           </form>

--- a/apps/frontend/app/(client)/(main)/settings/page.tsx
+++ b/apps/frontend/app/(client)/(main)/settings/page.tsx
@@ -23,11 +23,8 @@ import StudentIdSection from './_components/StudentIdSection'
 import TopicSection from './_components/TopicSection'
 import { SettingsProvider } from './_components/context'
 import type { SettingsContextType } from './_components/context'
-//import type { Profile } from './_components/context'
 import { useCheckPassword } from './_libs/hooks/useCheckPassword'
 import { schemaSettings } from './_libs/schemas'
-
-//import { useConfirmNavigation } from './_libs/utils'
 
 export default function Page() {
   const searchParams = useSearchParams()
@@ -66,7 +63,6 @@ export default function Page() {
     setValue('confirmPassword', '')
   }
 
-  const [passwordShow, setPasswordShow] = useState(false)
   const [newPasswordShow, setNewPasswordShow] = useState(false)
   const [confirmPasswordShow, setConfirmPasswordShow] = useState(false)
 
@@ -82,7 +78,7 @@ export default function Page() {
     defaultProfileValues,
     passwordState: {
       passwordShow: false,
-      setPasswordShow,
+      setPasswordShow: () => {},
       newPasswordShow,
       setNewPasswordShow,
       confirmPasswordShow,

--- a/apps/frontend/app/(client)/_libs/apis/settings.ts
+++ b/apps/frontend/app/(client)/_libs/apis/settings.ts
@@ -1,0 +1,22 @@
+import { safeFetcherWithAuth } from '@/libs/utils'
+
+export interface Profile {
+  username: string // ID
+  userProfile: {
+    realName: string
+  }
+  studentId: string
+  major: string
+}
+
+export const fetchUserProfile = async (): Promise<Profile> => {
+  return await safeFetcherWithAuth.get('user').json()
+}
+
+export const updateUserProfile = async (
+  updatePayload: Partial<Profile & { password?: string; newPassword?: string }>
+): Promise<Response> => {
+  return await safeFetcherWithAuth.patch('user', {
+    json: updatePayload
+  })
+}

--- a/apps/frontend/app/(client)/_libs/queries/settings.ts
+++ b/apps/frontend/app/(client)/_libs/queries/settings.ts
@@ -1,0 +1,19 @@
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query'
+import { fetchUserProfile, updateUserProfile } from '../apis/settings'
+
+//import type { Profile } from '../apis/settings'
+
+// 쿼리 키 관리
+
+export const useFetchUserProfileSuspense = () => {
+  return useSuspenseQuery({
+    queryKey: ['userProfile'],
+    queryFn: fetchUserProfile
+  })
+}
+
+export const useUpdateUserProfile = () => {
+  return useMutation({
+    mutationFn: updateUserProfile
+  })
+}

--- a/apps/frontend/app/(client)/_libs/queries/settings.ts
+++ b/apps/frontend/app/(client)/_libs/queries/settings.ts
@@ -1,10 +1,6 @@
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query'
 import { fetchUserProfile, updateUserProfile } from '../apis/settings'
 
-//import type { Profile } from '../apis/settings'
-
-// 쿼리 키 관리
-
 export const useFetchUserProfileSuspense = () => {
   return useSuspenseQuery({
     queryKey: ['userProfile'],


### PR DESCRIPTION
### Description

리팩토링 목적: useEffect를 포함한 API 호출 로직을 Tanstack Query로 관리하기

### Additional context

리팩토링 과정에서 기능 작동이 안되는 부분들이 있습니다 ...! 계속 수정 중인데 해결이 잘 안돼서 우선 PR 올려서 진행상황 공유드립니다!

closes TAS-1089


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
