### PR TITLE
style(fe): fix the gap between banner and Tap

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/Cover.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/Cover.tsx
@@ -20,13 +20,6 @@ const bgImg: { [key: string]: string } = {
   course: '/banners/courseInnerBanner.png'
 }
 
-const icons: { [key: string]: string } = {
-  problem: '/banners/codedang.png',
-  notice: '/banners/notice.png',
-  contest: '/banners/contest.png',
-  course: '/banners/contest.png'
-}
-
 /**
  * @param title - title text
  * @param description - description text

--- a/apps/frontend/app/(client)/(main)/_components/Cover.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/Cover.tsx
@@ -63,7 +63,6 @@ export function Cover({ title, description }: CoverProps) {
           </div>
         </div>
       </div>
-      <div className="h-16 w-full bg-white" />
     </div>
   )
 }

--- a/apps/frontend/app/(client)/(main)/contest/_components/ContestTabs.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/_components/ContestTabs.tsx
@@ -22,7 +22,7 @@ export function ContestTabs({ contestId }: { contestId: string }) {
         <Link
           href={`/contest/${id}` as Route}
           className={cn(
-            'flex w-1/2 justify-center p-[18px] text-lg',
+            'flex w-1/2 justify-center p-[18px] py-[22.5px] text-lg',
             isCurrentTab('') &&
               'text-primary border-b-primary border-b-4 font-semibold'
           )}
@@ -32,7 +32,7 @@ export function ContestTabs({ contestId }: { contestId: string }) {
         <Link
           href={`/contest/${id}/announcement` as Route}
           className={cn(
-            'flex w-1/2 justify-center p-[18px] text-lg',
+            'flex w-1/2 justify-center p-[18px] py-[22.5px] text-lg',
             isCurrentTab('announcement') &&
               'text-primary border-b-primary border-b-4 font-semibold'
           )}
@@ -42,7 +42,7 @@ export function ContestTabs({ contestId }: { contestId: string }) {
         <Link
           href={`/contest/${id}/leaderboard` as Route}
           className={cn(
-            'flex w-1/2 justify-center p-[18px] text-lg',
+            'flex w-1/2 justify-center p-[18px] py-[22.5px] text-lg',
             isCurrentTab('leaderboard') &&
               'text-primary border-b-primary border-b-4 font-semibold'
           )}
@@ -52,7 +52,7 @@ export function ContestTabs({ contestId }: { contestId: string }) {
         <Link
           href={`/contest/${id}/statistics` as Route}
           className={cn(
-            'flex w-1/2 justify-center p-[18px] text-lg',
+            'flex w-1/2 justify-center p-[18px] py-[22.5px] text-lg',
             isCurrentTab('statistics') &&
               'text-primary border-b-primary border-b-4 font-semibold'
           )}
@@ -62,7 +62,7 @@ export function ContestTabs({ contestId }: { contestId: string }) {
         <Link
           href={`/contest/${id}/qna` as Route}
           className={cn(
-            'flex w-1/2 justify-center p-[18px] text-lg',
+            'flex w-1/2 justify-center p-[18px] py-[22.5px] text-lg',
             isCurrentTab('qna') &&
               'text-primary border-b-primary border-b-4 font-semibold'
           )}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
contest 배너와 탭 간격 수정하였습니다.(py-[22.5px])

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
closes tas-1365
### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
