### PR TITLE
fix(fe): align banner top margin with header height

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/Cover.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/Cover.tsx
@@ -26,7 +26,7 @@ const icons: { [key: string]: string } = {
 export default function Cover({ title, description }: CoverProps) {
   return (
     <div className="w-screen">
-      <div className="absolute left-0 top-0 z-[10] h-16 w-full bg-white" />
+      <div className="absolute left-0 top-0 z-[10] h-14 w-full bg-white" />
       <div
         className={cn(
           bgColors[title.toLowerCase()],


### PR DESCRIPTION
### Description

배너 위 여백과 헤더의 height가 일치하지 않아 헤더의 디자인이 좋지 않게 보인다는 의견이 많아,
사용자 페이지의 배너 위 여백을 헤더와 일치하게 변경합니다.

AS-IS:
![image](https://github.com/user-attachments/assets/c2b89e5c-7a6d-4e8c-b260-9f298cace889)

TO-BE:
![image](https://github.com/user-attachments/assets/d3286cc7-a0b0-4e88-9639-5fa9ab18228b)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
