### PR TITLE
feat(fe): add course and fix management menu in mobile authModal

### DIFF
--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -40,8 +40,10 @@ export function HeaderAuthPanel({
     (state) => state
   )
   const isUser = session?.user.role === 'User'
-  const [hasCanCreateCoursePermission, setHasCanCreateCoursePermission] =
-    useState(false)
+  const [
+    hasCanCreateCourseOrContestPermission,
+    setHasCanCreateCourseOrContestPermission
+  ] = useState(false)
   const [hasAnyGroupLeaderRole, setHasAnyGroupLeaderRole] = useState(false)
   const isEditor = group === 'editor'
   const [needsUpdate, setNeedsUpdate] = useState(false)
@@ -56,13 +58,14 @@ export function HeaderAuthPanel({
         studentId: string
         major: string
         canCreateCourse: boolean
+        canCreateContest: boolean
       } = await userResponse.json()
       const updateNeeded =
         user.role === 'User' &&
         (user.studentId === '0000000000' || user.major === 'none')
 
-      if (user.canCreateCourse) {
-        setHasCanCreateCoursePermission(true)
+      if (user.canCreateCourse || user.canCreateContest) {
+        setHasCanCreateCourseOrContestPermission(true)
       }
       setNeedsUpdate(updateNeeded)
     }
@@ -117,12 +120,13 @@ export function HeaderAuthPanel({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               className={cn(
+                'hidden md:block',
                 isEditor &&
                   'mr-5 rounded-sm border-none bg-[#4C5565] px-0 font-normal text-white'
               )}
             >
               {(hasAnyGroupLeaderRole ||
-                hasCanCreateCoursePermission ||
+                hasCanCreateCourseOrContestPermission ||
                 !isUser) && (
                 <Link href="/admin">
                   <DropdownMenuItem
@@ -219,7 +223,7 @@ export function HeaderAuthPanel({
           <DropdownMenuTrigger className="flex gap-2 px-4 py-1 md:hidden">
             <RxHamburgerMenu size="30" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent>
+          <DropdownMenuContent className="md:hidden">
             <DropdownMenuItem
               className="text-primary flex cursor-pointer items-center gap-1 font-semibold"
               onClick={() => {
@@ -245,8 +249,15 @@ export function HeaderAuthPanel({
                 Problem
               </DropdownMenuItem>
             </Link>
+            <Link href="/course">
+              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+                Course
+              </DropdownMenuItem>
+            </Link>
             <DropdownMenuSeparator className="bg-gray-300" />
-            {session?.user.role !== 'User' && (
+            {(hasAnyGroupLeaderRole ||
+              hasCanCreateCourseOrContestPermission ||
+              !isUser) && (
               <Link href="/admin">
                 <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
                   <UserRoundCog className="size-4" /> Management
@@ -280,7 +291,7 @@ export function HeaderAuthPanel({
           <DropdownMenuTrigger className="flex gap-2 px-4 py-1 md:hidden">
             <RxHamburgerMenu size="30" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent>
+          <DropdownMenuContent className="md:hidden">
             <Link href="/notice">
               <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
                 Notice
@@ -294,6 +305,11 @@ export function HeaderAuthPanel({
             <Link href="/problem">
               <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
                 Problem
+              </DropdownMenuItem>
+            </Link>
+            <Link href="/course">
+              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+                Course
               </DropdownMenuItem>
             </Link>
             <DropdownMenuSeparator className="bg-gray-300" />


### PR DESCRIPTION
### Description

모바일 환경에서 나오는 헤더 대신 나오는 드롭다운에 
Course를 추가하고, Management 사이드바도 최신 로직을 반영합니다.

추가적으로, 데스크탑 드롭다운을 펼치고 브라우저 창의 길이를 줄여 md 이하가 되었을 때 해당 dropdown이 보이지 않게 변경합니다.

![Uploading image.png…]()


closes TAS-1421
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
