### PR TITLE
chore(infra): record coolify caddy changes and apply dns-01 challenge as acme protocol

### DIFF
--- a/apps/infra/stage/coolify/caddy/Dockerfile
+++ b/apps/infra/stage/coolify/caddy/Dockerfile
@@ -1,0 +1,14 @@
+# Not included in CI/CD. Should be built manually
+
+ARG CADDY_VERSION=2.8.4
+FROM caddy:${CADDY_VERSION}-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2 \
+    --with github.com/caddy-dns/route53
+
+FROM caddy:${CADDY_VERSION}-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+CMD ["caddy", "docker-proxy"]

--- a/apps/infra/stage/coolify/caddy/acme-challenge.caddy
+++ b/apps/infra/stage/coolify/caddy/acme-challenge.caddy
@@ -1,13 +1,13 @@
-// Not included in CI/CD. Should be added in coolify manually
+# Not included in CI/CD. Should be added in coolify manually
 
 *.coolify.codedang.com, coolify.codedang.com {
     tls {
         dns route53 {
-            wait_for_propagation true // should be set true
-            # access_key_id $AWS_ACCESS_KEY_ID // $AWS_ACCESS_KEY_ID should be set as environmental variable in coolify's docker-compose.yml
-            # secret_access_key $AWS_SECRET_ACCESS_KEY // $AWS_SECRET_ACCESS_KEY should be set as environmental variable in coolify's docker-compose.yml
-            # region $AWS_REGION // $AWS_REGION should be set as environmental variable in coolify's docker-compose.yml
+            wait_for_propagation true # should be set true
+            # access_key_id $AWS_ACCESS_KEY_ID # $AWS_ACCESS_KEY_ID should be set as environmental variable in coolify's docker-compose.yml
+            # secret_access_key $AWS_SECRET_ACCESS_KEY # $AWS_SECRET_ACCESS_KEY should be set as environmental variable in coolify's docker-compose.yml
+            # region $AWS_REGION # $AWS_REGION should be set as environmental variable in coolify's docker-compose.yml
         }
     }
-    reverse_proxy localhost:5525 // route to frontend stage/preview deployments.
+    reverse_proxy localhost:5525 # route to frontend stage/preview deployments.
 }

--- a/apps/infra/stage/coolify/caddy/acme-challenge.caddy
+++ b/apps/infra/stage/coolify/caddy/acme-challenge.caddy
@@ -1,0 +1,13 @@
+// Not included in CI/CD. Should be added in coolify manually
+
+*.coolify.codedang.com {
+    tls {
+        dns route53 {
+            wait_for_propagation true // should be set true
+            # access_key_id $AWS_ACCESS_KEY_ID // $AWS_ACCESS_KEY_ID should be set as environmental variable in coolify
+            # secret_access_key $AWS_SECRET_ACCESS_KEY // $AWS_SECRET_ACCESS_KEY should be set as environmental variable in coolify
+            # region "us-east-1" // $AWS_REGION should be set as environmental variable in coolify
+        }
+    }
+    reverse_proxy localhost:5525 // route to frontend stage/preview deployments.
+}

--- a/apps/infra/stage/coolify/caddy/acme-challenge.caddy
+++ b/apps/infra/stage/coolify/caddy/acme-challenge.caddy
@@ -1,12 +1,12 @@
 // Not included in CI/CD. Should be added in coolify manually
 
