### PR TITLE
feat(be): disable contest problems auth guard

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { ContestRole, Prisma, Role, type Contest } from '@prisma/client'
+import { ContestRole, Prisma, type Contest } from '@prisma/client'
 import {
   ConflictFoundException,
   EntityNotExistException,
@@ -169,7 +169,7 @@ export class ContestService {
     }
   }
 
-  async getContest(id: number, userId?: number) {
+  async getContest(id: number, userId?: number | null) {
     // check if the user has already registered this contest
     // initial value is false
     let isRegistered = false

--- a/apps/backend/apps/client/src/problem/problem.controller.ts
+++ b/apps/backend/apps/client/src/problem/problem.controller.ts
@@ -6,7 +6,11 @@ import {
   Query,
   Req
 } from '@nestjs/common'
-import { AuthNotNeededIfPublic, AuthenticatedRequest } from '@libs/auth'
+import {
+  AuthNotNeededIfPublic,
+  AuthenticatedRequest,
+  UserNullWhenAuthFailedIfPublic
+} from '@libs/auth'
 import { UnprocessableDataException } from '@libs/exception'
 import {
   CursorValidationPipe,
@@ -94,6 +98,7 @@ export class ContestProblemController {
   constructor(private readonly contestProblemService: ContestProblemService) {}
 
   @Get()
+  @UserNullWhenAuthFailedIfPublic()
   async getContestProblems(
     @Req() req: AuthenticatedRequest,
     @Param('contestId', IDValidationPipe) contestId: number,
@@ -103,7 +108,7 @@ export class ContestProblemController {
   ) {
     return await this.contestProblemService.getContestProblems({
       contestId,
-      userId: req.user.id,
+      userId: req.user?.id,
       cursor,
       take
     })

--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -253,7 +253,7 @@ export class ContestProblemService {
     take
   }: {
     contestId: number
-    userId: number
+    userId: number | null
     cursor: number | null
     take: number
   }) {

--- a/collection/client/Problem/Get Contest Problems/Succeed.bru
+++ b/collection/client/Problem/Get Contest Problems/Succeed.bru
@@ -5,12 +5,12 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/contest/1/problem?take=5
+  url: {{baseUrl}}/contest/6/problem?take=5
   body: none
   auth: none
 }
 
-query {
+params:query {
   take: 5
   ~cursor: 4
   ~groupId: 2
@@ -27,14 +27,8 @@ assert {
   res.body.total: isNumber
 }
 
-script:pre-request {
-  await require("./login").loginUser(req);
-}
-
 docs {
   # Get Contest Problems
-  
-  > 로그인이 필요한 API입니다.
   
   대회의 문제 목록을 가져옵니다.
   
@@ -50,4 +44,5 @@ docs {
   
   - 대회에 등록한 사용자는 대회 시작 전까지 문제를 열람할 수 없습니다.
   - 대회에 등록하지 않은 사용자는 대회가 끝나기 전까지 문제를 열람할 수 없습니다.
+  - 대회가 끝난 경우 로그인하지 않은 사용자도 문제 목록을 열람할 수 있습니다.
 }


### PR DESCRIPTION
### Description

- 현재 contest problem controller에서 auth guard가 막고 있어, 로그인 하지 않으면 끝난 contest여도 문제 목록을 볼 수 없도록 되어있습니다.
- UserNullWhenAuthFailedIfPublic guard를 추가하여 이 문제를 해결하였습니다.

### Additional context

- userId 가 null인 경우를 고려할 수 있도록 service code를 수정하였습니다.

---

### Before submitting the PR, please make sure you do the following
closes TAS-1383

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
