### PR TITLE
fix(be): use test-submission id for test, user-test api

### DIFF
--- a/apps/backend/apps/client/src/submission/submission-pub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-pub.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { AmqpConnection } from '@golevelup/nestjs-rabbitmq'
-import type { Submission } from '@prisma/client'
+import type { Submission, TestSubmission } from '@prisma/client'
 import { Span, TraceService } from 'nestjs-otel'
 import {
   EXCHANGE,
@@ -46,7 +46,7 @@ export class SubmissionPublicationService {
   @Span()
   async publishJudgeRequestMessage(
     code: Snippet[],
-    submission: Submission,
+    submission: Submission | TestSubmission,
     isTest = false,
     isUserTest = false,
     userTestcases?: { id: number; in: string; out: string }[]

--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -52,10 +52,9 @@ export class SubmissionSubscriptionService implements OnModuleInit {
             raw.properties.type === RUN_MESSAGE_TYPE ||
             raw.properties.type === USER_TESTCASE_MESSAGE_TYPE
           ) {
-            const testRequestedUserId = res.submissionId // Test용 submissionId == Test 요청 유저의 userId
             await this.handleRunMessage(
               res,
-              testRequestedUserId,
+              res.submissionId,
               raw.properties.type === USER_TESTCASE_MESSAGE_TYPE ? true : false
             )
             return
@@ -90,7 +89,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
 
   async handleRunMessage(
     msg: JudgerResponse,
-    userId: number,
+    submissionId: number,
     isUserTest = false
   ): Promise<void> {
     const status = Status(msg.resultCode)
@@ -108,14 +107,16 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       throw new UnprocessableDataException('judgeResult is empty')
     }
     if (!testcaseId) {
-      const key = isUserTest ? userTestcasesKey(userId) : testcasesKey(userId)
+      const key = isUserTest
+        ? userTestcasesKey(submissionId)
+        : testcasesKey(submissionId)
       const testcaseIds = (await this.cacheManager.get<number[]>(key)) ?? []
 
       for (const testcaseId of testcaseIds) {
         await this.cacheManager.set(
           isUserTest
-            ? userTestKey(userId, testcaseId)
-            : testKey(userId, testcaseId),
+            ? userTestKey(submissionId, testcaseId)
+            : testKey(submissionId, testcaseId),
           {
             id: testcaseId,
             result: status,
@@ -127,8 +128,8 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       return
     }
     const key = isUserTest
-      ? userTestKey(userId, testcaseId)
-      : testKey(userId, testcaseId)
+      ? userTestKey(submissionId, testcaseId)
+      : testKey(submissionId, testcaseId)
 
     const testcase = await this.cacheManager.get<{
       id: number
@@ -145,7 +146,7 @@ export class SubmissionSubscriptionService implements OnModuleInit {
     const memoryUsage = msg.judgeResult.memory
 
     const testSubmission = await this.prisma.testSubmission.findUnique({
-      where: { id: userId }
+      where: { id: submissionId }
     })
     if (testSubmission) {
       const maxCpuTime = testSubmission.maxCpuTime || BigInt(0)

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -617,7 +617,7 @@ export class SubmissionService {
    * @param {number} problemId - 테스트 제출 기록을 생성할 문제의 ID
    * @param {CreateSubmissionDto} submissionDto - 제출할 코드 및 관련 데이터
    * @param {boolean} [isUserTest=false] - 사용자 테스트 케이스인지 여부 (기본값: false)
-   * @returns {Promise<void>}
+   * @returns {Promise<TestSubmission>}
    * @throws {EntityNotExistException} 다음과 같은 경우에 발생합니다
    *   - 주어진 문제가 존재하지 않는 경우
    * @throws {ConflictFoundException} 다음과 같은 경우에 발생합니다
@@ -630,7 +630,7 @@ export class SubmissionService {
     userIp: string,
     submissionDto: CreateSubmissionDto,
     isUserTest = false
-  ): Promise<void> {
+  ): Promise<TestSubmission> {
     const problem = await this.prisma.problem.findFirst({
       where: {
         id: problemId
@@ -657,41 +657,30 @@ export class SubmissionService {
       throw new ConflictFoundException('Modifying template is not allowed')
     }
 
-    const testSubmission: Submission = {
-      code: [],
-      language: submissionDto.language,
-      id: userId, // test용 submission끼리의 구분을 위해 submission의 id를 요청 User의 id로 지정
-      problemId,
-      result: 'Judging',
-      score: 0,
-      userId,
-      userIp,
-      assignmentId: null,
-      contestId: null,
-      workbookId: null,
-      codeSize: null,
-      createTime: new Date(),
-      updateTime: new Date()
-    }
-
     // User Testcase에 대한 TEST 요청인 경우
     if (isUserTest) {
+      const testSubmission = await this.createTestSubmission(
+        { ...submissionDto, problemId, userId, userIp },
+        code,
+        false
+      )
+
       await this.publishUserTestMessage(
-        userId,
         submissionDto.code,
         testSubmission,
         (submissionDto as CreateUserTestSubmissionDto).userTestcases
       )
-      return
+      return testSubmission
     }
 
     // Open Testcase에 대한 TEST 요청인 경우
-    await this.publishTestMessage(
-      problemId,
-      userId,
-      submissionDto.code,
-      testSubmission
+    const testSubmission = await this.createTestSubmission(
+      { ...submissionDto, problemId, userId, userIp },
+      code,
+      true
     )
+    await this.publishTestMessage(problemId, submissionDto.code, testSubmission)
+    return testSubmission
   }
 
   /**
@@ -704,19 +693,15 @@ export class SubmissionService {
    * 4. publishJudgeRequestMessage 메서드를 호출하여 채점 요청 메시지를 게시
    *
    * @param {number} problemId - 문제 ID
-   * @param {number} userId - 사용자 ID
    * @param {Snippet[]} code - 제출된 코드 스니펫 배열
    * @param {Submission} testSubmission - 테스트 제출 객체
    * @returns {Promise<void>}
    */
   async publishTestMessage(
     problemId: number,
-    userId: number,
     code: Snippet[],
-    testSubmission: Submission
+    testSubmission: TestSubmission
   ): Promise<void> {
-    await this.createTestSubmission(testSubmission, code, false) // DB에 Test Submission 기록 저장
-
     const rawTestcases = await this.prisma.problemTestcase.findMany({
       where: {
         problemId,
@@ -727,14 +712,14 @@ export class SubmissionService {
     const testcaseIds: number[] = []
     for (const rawTestcase of rawTestcases) {
       await this.cacheManager.set(
-        testKey(userId, rawTestcase.id),
+        testKey(testSubmission.id, rawTestcase.id),
         { id: rawTestcase.id, result: 'Judging' },
         TEST_SUBMISSION_EXPIRE_TIME
       )
       testcaseIds.push(rawTestcase.id)
     }
 
-    await this.cacheManager.set(testcasesKey(userId), testcaseIds)
+    await this.cacheManager.set(testcasesKey(testSubmission.id), testcaseIds)
     await this.publish.publishJudgeRequestMessage(code, testSubmission, true)
   }
 
@@ -749,31 +734,30 @@ export class SubmissionService {
    * 3. publishJudgeRequestMessage 메서드를 호출하여 사용자 테스트케이스에 대한
    *    채점 요청 메시지를 게시
    *
-   * @param {number} userId - 사용자 ID
    * @param {Snippet[]} code - 제출된 코드 스니펫 배열
    * @param {Submission} testSubmission - 테스트 제출 객체
    * @param {{ id: number; in: string; out: string }[]} userTestcases - 사용자 정의 테스트케이스 배열
    * @returns {Promise<void>} 모든 작업이 완료되면 반환되는 프로미스
    */
   async publishUserTestMessage(
-    userId: number,
     code: Snippet[],
-    testSubmission: Submission,
+    testSubmission: TestSubmission,
     userTestcases: { id: number; in: string; out: string }[]
   ): Promise<void> {
-    await this.createTestSubmission(testSubmission, code, true) // DB에 Test Submission 기록 저장
-
     const testcaseIds: number[] = []
     for (const testcase of userTestcases) {
       await this.cacheManager.set(
-        userTestKey(userId, testcase.id),
+        userTestKey(testSubmission.id, testcase.id),
         { id: testcase.id, result: 'Judging' },
         TEST_SUBMISSION_EXPIRE_TIME
       )
       testcaseIds.push(testcase.id)
     }
 
-    await this.cacheManager.set(userTestcasesKey(userId), testcaseIds)
+    await this.cacheManager.set(
+      userTestcasesKey(testSubmission.id),
+      testcaseIds
+    )
     await this.publish.publishJudgeRequestMessage(
       code,
       testSubmission,
@@ -785,13 +769,16 @@ export class SubmissionService {
 
   @Span()
   async createTestSubmission(
-    testSubmission: Submission,
+    testSubmissionData: Pick<
+      Submission,
+      'problemId' | 'language' | 'userId' | 'userIp'
+    >,
     codeSnippet: Snippet[],
     isUserTest = false
   ): Promise<TestSubmission> {
     const problem = await this.prisma.problem.findFirst({
       where: {
-        id: testSubmission.problemId
+        id: testSubmissionData.problemId
       }
     })
 
@@ -799,15 +786,15 @@ export class SubmissionService {
       throw new EntityNotExistException('Problem')
     }
 
-    if (!problem.languages.includes(testSubmission.language)) {
+    if (!problem.languages.includes(testSubmissionData.language)) {
       throw new ConflictFoundException(
-        `This problem does not support language ${testSubmission.language}`
+        `This problem does not support language ${testSubmissionData.language}`
       )
     }
     if (
       !this.isValidCode(
         codeSnippet,
-        testSubmission.language,
+        testSubmissionData.language,
         plainToInstance(Template, problem.template)
       )
     ) {
@@ -816,34 +803,39 @@ export class SubmissionService {
 
     const submissionData = {
       code: codeSnippet.map((snippet) => ({ ...snippet })),
-      userId: testSubmission.userId,
-      userIp: testSubmission.userIp,
-      problemId: testSubmission.problemId,
+      userId: testSubmissionData.userId,
+      userIp: testSubmissionData.userIp,
+      problemId: testSubmissionData.problemId,
       codeSize: new TextEncoder().encode(codeSnippet[0].text).length,
-      language: testSubmission.language
+      language: testSubmissionData.language
     }
 
-    try {
-      const submission = await this.prisma.testSubmission.create({
-        data: {
-          ...submissionData,
-          isUserTest
-        }
-      })
-
-      return submission
-    } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
-        throw new UnprocessableDataException('Failed to create submission')
+    const submission = await this.prisma.testSubmission.create({
+      data: {
+        ...submissionData,
+        isUserTest
       }
-      throw error
-    }
+    })
+
+    return submission
   }
 
   async getTestResult(userId: number, isUserTest = false) {
+    // 가장 최신의 Test Submission 불러오기
+    const testSubmissionId = (
+      await this.prisma.testSubmission.findFirstOrThrow({
+        where: {
+          userId
+        },
+        orderBy: {
+          id: 'desc'
+        }
+      })
+    ).id
+
     const testCasesKey = isUserTest
-      ? userTestcasesKey(userId)
-      : testcasesKey(userId)
+      ? userTestcasesKey(testSubmissionId)
+      : testcasesKey(testSubmissionId)
 
     const testcases =
       (await this.cacheManager.get<number[]>(testCasesKey)) ?? []
@@ -851,8 +843,8 @@ export class SubmissionService {
     const results: { id: number; result: ResultStatus; output?: string }[] = []
     for (const testcaseId of testcases) {
       const key = isUserTest
-        ? userTestKey(userId, testcaseId)
-        : testKey(userId, testcaseId)
+        ? userTestKey(testSubmissionId, testcaseId)
+        : testKey(testSubmissionId, testcaseId)
       const testcase = await this.cacheManager.get<{
         id: number
         result: ResultStatus

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -823,7 +823,7 @@ export class SubmissionService {
   async getTestResult(userId: number, isUserTest = false) {
     // 가장 최신의 Test Submission 불러오기
     const testSubmissionId = (
-      await this.prisma.testSubmission.findFirstOrThrow({
+      await this.prisma.testSubmission.findFirst({
         where: {
           userId
         },
@@ -831,7 +831,11 @@ export class SubmissionService {
           id: 'desc'
         }
       })
-    ).id
+    )?.id
+
+    if (!testSubmissionId) {
+      return []
+    }
 
     const testCasesKey = isUserTest
       ? userTestcasesKey(testSubmissionId)

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -662,7 +662,7 @@ export class SubmissionService {
       const testSubmission = await this.createTestSubmission(
         { ...submissionDto, problemId, userId, userIp },
         code,
-        false
+        true
       )
 
       await this.publishUserTestMessage(
@@ -677,7 +677,7 @@ export class SubmissionService {
     const testSubmission = await this.createTestSubmission(
       { ...submissionDto, problemId, userId, userIp },
       code,
-      true
+      false
     )
     await this.publishTestMessage(problemId, submissionDto.code, testSubmission)
     return testSubmission

--- a/apps/backend/libs/cache/src/keys.ts
+++ b/apps/backend/libs/cache/src/keys.ts
@@ -10,11 +10,13 @@ export const invitationCodeKey = (code: string) => `invite:${code}`
 export const invitationGroupKey = (groupId: number) => `invite:to:${groupId}`
 
 /* TEST API용 Key */
-export const testKey = (userId: number, testcaseId: number) =>
-  `test:user:${userId}:testcase:${testcaseId}`
-export const testcasesKey = (userId: number) => `test:user:${userId}`
+export const testKey = (testSubmissionId: number, testcaseId: number) =>
+  `test:id:${testSubmissionId}:testcase:${testcaseId}`
+export const testcasesKey = (testSubmissionId: number) =>
+  `test:id:${testSubmissionId}`
 
 /* User Test API용 Key */
-export const userTestKey = (userId: number, testcaseId: number) =>
-  `user-test:${userId}:testcase:${testcaseId}`
-export const userTestcasesKey = (userId: number) => `user-test:${userId}`
+export const userTestKey = (testSubmissionId: number, testcaseId: number) =>
+  `user-test:id:${testSubmissionId}:testcase:${testcaseId}`
+export const userTestcasesKey = (testSubmissionId: number) =>
+  `user-test:${testSubmissionId}`


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
hotfix

Test, User Test API 호출에 대해 생성된 TestSubmission ID를 Cache Get/Set에 사용합니다.
UserId로 TestSubmission을 조작할 시, 생성된 TestSubmission 레코드 업데이트가 불가능한 문제를 해결합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
이제 Test / User-Test API 호출 시 일반 Submission과 마찬가지로 생성된 Test Submission 객체를 반환합니다.

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
