### PR TITLE
chore(fe): use turbo

### DIFF
--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -6,8 +6,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    typedRoutes: true,
-    instrumentationHook: true
+    typedRoutes: process.env.NODE_ENV !== 'development',
+    instrumentationHook: process.env.NODE_ENV !== 'development'
   },
   output: 'standalone',
   env: {
@@ -15,8 +15,7 @@ const nextConfig = {
   }
 }
 
-// Injected content via Sentry wizard below
-module.exports = withSentryConfig(withBundleAnalyzer(nextConfig), {
+const sentryConfig = {
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options
 
@@ -48,4 +47,9 @@ module.exports = withSentryConfig(withBundleAnalyzer(nextConfig), {
   // https://docs.sentry.io/product/crons/
   // https://vercel.com/docs/cron-jobs
   automaticVercelMonitors: true
-})
+}
+
+module.exports =
+  process.env.NODE_ENV === 'development'
+    ? withBundleAnalyzer(nextConfig)
+    : withSentryConfig(withBundleAnalyzer(nextConfig), sentryConfig)

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,7 @@
     "**/*.css"
   ],
   "scripts": {
-    "dev": "next dev -p 5525",
+    "dev": "next dev -p 5525 --turbo",
     "build": "pnpm run compile && next build",
     "analyze": "ANALYZE=true pnpm build",
     "start": "next start --keepAliveTimeout 70000",


### PR DESCRIPTION
### Description
작은 **pnpm dev 성능 비교** 실험
환경: Window OS, RAM 16GB, CPU 11th Gen Intel(R) Core(TM) i7

**실험 결과**
1. 기존
Ready까지 평균 6.1초, 처음 GET / 까지 평균 34.607

2. instrumentation만 제거
Ready까지 평균 1.66초, 처음 GET / 까지 평균 33.51

4. turbo만 적용
Ready까지 평균 3.2초, 처음 GET / 까지 평균 10.70

5. instrumentation 제거 + turbo 적용
Ready까지 평균 1.51초, 처음 GET / 까지 평균 11.08

**결론**
결과적으로 Ready 시간은 약 75% 감소했고, GET /  시간은 68% 감소했습니다. Ready까지의 시간 단축은 instrumentation 방지, GET /의 시간은 turopack 사용이 큰 영향을 미쳤습니다.



### Additional context

회의 때 말한 instrumentation.ts 관련 warining 문제는 turbo 활성화하니 나오지 않아서 따로 처리 하지는 않았습니다. 

+) turbopack이 지금 베타여서 기능이 온전하지 않을 수 있으니, 개발 중 수정하지 않은 부분에서 의문사한다면 --turbo 옵션을 제외하고 다시 해보길 추천드립니다! frontend/package.json의 scrpit 중 dev에서 `--turbo` 옵션만 지우면 됩니다

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
