### PR TITLE
feat(fe): add instructor assignment participant page

### DIFF
--- a/apps/frontend/app/admin/_components/table/DataTableProblemFilter.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableProblemFilter.tsx
@@ -12,7 +12,10 @@ import {
   PopoverContent,
   PopoverTrigger
 } from '@/components/shadcn/popover'
-import { GET_CONTEST_PROBLEMS } from '@/graphql/problem/queries'
+import {
+  GET_ASSIGNMENT_PROBLEMS,
+  GET_CONTEST_PROBLEMS
+} from '@/graphql/problem/queries'
 import { cn } from '@/libs/utils'
 import { useQuery } from '@apollo/client'
 import { useEffect, useState } from 'react'
@@ -28,7 +31,15 @@ const ALL_OPTION_LABEL = 'All Problems'
  * @param contestId
  * 문제를 가져올 대회의 아이디
  */
-export function DataTableProblemFilter({ contestId }: { contestId: number }) {
+export function DataTableProblemFilter({
+  contestId = 0,
+  groupId = 0,
+  assignmentId = 0
+}: {
+  contestId?: number
+  groupId?: number
+  assignmentId?: number
+}) {
   const { table } = useDataTable()
   const column = table.getColumn(PROBLEM_COLUMN_ID)
   const selectedValue = getSelectedValue(column?.getFilterValue())
@@ -38,13 +49,21 @@ export function DataTableProblemFilter({ contestId }: { contestId: number }) {
     { value: string | null; label: string }[]
   >([])
 
-  const { data } = useQuery(GET_CONTEST_PROBLEMS, {
-    variables: { contestId }
+  const contestProblems = useQuery(GET_CONTEST_PROBLEMS, {
+    variables: { contestId },
+    skip: Boolean(groupId)
+  })
+
+  const assignmentProblems = useQuery(GET_ASSIGNMENT_PROBLEMS, {
+    variables: { groupId, assignmentId },
+    skip: Boolean(contestId)
   })
 
   useEffect(() => {
-    const sortedProblems =
-      data?.getContestProblems.slice().sort((a, b) => a.order - b.order) ?? []
+    const data = contestId
+      ? contestProblems?.data?.getContestProblems
+      : assignmentProblems?.data?.getAssignmentProblems
+    const sortedProblems = data?.slice().sort((a, b) => a.order - b.order) ?? []
     setOptions([
       { value: null, label: ALL_OPTION_LABEL },
       ...sortedProblems.map((problem) => ({
@@ -52,7 +71,7 @@ export function DataTableProblemFilter({ contestId }: { contestId: number }) {
         label: `${String.fromCharCode(65 + problem.order)}. ${problem.problem.title}`
       }))
     ])
-  }, [data])
+  }, [contestId, contestProblems, assignmentProblems])
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/submission/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/submission/page.tsx
@@ -9,12 +9,15 @@ import {
 export default function Submission({
   params
 }: {
-  params: { assignmentId: string }
+  params: { courseId: string; assignmentId: string }
 }) {
   return (
     <ErrorBoundary fallback={FetchErrorFallback}>
       <Suspense fallback={<SubmissionTableFallback />}>
-        <SubmissionTable assignmentId={Number(params.assignmentId)} />
+        <SubmissionTable
+          groupId={Number(params.courseId)}
+          assignmentId={Number(params.assignmentId)}
+        />
       </Suspense>
     </ErrorBoundary>
   )

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/layout.tsx
@@ -27,7 +27,7 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
     <main className="flex flex-col gap-6 px-20 py-16">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <Link href={`/admin/course/${courseId}` as Route}>
+          <Link href={`/admin/course/${courseId}/assignment` as Route}>
             <FaAngleLeft className="h-12 hover:text-gray-700/80" />
           </Link>
           <span className="text-4xl font-bold">{assignmentData?.title}</span>

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/ScoreColumns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/ScoreColumns.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import type { ProblemData } from '@/app/admin/contest/_libs/schemas'
+import type { ColumnDef, Row } from '@tanstack/react-table'
+
+export interface ScoreSummary {
+  studentId: string
+  realName?: string | null
+  username: string
+  submittedProblemCount: number
+  totalProblemCount: number
+  userAssignmentScore: number
+  assignmentPerfectScore: number
+  problemScores: {
+    problemId: number
+    score: number
+    maxScore: number
+  }[]
+}
+
+interface DataTableSubmissionSummary
+  extends Pick<
+    ScoreSummary,
+    | 'assignmentPerfectScore'
+    | 'submittedProblemCount'
+    | 'userAssignmentScore'
+    | 'totalProblemCount'
+  > {
+  id: number
+  problemScores: {
+    problemId: number
+    score: number
+  }[]
+}
+
+// interface DataTableSubmissionSummary {
+//   id: number
+//   studentId: string
+//   realName?: string | null
+//   username: string
+//   submittedProblemCount: number
+//   totalProblemCount: number
+//   userAssignmentScore: number
+//   assignmentPerfectScore: number
+//   userAssignmentFinalScore?: number | null | undefined
+//   problemScores: {
+//     problemId: number
+//     score: number
+//     maxScore: number
+//   }[]
+// }
+
+export const createColumns = (
+  problemData: ProblemData[]
+): ColumnDef<DataTableSubmissionSummary>[] => {
+  return [
+    {
+      accessorKey: 'submittedProblemCount',
+      header: () => <p className="py-1 font-mono text-sm">Submit</p>,
+      cell: ({ row }) => (
+        <div className="flex justify-center">
+          {row.original.submittedProblemCount}/{row.original.totalProblemCount}
+        </div>
+      )
+    },
+    {
+      accessorKey: 'userAssignmentScore',
+      header: () => <p className="py-1 font-mono text-sm">Total</p>,
+      cell: ({ row }) => (
+        <div>
+          {row.original.userAssignmentScore}/
+          {row.original.assignmentPerfectScore}
+        </div>
+      )
+    },
+    ...problemData.map((problem, i) => ({
+      accessorKey: `${String.fromCharCode(Number(65 + i))}`,
+      header: () => (
+        <p className="font-mono text-sm">
+          {String.fromCharCode(Number(65 + i))}
+        </p>
+      ),
+      cell: ({ row }: { row: Row<DataTableSubmissionSummary> }) => {
+        const problemScore = row.original.problemScores.find(
+          (ps) => ps.problemId === problem.problemId
+        )
+        return (
+          <div>
+            {problemScore
+              ? `${problemScore.score}/${problem.score}`
+              : `-/${problem.score}`}
+          </div>
+        )
+      }
+    }))
+  ]
+}

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/ScoreTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/ScoreTable.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import {
+  DataTable,
+  DataTableFallback,
+  DataTableRoot
+} from '@/app/admin/_components/table'
+import { GET_ASSIGNMENT_SUBMISSION_SUMMARIES_OF_USER } from '@/graphql/assignment/queries'
+import { GET_ASSIGNMENT_PROBLEMS } from '@/graphql/problem/queries'
+import { useSuspenseQuery } from '@apollo/client'
+import { createColumns } from './ScoreColumns'
+
+interface ScoreTableProps {
+  groupId: number
+  assignmentId: number
+  userId: number
+}
+
+export function ScoreTable({ groupId, assignmentId, userId }: ScoreTableProps) {
+  const submissions = useSuspenseQuery(
+    GET_ASSIGNMENT_SUBMISSION_SUMMARIES_OF_USER,
+    {
+      variables: { groupId, assignmentId, userId, take: 1000 }
+    }
+  )
+  const scoreData =
+    submissions.data.getAssignmentSubmissionSummaryByUserId.scoreSummary
+
+  const problems = useSuspenseQuery(GET_ASSIGNMENT_PROBLEMS, {
+    variables: { groupId, assignmentId }
+  })
+  const problemData = problems.data.getAssignmentProblems
+    .slice()
+    .sort((a, b) => a.order - b.order)
+
+  return (
+    <DataTableRoot
+      data={[{ ...scoreData, id: userId }]}
+      columns={createColumns(problemData)}
+    >
+      <DataTable />
+    </DataTableRoot>
+  )
+}
+
+export function ScoreTableFallback() {
+  return <DataTableFallback withSearchBar={false} columns={createColumns([])} />
+}

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/SubmissionColumns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/SubmissionColumns.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import type { UserSubmission } from '@/app/admin/contest/_libs/schemas'
+import { cn, getResultColor } from '@/libs/utils'
+import type { ColumnDef } from '@tanstack/react-table'
+import dayjs from 'dayjs'
+
+export const submissionColumns: ColumnDef<UserSubmission>[] = [
+  {
+    accessorKey: 'problemTitle',
+    header: () => <div className="py-1 font-mono text-sm">Problem Title</div>,
+    cell: ({ row }) => (
+      <div className="whitespace-nowrap py-1 text-center text-xs">
+        {String.fromCharCode(65 + (row.original.order ?? 0))}.{' '}
+        {row.getValue('problemTitle')}
+      </div>
+    )
+  },
+  {
+    accessorKey: 'submissionResult',
+    header: () => <p className="font-mono text-sm">Result</p>,
+    cell: ({ row }) => (
+      <div
+        className={cn(
+          'whitespace-nowrap text-center text-xs',
+          getResultColor(row.getValue('submissionResult'))
+        )}
+      >
+        {row.getValue('submissionResult')}
+      </div>
+    )
+  },
+  {
+    accessorKey: 'language',
+    header: () => <p className="font-mono text-sm">Language</p>,
+    cell: ({ row }) => (
+      <div className="whitespace-nowrap text-center text-xs">
+        {row.getValue('language')}
+      </div>
+    )
+  },
+  {
+    accessorKey: 'submissionTime',
+    header: () => <p className="font-mono text-sm">Submission Time</p>,
+    cell: ({ row }) => (
+      <div className="whitespace-nowrap text-center text-xs">
+        {dayjs(new Date(parseInt(row.getValue('submissionTime'), 10))).format(
+          'YYYY-MM-DD HH:mm:ss'
+        )}
+      </div>
+    )
+  },
+  {
+    accessorKey: 'codeSize',
+    header: () => <p className="font-mono text-sm">Code Size</p>,
+    cell: ({ row }) => (
+      <div className="whitespace-nowrap text-center text-xs">
+        {row.getValue('codeSize') ? `${row.getValue('codeSize')} B` : 'N/A'}
+      </div>
+    )
+  },
+  {
+    accessorKey: 'ip',
+    header: () => <p className="font-mono text-sm">IP</p>,
+    cell: ({ row }) => (
+      <div className="whitespace-nowrap text-center text-xs">
+        {row.getValue('ip') ?? 'Unknown'}
+      </div>
+    )
+  }
+]

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/SubmissionTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/_components/SubmissionTable.tsx
@@ -1,53 +1,48 @@
 'use client'
 
 import {
-  DataTable,
-  DataTableFallback,
-  DataTablePagination,
-  DataTableProblemFilter,
   DataTableRoot,
-  DataTableSearchBar
+  DataTableProblemFilter,
+  DataTable,
+  DataTablePagination,
+  DataTableFallback
 } from '@/app/admin/_components/table'
-import { SubmissionDetailAdmin } from '@/app/admin/course/[courseId]/assignment/[assignmentId]/_components/SubmissionDetailAdmin'
+import { SubmissionDetailAdmin } from '@/app/admin/contest/[contestId]/_components/SubmissionDetailAdmin'
 import { Dialog, DialogContent } from '@/components/shadcn/dialog'
-import { GET_ASSIGNMENT_SUBMISSIONS } from '@/graphql/submission/queries'
+import { GET_ASSIGNMENT_SUBMISSION_SUMMARIES_OF_USER } from '@/graphql/assignment/queries'
 import { useSuspenseQuery } from '@apollo/client'
 import { useState } from 'react'
-import { columns } from './Columns'
+import { submissionColumns } from './SubmissionColumns'
 
 export function SubmissionTable({
   groupId,
-  assignmentId
+  assignmentId,
+  userId
 }: {
   groupId: number
   assignmentId: number
+  userId: number
 }) {
-  const { data } = useSuspenseQuery(GET_ASSIGNMENT_SUBMISSIONS, {
-    variables: {
-      input: {
-        assignmentId
-      },
-      take: 1000
+  const submissions = useSuspenseQuery(
+    GET_ASSIGNMENT_SUBMISSION_SUMMARIES_OF_USER,
+    {
+      variables: { groupId, assignmentId, userId, take: 1000 }
     }
-  })
-
+  )
   const [isSubmissionDialogOpen, setIsSubmissionDialogOpen] = useState(false)
   const [submissionId, setSubmissionId] = useState(0)
+
+  const submissionsData =
+    submissions.data.getAssignmentSubmissionSummaryByUserId.submissions
 
   return (
     <>
       <DataTableRoot
-        data={data.getAssignmentSubmissions}
-        columns={columns}
+        columns={submissionColumns}
+        data={submissionsData}
         defaultSortState={[{ id: 'submissionTime', desc: true }]}
       >
-        <div className="flex gap-4">
-          <DataTableSearchBar columndId="realname" />
-          <DataTableProblemFilter
-            groupId={groupId}
-            assignmentId={assignmentId}
-          />
-        </div>
+        <DataTableProblemFilter groupId={groupId} assignmentId={assignmentId} />
         <DataTable
           onRowClick={(_, row) => {
             setSubmissionId(row.original.id)
@@ -69,5 +64,5 @@ export function SubmissionTable({
 }
 
 export function SubmissionTableFallback() {
-  return <DataTableFallback columns={columns} />
+  return <DataTableFallback withSearchBar={false} columns={submissionColumns} />
 }

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/participant/[userId]/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { FetchErrorFallback } from '@/components/FetchErrorFallback'
+import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
+import { GET_GROUP_MEMBER } from '@/graphql/user/queries'
+import { useQuery } from '@apollo/client'
+import { ErrorBoundary } from '@suspensive/react'
+import type { Route } from 'next'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { FaAngleLeft } from 'react-icons/fa6'
+import { ScoreTable, ScoreTableFallback } from './_components/ScoreTable'
+import {
+  SubmissionTable,
+  SubmissionTableFallback
+} from './_components/SubmissionTable'
+
+export default function Page({
+  params
+}: {
+  params: { courseId: string; assignmentId: string; userId: string }
+}) {
+  const groupId = Number(params.courseId)
+  const assignmentId = Number(params.assignmentId)
+  const userId = Number(params.userId)
+
+  const user = useQuery(GET_GROUP_MEMBER, {
+    variables: { groupId, userId }
+  })
+  const userData = user.data?.getGroupMember
+
+  return (
+    <ScrollArea className="shrink-0">
+      <main className="flex flex-col gap-6 px-20 py-16">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Link
+              href={
+                `/admin/course/${groupId}/assignment/${assignmentId}` as Route
+              }
+            >
+              <FaAngleLeft className="h-12 hover:text-gray-700/80" />
+            </Link>
+            <span className="text-4xl font-bold">
+              {userData?.name} ({userData?.studentId})
+            </span>
+          </div>
+        </div>
+        <div className="prose mb-4 w-full max-w-full border-y-2 border-y-gray-300 p-5 py-12">
+          <div className="flex flex-col gap-4">
+            <div className="font-semibold">{userData?.major}</div>
+            <div className="flex space-x-4">
+              <div className="flex flex-col gap-4 font-medium">
+                <span>User ID</span>
+                <span>Student ID</span>
+              </div>
+              <div className="flex flex-col gap-4">
+                <span>{userData?.username}</span>
+                <span>{userData?.studentId}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <ErrorBoundary fallback={FetchErrorFallback}>
+            <Suspense fallback={<ScoreTableFallback />}>
+              <ScoreTable
+                groupId={groupId}
+                assignmentId={assignmentId}
+                userId={userId}
+              />
+            </Suspense>
+          </ErrorBoundary>
+          <ErrorBoundary fallback={FetchErrorFallback}>
+            <Suspense fallback={<SubmissionTableFallback />}>
+              <SubmissionTable
+                groupId={groupId}
+                assignmentId={assignmentId}
+                userId={userId}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </div>
+      </main>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  )
+}

--- a/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentProblemListLabel.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentProblemListLabel.tsx
@@ -25,11 +25,11 @@ export function AssignmentProblemListLabel() {
             {/* assignment visible 정책 결정 후 문구 확정 */}
             <p className="text-xs font-normal text-black">
               If a problem is included in at least one ongoing, or upcoming
-              contest, it will automatically become invisible state in the ‘All
-              Problem List’. You cannot change its visibility until all the
-              ongoing or upcoming contests it is part of have ended. After the
-              contests are all over, you can manually make the problem visible
-              again.
+              assignment, it will automatically become invisible state in the
+              ‘All Problem List’. You cannot change its visibility until all the
+              ongoing or upcoming assignments it is part of have ended. After
+              the assignments are all over, you can manually make the problem
+              visible again.
             </p>
           </TooltipContent>
         </Tooltip>

--- a/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentTable.tsx
@@ -20,8 +20,9 @@ interface AssignmentTableProps {
 
 const headerStyle = {
   select: '',
-  title: 'w-3/5',
+  title: 'w-1/2',
   startTime: 'px-0 w-2/5',
+  week: 'px-0 w-1/5',
   isVisible: 'px-0 w-1/12'
 }
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentTableColumns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentTableColumns.tsx
@@ -175,6 +175,23 @@ export const columns: ColumnDef<DataTableAssignment>[] = [
     size: 250
   },
   {
+    accessorKey: 'week',
+    header: ({ column }) => (
+      <div className="flex justify-center">
+        <DataTableColumnHeader
+          column={column}
+          title="Week"
+          className="text-center"
+        />
+      </div>
+    ),
+    cell: ({ row }) => (
+      <p className="overflow-hidden whitespace-nowrap text-center font-normal">
+        {`Week ${row.original.week}`}
+      </p>
+    )
+  },
+  {
     accessorKey: 'isVisible',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Visible" />


### PR DESCRIPTION
### Description

아까 깜박하고 못 만든 participant page를 만들었습니다. 특이사항으로는 datatableproblemfilter의 재사용을 위해 contestId뿐 아니라 groupId와 assignmentId를 받을 수 있게 확장하였는데, 오히려 코드가 더러워져 그냥 두 개로 분리할 걸 그랬나 싶기도 하네요... 어쨌든 작동은 잘 합니다.

\+ 사소하게 week column 없었던 거 추가

closes TAS-1358

### Additional context

assignments/_components의 AssignmentProblemColumns 파일을 보면서 미처 ContainedContests를 ContainedAssignments로 못 바꿨다는 걸 깨달았는데 백엔드의 GetAssignmentsByProblemId 코드를 보니 groupId를 받는 걸로 보아 현재 course 안에서 같은 문제를 공유하는 assignment들을 가져오는 것 같은데 뭔가 그러면 너무 쓸모없을 것 같아 일단 바꾸지 않고 냅뒀습니다. 관련해서 Figma에 댓글 남겼으니 한 번 확인해주세요!



P.S. 하루에 12시간 코딩하니까 죽을 것 같아요...

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
