### PR TITLE
feat(fe): improve management course grade table link

### DIFF
--- a/apps/frontend/app/admin/_components/table/DataTable.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTable.tsx
@@ -96,11 +96,29 @@ export function DataTable<TData extends { id: number }, TRoute extends string>({
                   }
                 }}
               >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} className="text-center md:p-4">
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+                {row.getVisibleCells().map((cell) => {
+                  const meta = cell.column.columnDef.meta as {
+                    link: (row: TData) => string
+                  }
+                  const href = meta?.link(row.original)
+                  return (
+                    <TableCell
+                      key={cell.id}
+                      className="text-center md:p-4"
+                      onClick={(e) => {
+                        if (href) {
+                          e.stopPropagation()
+                          router.push(href as Route)
+                        }
+                      }}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  )
+                })}
               </TableRow>
             ))
           ) : (

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/Columns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/Columns.tsx
@@ -22,7 +22,9 @@ interface DataTableScoreSummary {
 }
 
 export const createColumns = (
-  problemData: ProblemData[]
+  problemData: ProblemData[],
+  courseId: number,
+  assignmentId: number
 ): ColumnDef<DataTableScoreSummary>[] => {
   return [
     {
@@ -68,6 +70,10 @@ export const createColumns = (
               : `-/${problem.score}`}
           </div>
         )
+      },
+      meta: {
+        link: (row: DataTableScoreSummary) =>
+          `/admin/course/${courseId}/grade/assignment/${assignmentId}/user/${row.id}/problem/${problem.problemId}`
       }
     })),
     {

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/ParticipantTable.tsx
@@ -200,7 +200,7 @@ export function ParticipantTable({
         </div>
         <DataTable
           getHref={(data) =>
-            `/admin/course/${groupId}/grade/assignment/${assignmentId}/user/${data.id}/problem/1` as Route
+            `/admin/course/${groupId}/grade/assignment/${assignmentId}/user/${data.id}/problem/${problemData[0].problemId}` as Route
           }
         />
         <DataTablePagination />

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/ParticipantTable.tsx
@@ -37,7 +37,7 @@ export function ParticipantTable({
     }
   }).data?.getAssignment
 
-  const [updateAssignment, { error }] = useMutation(UPDATE_ASSIGNMENT)
+  const [updateAssignment] = useMutation(UPDATE_ASSIGNMENT)
 
   const summaries = useSuspenseQuery(GET_ASSIGNMENT_SCORE_SUMMARIES, {
     variables: { groupId, assignmentId, take: 300 }
@@ -137,7 +137,10 @@ export function ParticipantTable({
         <span className="text-primary font-bold">{summariesData.length}</span>{' '}
         Participants
       </p>
-      <DataTableRoot data={summariesData} columns={createColumns(problemData)}>
+      <DataTableRoot
+        data={summariesData}
+        columns={createColumns(problemData, groupId, assignmentId)}
+      >
         <div className="flex items-center gap-4">
           <DataTableSearchBar columndId="realName" placeholder="Search Name" />
           <div className="flex items-center gap-2">
@@ -197,7 +200,7 @@ export function ParticipantTable({
         </div>
         <DataTable
           getHref={(data) =>
-            `/admin/course/${groupId}/grade/assignment/${assignmentId}/user/${data.id}` as Route
+            `/admin/course/${groupId}/grade/assignment/${assignmentId}/user/${data.id}/problem/1` as Route
           }
         />
         <DataTablePagination />
@@ -210,7 +213,7 @@ export function ParticipantTableFallback() {
   return (
     <div>
       <Skeleton className="mb-3 h-[24px] w-2/12" />
-      <DataTableFallback columns={createColumns([])} />
+      <DataTableFallback columns={createColumns([], 0, 0)} />
     </div>
   )
 }


### PR DESCRIPTION
### Description

기존에는 getHref를 통해 Row 단위로만 링크를 추가할 수 있었지만, columns.tsx에서 meta: link를 추가하면 Cell 단위로 링크를 이동할 수 있도록 변경했습니다. 솔직히 이렇게 Tanstack table의 meta를 활용해도 되는지 잘 모르겠고, type 관련해서도 좀 조잡하긴 합니다. 하지만 유저의 특정 문제 점수를 클릭했을 때 해당 문제로 이동하는 기능은 반드시 필요하겠다는 생각이 들어 이렇게라도 구현해야 할 것 같았습니다. 

결론: Management Course Grade Assignment Table에서 그냥 Row를 누르면 해당 유저의 첫 번째 문제로 이동, A / B / C 등 문제 Column의 Cell을 누르면 해당 유저의 해당 문제로 이동.

closes TAS-1386

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
