### PR TITLE
fix(fe): modify user table query from group members to users

### DIFF
--- a/apps/frontend/app/admin/user/_components/Columns.tsx
+++ b/apps/frontend/app/admin/user/_components/Columns.tsx
@@ -3,32 +3,75 @@ import type { ColumnDef } from '@tanstack/react-table'
 interface DataTableUser {
   id: number
   username: string
-  userId: number
-  name: string
+  realName: string
   email: string
+  studentId: string
+  major: string
+  role: string
+  canCreateCourse: boolean
+  canCreateContest: boolean
+  lastLogin: string
+  createTime: string
 }
 
 export const columns: ColumnDef<DataTableUser>[] = [
   {
-    accessorKey: 'userId',
-    header: '#',
-    cell: ({ row }) => <div>{row.getValue('userId')}</div>
+    accessorKey: 'id',
+    header: () => <p className="text-xs">#</p>,
+    cell: ({ row }) => <p>{row.getValue('id')}</p>
   },
   {
     accessorKey: 'username',
-    header: 'User ID',
-    cell: ({ row }) => <div>{row.getValue('username')}</div>
+    header: () => <p className="text-xs">User ID</p>,
+    cell: ({ row }) => <p>{row.getValue('username')}</p>
   },
   {
-    accessorKey: 'name',
-    header: 'Name',
-    cell: ({ row }) => {
-      return <div>{row.getValue('name') || '-'}</div>
-    }
+    accessorKey: 'realName',
+    header: () => <p className="text-xs">Name</p>,
+    cell: ({ row }) => <p className="text-nowrap">{row.getValue('realName')}</p>
   },
   {
     accessorKey: 'email',
-    header: 'Email',
-    cell: ({ row }) => <div>{row.getValue('email')}</div>
+    header: () => <p className="text-xs">Email</p>,
+    cell: ({ row }) => <p>{row.getValue('email')}</p>
+  },
+  {
+    accessorKey: 'studentId',
+    header: () => <p className="text-xs">Student ID</p>,
+    cell: ({ row }) => <p>{row.getValue('studentId')}</p>
+  },
+  {
+    accessorKey: 'major',
+    header: () => <p className="text-xs">Major</p>,
+    cell: ({ row }) => <p className="text-nowrap">{row.getValue('major')}</p>
+  },
+  {
+    accessorKey: 'role',
+    header: () => <p className="text-xs">Role</p>,
+    cell: ({ row }) => <p>{row.getValue('role')}</p>
+  },
+  {
+    accessorKey: 'canCreateCourse',
+    header: () => <p className="text-xs">Can Create Course</p>,
+    cell: ({ row }) => <p>{row.getValue('canCreateCourse') ? 'Yes' : 'No'}</p>
+  },
+  {
+    accessorKey: 'canCreateContest',
+    header: () => <p className="text-xs">Can Create Contest</p>,
+    cell: ({ row }) => <p>{row.getValue('canCreateContest') ? 'Yes' : 'No'}</p>
+  },
+  {
+    accessorKey: 'lastLogin',
+    header: () => <p className="text-xs">Last Login</p>,
+    cell: ({ row }) => (
+      <p className="text-nowrap">{row.getValue('lastLogin')}</p>
+    )
+  },
+  {
+    accessorKey: 'createTime',
+    header: () => <p className="text-xs">Create Time</p>,
+    cell: ({ row }) => (
+      <p className="text-nowrap">{row.getValue('createTime')}</p>
+    )
   }
 ]

--- a/apps/frontend/app/admin/user/_components/UserTable.tsx
+++ b/apps/frontend/app/admin/user/_components/UserTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { GET_GROUP_MEMBERS } from '@/graphql/user/queries'
+import { GET_USERS } from '@/graphql/user/queries'
+import { dateFormatter } from '@/libs/utils'
 import { useSuspenseQuery } from '@apollo/client'
 import {
   DataTable,
@@ -11,21 +12,31 @@ import {
 import { columns } from './Columns'
 
 export function UserTable() {
-  const { data } = useSuspenseQuery(GET_GROUP_MEMBERS, {
+  const { data } = useSuspenseQuery(GET_USERS, {
     variables: {
-      groupId: 1,
-      cursor: 1,
-      take: 5000,
-      leaderOnly: false
+      take: 5000
     }
   })
-  const users = data.getGroupMembers.map((member) => ({
-    ...member,
-    id: member.userId
+  const users = data.getUsers
+
+  const mappedUsers = users.map((user) => ({
+    id: Number(user.id),
+    username: user.username,
+    realName: user.userProfile ? user.userProfile.realName : '-',
+    email: user.email,
+    studentId: user.studentId,
+    major: user.major ?? '-',
+    role: user.role,
+    canCreateCourse: user.canCreateCourse,
+    canCreateContest: user.canCreateContest,
+    lastLogin: dateFormatter(user.lastLogin, 'YYYY-MM-DD HH:mm:ss'),
+    createTime: user.userProfile
+      ? dateFormatter(user.userProfile.createTime, 'YYYY-MM-DD HH:mm:ss')
+      : '-'
   }))
 
   return (
-    <DataTableRoot data={users} columns={columns}>
+    <DataTableRoot data={mappedUsers} columns={columns}>
       <DataTable />
       <DataTablePagination />
     </DataTableRoot>

--- a/apps/frontend/graphql/user/queries.ts
+++ b/apps/frontend/graphql/user/queries.ts
@@ -1,5 +1,25 @@
 import { gql } from '@generated'
 
+const GET_USERS = gql(`
+  query GetUsers($cursor: Int, $take: Int!) {
+    getUsers(cursor: $cursor, take: $take) {
+      id
+      userProfile {
+        realName
+        createTime
+      }
+      username
+      email
+      studentId
+      major
+      role
+      canCreateCourse
+      canCreateContest
+      lastLogin
+    }
+  }
+`)
+
 const GET_GROUP_MEMBER =
   gql(`query GetGroupMember($groupId: Int!, $userId: Int!) {
     getGroupMember(groupId: $groupId, userId: $userId) {
@@ -29,4 +49,4 @@ const GET_GROUP_MEMBERS = gql(`
   }
 `)
 
-export { GET_GROUP_MEMBER, GET_GROUP_MEMBERS }
+export { GET_USERS, GET_GROUP_MEMBER, GET_GROUP_MEMBERS }


### PR DESCRIPTION
### Description
`GET_GROUP_MEMBERS` 를  `GET_USERS` 로 대체
기존에 groupId: 1의 member 들만 UserTable에 노출됐었는데
드디어 group과 상관 없이 모든 user들이 보입니다!

role, canCreateCourse, canCreateContest, lastLogin, createTime 등이 Column에 추가되었습니다

![image](https://github.com/user-attachments/assets/c9a2e802-3e18-4602-b769-4ba1b6939171)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
