### PR TITLE
feat(be): add course duplicate api

### DIFF
--- a/apps/backend/apps/admin/src/group/group.resolver.ts
+++ b/apps/backend/apps/admin/src/group/group.resolver.ts
@@ -40,6 +40,14 @@ export class GroupResolver {
     return await this.groupService.deleteGroup(id, GroupType.Course, req.user)
   }
 
+  @Mutation(() => Group)
+  async duplicateCourse(
+    @Context('req') req: AuthenticatedRequest,
+    @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number
+  ) {
+    return await this.groupService.duplicateCourse(groupId, req.user.id)
+  }
+
   @Query(() => [FindGroup])
   @SetMetadata(LEADER_NOT_NEEDED_KEY, true)
   async getCoursesUserLead(@Context('req') req: AuthenticatedRequest) {

--- a/apps/backend/apps/admin/src/group/group.resolver.ts
+++ b/apps/backend/apps/admin/src/group/group.resolver.ts
@@ -9,7 +9,7 @@ import {
   WhitelistService
 } from './group.service'
 import { CourseInput } from './model/group.input'
-import { FindGroup } from './model/group.output'
+import { DuplicateCourse, FindGroup } from './model/group.output'
 
 @Resolver(() => Group)
 export class GroupResolver {
@@ -40,7 +40,7 @@ export class GroupResolver {
     return await this.groupService.deleteGroup(id, GroupType.Course, req.user)
   }
 
-  @Mutation(() => Group)
+  @Mutation(() => DuplicateCourse)
   async duplicateCourse(
     @Context('req') req: AuthenticatedRequest,
     @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number

--- a/apps/backend/apps/admin/src/group/model/group.output.ts
+++ b/apps/backend/apps/admin/src/group/model/group.output.ts
@@ -12,6 +12,18 @@ export class FindGroup extends Group {
 }
 
 @ObjectType()
+export class DuplicateCourse {
+  @Field(() => Group, { nullable: false })
+  duplicatedCourse!: Group
+
+  @Field(() => [Int], { nullable: false })
+  originAssignments!: number
+
+  @Field(() => [Int], { nullable: false })
+  copiedAssignments!: number
+}
+
+@ObjectType()
 export class DeletedUserGroup {
   @Field(() => Int, { nullable: false })
   count!: number

--- a/apps/backend/prisma/migrations/20250222113752_add_ondelete_cascade_to_workbook_and_assignment/migration.sql
+++ b/apps/backend/prisma/migrations/20250222113752_add_ondelete_cascade_to_workbook_and_assignment/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "assignment" DROP CONSTRAINT "assignment_group_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "workbook" DROP CONSTRAINT "workbook_group_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "assignment" ADD CONSTRAINT "assignment_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workbook" ADD CONSTRAINT "workbook_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -302,7 +302,7 @@ model Assignment {
   id                   Int      @id @default(autoincrement())
   createdBy            User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdById          Int?     @map("created_by_id")
-  group                Group    @relation(fields: [groupId], references: [id])
+  group                Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
   groupId              Int      @map("group_id")
   week                 Int      @default(1)
   title                String
@@ -483,7 +483,7 @@ model Workbook {
   id          Int      @id @default(autoincrement())
   createdBy   User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdById Int?     @map("created_by_id")
-  group       Group    @relation(fields: [groupId], references: [id])
+  group       Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
   groupId     Int      @map("group_id")
   title       String
   description String

--- a/collection/instructor/Course/Duplicate Course/Succeed.bru
+++ b/collection/instructor/Course/Duplicate Course/Succeed.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Succeed
+  type: graphql
+  seq: 1
+}
+
+post {
+  url: {{gqlUrl}}
+  body: graphql
+  auth: none
+}
+
+body:graphql {
+  mutation {
+    duplicateCourse(groupId: 2) {
+      id
+      groupName
+      groupType
+      config
+      courseInfo {
+        courseNum
+        classNum
+        professor
+        semester
+        week
+        email
+        website
+        office
+        phoneNum
+      }
+    }
+  }
+
+}
+
+docs {
+  # Duplicate Group
+  ---
+  - `groupId`에 해당하는 Group을 복제합니다.
+}

--- a/collection/instructor/Course/Duplicate Course/Succeed.bru
+++ b/collection/instructor/Course/Duplicate Course/Succeed.bru
@@ -13,24 +13,28 @@ post {
 body:graphql {
   mutation {
     duplicateCourse(groupId: 2) {
-      id
-      groupName
-      groupType
-      config
-      courseInfo {
-        courseNum
-        classNum
-        professor
-        semester
-        week
-        email
-        website
-        office
-        phoneNum
+      duplicatedCourse {
+        id
+        groupName
+        groupType
+        config
+        courseInfo {
+          courseNum
+          classNum
+          professor
+          semester
+          week
+          email
+          website
+          office
+          phoneNum
+        }
       }
+      originAssignments
+      copiedAssignments
     }
   }
-
+  
 }
 
 docs {

--- a/collection/instructor/Course/Update Course/Succeed.bru
+++ b/collection/instructor/Course/Update Course/Succeed.bru
@@ -17,9 +17,10 @@ body:graphql {
       input: {
         courseTitle: "정보보호개론"
         courseNum: "SWE3033"
-        classNum: 42
+        classNum: 43
         professor: "김우주"
         semester: "2025 Spring"
+        week: 16
         email: "johndoe@example.com"
         website: "https://example.com"
         office: "Room 301"
@@ -48,7 +49,7 @@ body:graphql {
       }
     }
   }
-  
+
 }
 
 assert {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
#### Course 복제 기능 추가

이전 학기의 Course를 추가하거나 같은 학기여도 같은 수업의 다른 분반을 만들기 위해 필요한 기능입니다.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following
Closes TAS-1306
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