-*.coolify.codedang.com {
+*.coolify.codedang.com, coolify.codedang.com {
     tls {
         dns route53 {
             wait_for_propagation true // should be set true
-            # access_key_id $AWS_ACCESS_KEY_ID // $AWS_ACCESS_KEY_ID should be set as environmental variable in coolify
-            # secret_access_key $AWS_SECRET_ACCESS_KEY // $AWS_SECRET_ACCESS_KEY should be set as environmental variable in coolify
-            # region "us-east-1" // $AWS_REGION should be set as environmental variable in coolify
+            # access_key_id $AWS_ACCESS_KEY_ID // $AWS_ACCESS_KEY_ID should be set as environmental variable in coolify's docker-compose.yml
+            # secret_access_key $AWS_SECRET_ACCESS_KEY // $AWS_SECRET_ACCESS_KEY should be set as environmental variable in coolify's docker-compose.yml
+            # region $AWS_REGION // $AWS_REGION should be set as environmental variable in coolify's docker-compose.yml
         }
     }
     reverse_proxy localhost:5525 // route to frontend stage/preview deployments.

--- a/apps/infra/stage/coolify/caddy/docker-compose.yml
+++ b/apps/infra/stage/coolify/caddy/docker-compose.yml
@@ -1,0 +1,31 @@
+networks:
+  coolify:
+    external: true
+services:
+  caddy:
+    container_name: coolify-proxy
+    image: 'jimin9038/caddy-docker-proxy-with-route53'
+    restart: unless-stopped
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      - CADDY_DOCKER_POLLING_INTERVAL=5s
+      - CADDY_DOCKER_CADDYFILE_PATH=/dynamic/Caddyfile
+      # For using DNS-01 challenge in Caddy, make an access key having access to use route53 - see: https://github.com/libdns/route53
+      - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+      - AWS_REGION=us-east-1
+    networks:
+      - coolify
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    labels:
+      - coolify.managed=true
+      - coolify.proxy=true
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/data/coolify/proxy/caddy/dynamic:/dynamic'
+      - '/data/coolify/proxy/caddy/config:/config'
+      - '/data/coolify/proxy/caddy/data:/data'


### PR DESCRIPTION
### Description

서버 1에서 돌아가는 Coolify의 리버스 프록시인 Caddy의 설정을 기록하고, 
TLS certificate를 얻기 위한 세 가지 ACME Challenge 중 HTTP challenge나 TLS-ALPN challenge가 아닌 DNS Challenge를 이용하도록 변경합니다. (참고: [Caddy ACME Challenges](https://caddyserver.com/docs/automatic-https#acme-challenges))

Route53에서 DNS를 사용하기 위해 Dockerfile로 caddy-dns/route53 모듈을 설치하여 Caddy 이미지를 새로 빌드하고, 이를 기반으로 컨테이너를 띄웁니다. acme-challenge.caddy를 dynamic configure으로 caddy에 추가하여 DNS-01 challenge를 사용합니다. 

참고: Caddy wiki - [How to use DNS provider modules in Caddy 2](https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148)

Closes TAS-1228
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

- Caddy는 기본적으로 https://caddyserver.com/docs/automatic-https#dns-challenge 에 언급되어 있는 것처럼, 세 가지의 ACME Challenge를 사용할 수 있습니다.

### 기존 Challenge (HTTP challenge, TLS-ALPN challenge)들의 문제점

- HTTP challenge와 TLS-ALPN challenge는 다음과 같은 이유에서 비효율적이라고 판단되었습니다:
    - Caddy 로그를 확인해보았을 때 HTTP-01 챌린지와 TLS-ALPN-01 챌린지는 실패하여 재시도한 적이 많습니다. Let's encrypt의 ACME 서버는 CloudFlare의 넓은 IP 대역폭에서 실행되며, IP 기반 방화벽에 막혀왔을 가능성이 있습니다. )
        - 저희의 80 / 443번 포트는 개방되어 있기는 하지만, 학교 방화벽을 통해서 들어오기 때문에 차단당할 가능성이 있습니다.
    - HTTP-01과 TLS-ALPN-01은 개별 도메인 이름(예: `sub.example.com`)에 대해서만 인증서를 발급할 수 있습니다. 따라서 매 Frontend Preview 배포가 일어날때마다 인증서를 발급받아야 합니다.

### DNS Challenge를 사용하는 이유

### 1. **와일드카드 인증서 발급 가능**

- DNS-01 챌린지는 와일드카드 인증서(예: `.example.com`) 발급이 가능한 유일한 방식입니다.
    - HTTP-01과 TLS-ALPN-01은 개별 도메인 이름(예: `coolify.codedang.com`)에 대해서만 인증서를 발급할 수 있습니다.
    - 와일드카드 인증서를 사용하면 새로운 서브도메인 추가 시 인증서를 다시 발급받을 필요 없이, 기존 인증서를 재사용할 수 있습니다.
    - 따라서, `{pr-id}.coolify.codedang.com` 을 기준으로 Preview 배포가 일어나는 프론트엔드 배포가 일어나는 저희의 상황에서, `*.coolify.codedang.com`에 대해서 인증서를 발급받으면, 매 Preview 배포마다 인증서를 발급받을 필요가 없습니다. 

### 2. **방화벽 및 네트워크 제한에 독립적**

- DNS-01 챌린지는 도메인의 **DNS TXT 레코드**를 추가하여 소유권을 증명하므로, HTTP 또는 HTTPS 포트(80/443)에 대한 외부 접근이 필요하지 않습니다.
- 학교, 기업, 또는 네트워크 제한이 있는 환경에서도 작동합니다. 
(HTTP나 TLS 챌린지처럼 인증 기관이 저희 서버에 접속하지 않아도 괜찮습니다.)
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
