### PR TITLE
refactor(fe): use tanstack query for settings page

### DIFF
--- a/apps/frontend/app/(client)/(main)/settings/_libs/apis/profile.ts
+++ b/apps/frontend/app/(client)/(main)/settings/_libs/apis/profile.ts
@@ -1,0 +1,22 @@
+import { safeFetcherWithAuth } from '@/libs/utils'
+
+export interface Profile {
+  username: string // ID
+  userProfile: {
+    realName: string
+  }
+  studentId: string
+  major: string
+}
+
+export const fetchUserProfile = async (): Promise<Profile> => {
+  return await safeFetcherWithAuth.get('user').json()
+}
+
+export const updateUserProfile = async (
+  updatePayload: Partial<Profile & { password?: string; newPassword?: string }>
+): Promise<Response> => {
+  return await safeFetcherWithAuth.patch('user', {
+    json: updatePayload
+  })
+}

--- a/apps/frontend/app/(client)/(main)/settings/_libs/queries/profile.ts
+++ b/apps/frontend/app/(client)/(main)/settings/_libs/queries/profile.ts
@@ -1,0 +1,15 @@
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query'
+import { fetchUserProfile, updateUserProfile } from '../apis/profile'
+
+export const useFetchUserProfileSuspense = () => {
+  return useSuspenseQuery({
+    queryKey: ['userProfile'],
+    queryFn: fetchUserProfile
+  })
+}
+
+export const useUpdateUserProfile = () => {
+  return useMutation({
+    mutationFn: updateUserProfile
+  })
+}


### PR DESCRIPTION
### Description

리팩토링 목적: useEffect를 포함한 API 호출 로직을 Tanstack Query로 관리하기

### Additional context

- 브랜치를 옮겼습니다. 
- 비밀번호 수정 과정에서 새 비밀번호를 재입력 할 때 다음과 같은 에러가 발생합니다. 

Failed to Load Main Page!

Too many re-renders. React limits the number of renders to prevent an infinite loop.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
