### PR TITLE
fix(be): cannot make is visible on update problem when not admin

### DIFF
--- a/apps/backend/apps/admin/src/problem/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.ts
@@ -549,6 +549,13 @@ export class ProblemService {
   ) {
     const { id, languages, template, tags, testcases, isVisible, ...data } =
       input
+
+    if (userRole == Role.User && isVisible == true) {
+      throw new UnprocessableDataException(
+        'User cannot set a problem to public'
+      )
+    }
+
     const problem = await this.prisma.problem.findFirstOrThrow({
       where: { id },
       include: {


### PR DESCRIPTION
### Description

create problem에서는 user role이 admin이 아닐 때 isvisible을 true로 변경하는 지 검사하지만, 
update 할 때는 이것을 검사하지 않아 아직 visible을 true로 변경할 수 있었습니다. 수정하지 못하도록 바꿉니다. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
