### PR TITLE
feat(fe): copy FinishedTableColumns.tsx from contest to course

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/_components/FinishedAssignmentTable.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/FinishedAssignmentTable.tsx
@@ -2,7 +2,7 @@ import { DataTable } from '@/app/(client)/(main)/_components/DataTable'
 import { fetcher, fetcherWithAuth } from '@/libs/utils'
 import type { Contest } from '@/types/type'
 import type { Session } from 'next-auth'
-import { columns } from '../../contest/_components/FinishedTableColumns'
+import { columns } from './FinishedTableColumns'
 
 interface ContestProps {
   data: Contest[]

--- a/apps/frontend/app/(client)/(main)/course/_components/FinishedTableColumns.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/FinishedTableColumns.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { dateFormatter } from '@/libs/utils'
+import checkIcon from '@/public/icons/check-gray.svg'
+import type { Contest } from '@/types/type'
+import type { ColumnDef } from '@tanstack/react-table'
+import Image from 'next/image'
+
+export const columns: ColumnDef<Contest>[] = [
+  {
+    header: 'Title',
+    accessorKey: 'title',
+    cell: ({ row }) => (
+      <p className="overflow-hidden text-ellipsis whitespace-nowrap text-left text-sm md:text-base">
+        {row.original.title}
+      </p>
+    )
+  },
+  {
+    header: 'Registered',
+    accessorKey: 'registered',
+    cell: ({ row }) =>
+      row.original.isRegistered && (
+        <div className="flex items-center justify-center">
+          <Image src={checkIcon} alt="check" height={24} />
+        </div>
+      )
+  },
+  {
+    header: 'Participants',
+    accessorKey: 'participants',
+    cell: ({ row }) => row.original.participants
+  },
+  {
+    header: 'Period',
+    accessorKey: 'period',
+    cell: ({ row }) =>
+      `${dateFormatter(row.original.startTime, 'YYYY-MM-DD')} ~ ${dateFormatter(
+        row.original.endTime,
+        'YYYY-MM-DD'
+      )}`
+  }
+]


### PR DESCRIPTION
### Description

요청해주신 contest의 FinishedTableColumns을 course에 복사해서 새로 import했습니다!

### Additional context

<img width="895" alt="image" src="https://github.com/user-attachments/assets/f962d933-ea17-4a61-a3ce-5fdd79898ad2" />

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1253