### PR TITLE
feat(fe): make announcement table

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/DataTable.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/DataTable.tsx
@@ -29,6 +29,7 @@ interface DataTableProps<TData, TValue> {
   headerStyle: {
     [key: string]: string
   }
+  tableStyle?: string
   linked?: boolean
   emptyMessage?: string
 }
@@ -74,6 +75,7 @@ export function DataTable<TData extends Item, TValue>({
   columns,
   data,
   headerStyle,
+  tableStyle,
   linked = false,
   emptyMessage = 'No results.'
 }: DataTableProps<TData, TValue>) {
@@ -126,7 +128,10 @@ export function DataTable<TData extends Item, TValue>({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
-                className="cursor-pointer border-b-[1.5px] border-[#80808040] hover:bg-[#80808014]"
+                className={cn(
+                  'cursor-pointer border-b-[1.5px] border-[#80808040] hover:bg-[#80808014]',
+                  tableStyle
+                )}
                 onClick={handleClick}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/announcement/_components/Columns.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/announcement/_components/Columns.tsx
@@ -6,10 +6,19 @@ import type { ColumnDef } from '@tanstack/react-table'
 
 export const columns: ColumnDef<ContestAnnouncement>[] = [
   {
+    header: 'No',
+    accessorKey: 'no',
+    cell: ({ row, table }) => (
+      <div className="h-full text-base">
+        {table.getCoreRowModel().rows.length - row.index}
+      </div>
+    )
+  },
+  {
     header: 'Problem',
     accessorKey: 'problem',
     cell: ({ row }) => (
-      <div className="h-full">
+      <div className="h-full text-base">
         {row.original.problemId !== null
           ? convertToLetter(row.original.problemId)
           : ''}
@@ -17,18 +26,19 @@ export const columns: ColumnDef<ContestAnnouncement>[] = [
     )
   },
   {
-    header: () => 'Description',
+    header: () => 'Announcement',
     accessorKey: 'content',
     cell: ({ row }) => (
-      <div className="text-left [tr:not(.expanded)_&]:truncate">
-        {row.original.content}
-      </div>
+      <div className="text-left text-base">{row.original.content}</div>
     )
   },
   {
-    header: () => 'Posted',
-    accessorKey: 'updateTime',
-    cell: ({ row }) =>
-      dateFormatter(row.original.updateTime, 'YYYY-MM-DD HH:mm')
+    header: () => 'Date',
+    accessorKey: 'createTime',
+    cell: ({ row }) => (
+      <div className="text-[#808080]">
+        {dateFormatter(row.original.createTime, 'YYYY-MM-DD HH:mm')}
+      </div>
+    )
   }
 ]

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/announcement/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/announcement/page.tsx
@@ -18,16 +18,22 @@ export default async function ContestAnnouncement({
       }
     })
     .json()
-
   return (
-    <DataTable
-      data={contestAnnouncements}
-      columns={columns}
-      headerStyle={{
-        problem: 'w-[12%]',
-        content: 'w-[70%]',
-        updateTime: 'w-[18%]'
-      }}
-    />
+    <div className="pb-[120px]">
+      <p className="mb-20 mt-20 text-center text-2xl font-semibold text-[#3581FA]">
+        ANNOUNCEMENT
+      </p>
+      <DataTable
+        data={contestAnnouncements}
+        columns={columns}
+        headerStyle={{
+          no: 'text-[#808080b3] font-normal w-[9%]',
+          problem: 'text-[#808080b3] font-normal w-[15%]',
+          content: 'text-[#808080b3] font-normal w-[51%]',
+          createTime: 'text-[#808080b3] font-normal w-[25%]'
+        }}
+        tableStyle="hover:bg-white cursor-auto"
+      />
+    </div>
   )
 }

--- a/apps/frontend/app/(client)/(main)/contest/_components/ContestTabs.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/_components/ContestTabs.tsx
@@ -30,10 +30,10 @@ export function ContestTabs({ contestId }: { contestId: string }) {
           Overview
         </Link>
         <Link
-          href={`/contest/${id}/notice` as Route}
+          href={`/contest/${id}/announcement` as Route}
           className={cn(
             'flex w-1/2 justify-center p-[18px] text-lg',
-            isCurrentTab('notice') &&
+            isCurrentTab('announcement') &&
               'text-primary border-b-primary border-b-4 font-semibold'
           )}
         >

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -138,7 +138,9 @@ export interface Contest {
 export interface ContestAnnouncement {
   id: number
   content: string
-  problemId: number
+  assignmentId: null | string
+  constestId: number
+  problemId: null | number
   createTime: string
   updateTime: string
 }


### PR DESCRIPTION
### Description
<ul>
<li>contest의 announcement 페이지를 작업하였습니다.</li>
<li>No: 공지사항이 작성된 순서입니다.
<li>Problem: 특정 문제에 관한 공지를 가져올 때는 문제의 order(A, B, C, D 등)를 가져오고, 특정 문제가 아닌 contest 자체에 관한 공지일 때는 공란으로 비워두었습니다.</li>
<li>Announcement: 명세에 따라 공지사항의 전체내용이 노출되고, 글자수의 제한 없이 내용만큼 각 행의 세로 길이가 늘어나도록 하였습니다.</li>
<li>Date: 공지사항이 작성된 시각(수정된 시각 아님)으로 설정하였습니다.</li>
<li>클릭하여 창을 띄우는 명세 등이 아직 없기 때문에 hover를 없앴고, 커서도 수정하였습니다.</li>
</ul>

![image](https://github.com/user-attachments/assets/4d4f2ef6-36d3-49d4-935d-9ff0d528f6e0)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
