### PR TITLE
feat(fe): lock problem isvisible false when not admin

### DIFF
--- a/apps/frontend/app/admin/problem/[problemId]/edit/page.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/page.tsx
@@ -3,6 +3,7 @@
 import { ConfirmNavigation } from '@/app/admin/_components/ConfirmNavigation'
 import { Button } from '@/components/shadcn/button'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
+import { useSession } from '@/libs/hooks/useSession'
 import type { UpdateProblemInput } from '@generated/graphql'
 import { valibotResolver } from '@hookform/resolvers/valibot'
 import Link from 'next/link'
@@ -24,6 +25,9 @@ import { EditProblemForm } from './_components/EditProblemForm'
 
 export default function Page({ params }: { params: { problemId: string } }) {
   const { problemId } = params
+
+  const session = useSession()
+  const isAdmin = session?.user?.role !== 'User'
 
   const methods = useForm<UpdateProblemInput>({
     resolver: valibotResolver(editSchema),
@@ -50,7 +54,9 @@ export default function Page({ params }: { params: { problemId: string } }) {
               <FormSection title="Visible">
                 <PopoverVisibleInfo />
                 <VisibleForm
-                  blockEdit={methods.getValues('isVisible') === null}
+                  blockEdit={
+                    methods.getValues('isVisible') === null || !isAdmin
+                  }
                 />
               </FormSection>
             </div>

--- a/apps/frontend/app/admin/problem/create/_components/CreateProblemForm.tsx
+++ b/apps/frontend/app/admin/problem/create/_components/CreateProblemForm.tsx
@@ -3,6 +3,7 @@
 import { useConfirmNavigationContext } from '@/app/admin/_components/ConfirmNavigation'
 import { createSchema } from '@/app/admin/problem/_libs/schemas'
 import { CREATE_PROBLEM } from '@/graphql/problem/mutations'
+import { useSession } from '@/libs/hooks/useSession'
 import { useMutation } from '@apollo/client'
 import { Level, type CreateProblemInput } from '@generated/graphql'
 import { valibotResolver } from '@hookform/resolvers/valibot'
@@ -18,6 +19,9 @@ interface CreateProblemFormProps {
 }
 
 export function CreateProblemForm({ children }: CreateProblemFormProps) {
+  const session = useSession()
+  const isAdmin = session?.user?.role !== 'User'
+
   const methods = useForm<CreateProblemInput>({
     resolver: valibotResolver(createSchema),
     defaultValues: {
@@ -32,7 +36,7 @@ export function CreateProblemForm({ children }: CreateProblemFormProps) {
       hint: '',
       source: '',
       template: [],
-      isVisible: true
+      isVisible: isAdmin
     }
   })
 

--- a/apps/frontend/app/admin/problem/create/page.tsx
+++ b/apps/frontend/app/admin/problem/create/page.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import { Button } from '@/components/shadcn/button'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
+import { useSession } from '@/libs/hooks/useSession'
 import Link from 'next/link'
 import { FaAngleLeft } from 'react-icons/fa6'
 import { IoMdCheckmarkCircleOutline } from 'react-icons/io'
@@ -17,6 +20,8 @@ import { TestcaseField } from '../_components/TestcaseField'
 import { CreateProblemForm } from './_components/CreateProblemForm'
 
 export default function Page() {
+  const session = useSession()
+  const isAdmin = session?.user?.role !== 'User'
   return (
     <ConfirmNavigation>
       <ScrollArea className="shrink-0">
@@ -36,7 +41,7 @@ export default function Page() {
 
               <FormSection title="Visible">
                 <PopoverVisibleInfo />
-                <VisibleForm />
+                <VisibleForm blockEdit={!isAdmin} />
               </FormSection>
             </div>
 


### PR DESCRIPTION
### Description

admin 계정이 아닐 시 problem create에서 `isVisible` 값을 false로 고정하고 변경 불가능하게 하였으며, problem edit에서 역시 admin 계정이 아닐 시 `isVisible` 값을 변경 불가능하게 하였습니다.

Instructor 계정으로 들어간 problem create 화면: 
![image](https://github.com/user-attachments/assets/21a8a947-3dc2-4a72-9588-4b25d9f15f5b)

closes TAS-1408


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
