### PR TITLE
chore(fe): remove handle from resizable panel

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -91,7 +91,7 @@ export function EditorMainResizablePanel({
         </div>
       </ResizablePanel>
 
-      <ResizableHandle withHandle className="border-[0.5px] border-slate-700" />
+      <ResizableHandle className="border-[0.5px] border-slate-700" />
 
       <ResizablePanel defaultSize={65} className="bg-[#222939]">
         <div className="grid-rows-editor grid h-full">
@@ -121,10 +121,7 @@ export function EditorMainResizablePanel({
                     <ScrollBar orientation="vertical" />
                   </ScrollArea>
                 </ResizablePanel>
-                <ResizableHandle
-                  withHandle
-                  className="border-[0.5px] border-slate-700"
-                />
+                <ResizableHandle className="border-[0.5px] border-slate-700" />
                 <ResizablePanel defaultSize={40}>
                   <TestcasePanel />
                 </ResizablePanel>


### PR DESCRIPTION
### Description
### 문제상황
- resize handle에 hover 됐는데 패널 사이즈 조절이 안됨
### 문제원인
- 사실 resize handle은 기능이 없고 resize 가능하다는 표시일 뿐이었음
- resize handle에 hover나 active 효과가 있지만, 기능은 없음...
- 이는 resize handle로만 사이즈를 조절할 수 있다고 사용자에게 혼동을 줄 수 있음
### 해결방법
- resize handle을 없애자!
패널 경계에 hover하면, 커서 모양이 바뀌기 때문에
사이즈 조절이 가능함을 사용자에게 알리기 충분하다고 판단했습니다

### AS-IS
![image](https://github.com/user-attachments/assets/f193e9df-ad00-4286-8ce7-38fd1ed34f04)
### TO-BE
![image](https://github.com/user-attachments/assets/e8229e74-68f2-445a-9a5c-78c29508cc05)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Closes TAS-1259
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
