### PR TITLE
feat(fe): change init design qa

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/StatusBadge.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/StatusBadge.tsx
@@ -40,9 +40,9 @@ interface Props {
 export function StatusBadge({ variant }: Props) {
   const { image, text, color } = variants[variant]
   return (
-    <div className="inline-flex items-center gap-2">
+    <div className="inline-flex items-center gap-[6px]">
       <Image src={image} alt={text} />
-      <p className={cn('font-mono font-medium', color)}>{text}</p>
+      <p className={cn('font-sans text-sm font-semibold', color)}>{text}</p>
     </div>
   )
 }

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/CourseInfoBox.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/CourseInfoBox.tsx
@@ -33,28 +33,30 @@ export function CourseInfoBox({ courseId }: CourseInfoBoxProps) {
       <div className="flex gap-1">
         <Image src={ongoingIcon} alt="ongoing" width={20} height={20} />
         {/* FIXME: 하드코딩된 ONGOING 대신 데이터를 받아와주세요 */}
-        <p className="text-primary">{course && 'ONGOING'}</p>
+        <p className="text-primary text-sm font-semibold">
+          {course && 'ONGOING'}
+        </p>
       </div>
-      <p className="line-clamp-2 w-56 break-words text-base font-semibold">
+      <p className="line-clamp-2 w-56 break-words text-lg font-semibold tracking-[-0.54px]">
         {course
           ? `[${course.courseInfo.courseNum}_${course.courseInfo.classNum}] ${course.groupName}`
           : ''}
       </p>
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-2">
+      <div className="mt-2 flex flex-col gap-2">
+        <div className="flex gap-[14px]">
           <Image src={calendarIcon} alt="calendar" width={16} height={16} />
-          <p className="font-medium text-[#8A8A8A]">
+          <p className="text-sm font-medium tracking-[-0.42px] text-[#8A8A8A]">
             {course ? course.courseInfo.semester : ''}
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-[14px]">
           <Image
             src={personFillIcon}
             alt="person-fill"
             width={16}
             height={16}
           />
-          <p className="font-medium text-[#8A8A8A]">
+          <p className="text-sm font-medium tracking-[-0.42px] text-[#8A8A8A]">
             {course ? `${course.courseInfo.professor} 교수` : ''}
           </p>
         </div>

--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
@@ -18,27 +18,27 @@ export function CourseCard({ course, color }: CourseCardProps) {
   return (
     <div className="flex h-[300px] w-[310px] flex-col justify-between rounded-lg border border-gray-200 shadow-none">
       <div className={cn('h-[108px] rounded-t-lg', color)} />
-      <div className="flex h-[192px] w-full flex-col justify-between px-6 py-6">
+      <div className="flex h-[192px] w-full flex-col justify-between gap-3 px-6 pb-8 pt-[26px]">
         <StatusBadge variant={'ongoing'} />
-        <div className="my-1 line-clamp-1 h-6 w-[347px] text-ellipsis whitespace-pre-wrap text-lg font-semibold leading-tight text-black">
+        <div className="text-ellipsis whitespace-pre-wrap text-lg font-semibold leading-tight tracking-[-0.54px] text-black">
           [{course?.courseInfo?.courseNum}_{course?.courseInfo?.classNum}]{' '}
           {course.groupName}
         </div>
-        <div className="flex flex-col gap-1">
-          <div className="inline-flex items-center gap-2 whitespace-nowrap text-xs text-gray-800">
+        <div className="flex flex-col gap-1 pt-1">
+          <div className="inline-flex items-center gap-[14px] whitespace-nowrap">
             <Image src={calendarIcon} alt="calendar" width={16} height={16} />
-            <p className="my-2 text-sm font-medium text-[#8A8A8A]">
+            <p className="my-2 text-sm font-medium tracking-[-0.42px] text-[#8A8A8A]">
               {course?.courseInfo?.semester}
             </p>
           </div>
-          <div className="inline-flex items-center gap-2 whitespace-nowrap text-xs text-gray-800">
+          <div className="inline-flex items-center gap-[14px] whitespace-nowrap">
             <Image
               src={personFillIcon}
               alt="person-fill"
               width={16}
               height={16}
             />
-            <p className="text-sm font-medium text-[#8A8A8A]">
+            <p className="text-sm font-medium tracking-[-0.42px] text-[#8A8A8A]">
               Prof. {course?.courseInfo?.professor}{' '}
             </p>
           </div>

--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
@@ -27,7 +27,7 @@ export function CourseCard({ course, color }: CourseCardProps) {
         <div className="flex flex-col gap-1">
           <div className="inline-flex items-center gap-2 whitespace-nowrap text-xs text-gray-800">
             <Image src={calendarIcon} alt="calendar" width={16} height={16} />
-            <p className="my-2 text-sm font-medium text-neutral-600">
+            <p className="my-2 text-sm font-medium text-[#8A8A8A]">
               {course?.courseInfo?.semester}
             </p>
           </div>
@@ -38,7 +38,7 @@ export function CourseCard({ course, color }: CourseCardProps) {
               width={16}
               height={16}
             />
-            <p className="text-sm font-medium text-neutral-600">
+            <p className="text-sm font-medium text-[#8A8A8A]">
               Prof. {course?.courseInfo?.professor}{' '}
             </p>
           </div>

--- a/apps/frontend/app/(client)/(main)/course/_components/CourseMainBanner.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseMainBanner.tsx
@@ -156,7 +156,6 @@ export function CourseMainBanner({ course }: { course: JoinedCourse | null }) {
           </div>
         ))}
       </div>
-      <div className="h-[100px]" />
     </div>
   )
 }

--- a/apps/frontend/app/(client)/(main)/course/page.tsx
+++ b/apps/frontend/app/(client)/(main)/course/page.tsx
@@ -40,7 +40,7 @@ export default async function Course() {
   return (
     <>
       <CourseMainBanner course={null} />
-      <div className="flex w-full max-w-7xl flex-col gap-5 p-5 py-8">
+      <div className="flex w-full max-w-7xl flex-col gap-5 p-5 pb-8 pt-[100px]">
         <ErrorBoundary fallback={FetchErrorFallback}>
           <Suspense fallback={<CardListFallback />}>
             <CourseCardList title="MY COURSE" />

--- a/apps/frontend/components/shadcn/carousel.tsx
+++ b/apps/frontend/components/shadcn/carousel.tsx
@@ -208,7 +208,7 @@ const CarouselPrevious = React.forwardRef<
       className={cn(
         'flex h-8 w-8 items-center justify-center disabled:opacity-100',
         orientation === 'horizontal'
-          ? '-right-12 -translate-y-1/2'
+          ? '-right-12 -translate-y-[0px]'
           : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
@@ -246,7 +246,7 @@ const CarouselNext = React.forwardRef<
       className={cn(
         'flex h-8 w-8 items-center justify-center disabled:opacity-100',
         orientation === 'horizontal'
-          ? '-right-12 top-1/2 -translate-y-1/2'
+          ? '-right-12 top-1/2 -translate-y-[0px]'
           : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}


### PR DESCRIPTION
### Description

Before:
![스크린샷 2025-03-03 070024](https://github.com/user-attachments/assets/38328c62-25d7-474f-a763-9e5dc85f283d)
![스크린샷 2025-03-03 070153](https://github.com/user-attachments/assets/4c3ab1e9-6d84-4c33-afa3-39b0d62c9b40)

After: 
![스크린샷 2025-03-03 070037](https://github.com/user-attachments/assets/a5a16c1e-d246-48b0-842c-16a0646223cc)
![스크린샷 2025-03-03 070202](https://github.com/user-attachments/assets/f2687ded-e63c-430e-a1b2-3e29ce3dc6b2)

보민님이 올려주신 것 이외에 추가로 `CarouselPrevious`, `CarouselNext` 버튼이 `-translate-y-1/2` 속성 때문에 위쪽으로 좀 튀어나오더라고요... Course List 뿐 아니라 유자차쪽 `ContestFeatureList` 쪽에서도 동일한 현상이 있는 듯해 한꺼번에 변경했습니다!

댓글로 남겨주신 Course 메인 페이지의 카드 및 My Course 타이틀의 가로 위치(가로 길이 전체 1440 기준 맨 좌측과의 간격 116)의 경우에는 제 짧은 지식으로는 기기 넓이에 따라 가로 간격을 픽셀 단위로 변경하는 게 어려울 것 같아 수정하지 않았습니다. 현재 `CourseCardList`의 최대 넓이가 `max-w-7xl`(1280px)로 설정되어 있는데 그냥 (1440-116*2=1208px)로 하면 되는 건지... 좋은 방법 있으신 분 알려주세요!!

closes TAS-1387

### Additional context

솔직히 2px 차이까지 눈치채고 알려주실 필요까진 없다고 생각했으나... 코드당이 건강해지는 과정이라고 생각하고 열심히 작업했습니다!! (그래도 앞으로는 좀만 눈을 작게 뜨고 확인해주셔도...ㅎㅎ)

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
