### PR TITLE
fix(fe): impl grade code editor without user submission

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/[submissionId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/[submissionId]/page.tsx
@@ -2,7 +2,6 @@ import { FetchErrorFallback } from '@/components/FetchErrorFallback'
 import { Skeleton } from '@/components/shadcn/skeleton'
 import { ErrorBoundary } from '@suspensive/react'
 import { ArrowLeft } from 'lucide-react'
-import type { Route } from 'next'
 import Link from 'next/link'
 import { Suspense } from 'react'
 import { SubmissionDetail } from './_components/SubmissionDetail'
@@ -25,7 +24,7 @@ export default function Page({
       <div className="z-20 flex items-center gap-3">
         <Link
           href={
-            `course/${courseId}/assignment/${assignmentId}/problem/${problemId}/submission` as Route
+            `/course/${courseId}/assignment/${assignmentId}/problem/${problemId}/submission` as const
           }
         >
           <ArrowLeft className="size-5" />

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/_components/SubmissionPaginatedTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/_components/SubmissionPaginatedTable.tsx
@@ -19,11 +19,13 @@ import { columns } from './Columns'
 const itemsPerPage = 20
 
 interface SubmissionPaginatedTableProps {
+  courseId: number
   assignmentId: number
   problemId: number
 }
 
 export function SubmissionPaginatedTable({
+  courseId,
   assignmentId,
   problemId
 }: SubmissionPaginatedTableProps) {
@@ -60,7 +62,9 @@ export function SubmissionPaginatedTable({
       <SubmissionTable
         data={paginatedItems}
         columns={columns}
-        getHref={(row) => `submission/${row.original.id}` as Route}
+        getHref={(row) =>
+          `/course/${courseId}/assignment/${assignmentId}/problem/${problemId}/submission/${row.original.id}` as Route
+        }
       />
       <Paginator>
         <SlotNavigation

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/page.tsx
@@ -9,14 +9,15 @@ import {
 export default function SubmissionPage({
   params
 }: {
-  params: { problemId: string; assignmentId: string }
+  params: { courseId: string; assignmentId: string; problemId: string }
 }) {
-  const { assignmentId, problemId } = params
+  const { courseId, assignmentId, problemId } = params
 
   return (
     <TanstackQueryErrorBoundary fallback={FetchErrorFallback}>
       <Suspense fallback={<SubmissionPaginatedTableFallback />}>
         <SubmissionPaginatedTable
+          courseId={Number(courseId)}
           assignmentId={Number(assignmentId)}
           problemId={Number(problemId)}
         />

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/Columns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/Columns.tsx
@@ -24,7 +24,8 @@ interface DataTableScoreSummary {
 export const createColumns = (
   problemData: ProblemData[],
   courseId: number,
-  assignmentId: number
+  assignmentId: number,
+  isAssignmentFinished: boolean
 ): ColumnDef<DataTableScoreSummary>[] => {
   return [
     {
@@ -72,8 +73,11 @@ export const createColumns = (
         )
       },
       meta: {
-        link: (row: DataTableScoreSummary) =>
-          `/admin/course/${courseId}/grade/assignment/${assignmentId}/user/${row.id}/problem/${problem.problemId}`
+        link: (row: DataTableScoreSummary) => {
+          return isAssignmentFinished
+            ? `/admin/course/${courseId}/grade/assignment/${assignmentId}/user/${row.id}/problem/${problem.problemId}`
+            : null
+        }
       }
     })),
     {

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/_components/ParticipantTable.tsx
@@ -17,10 +17,12 @@ import {
 import { GET_ASSIGNMENT_PROBLEMS } from '@/graphql/problem/queries'
 import excelIcon from '@/public/icons/excel.svg'
 import { useMutation, useQuery, useSuspenseQuery } from '@apollo/client'
+import dayjs from 'dayjs'
 import type { Route } from 'next'
 import Image from 'next/image'
 import { useState } from 'react'
 import { CSVLink } from 'react-csv'
+import { toast } from 'sonner'
 import { createColumns } from './Columns'
 
 export function ParticipantTable({
@@ -70,6 +72,10 @@ export function ParticipantTable({
   }
 
   const assignmentTitle = assignmentData?.title
+
+  const now = dayjs()
+
+  const isAssignmentFinished = now.isAfter(dayjs(assignmentData?.endTime))
 
   const fileName = assignmentTitle
     ? `${assignmentTitle.replace(/\s+/g, '_')}.csv`
@@ -139,7 +145,12 @@ export function ParticipantTable({
       </p>
       <DataTableRoot
         data={summariesData}
-        columns={createColumns(problemData, groupId, assignmentId)}
+        columns={createColumns(
+          problemData,
+          groupId,
+          assignmentId,
+          isAssignmentFinished
+        )}
       >
         <div className="flex items-center gap-4">
           <DataTableSearchBar columndId="realName" placeholder="Search Name" />
@@ -198,11 +209,22 @@ export function ParticipantTable({
             />
           </CSVLink>
         </div>
-        <DataTable
-          getHref={(data) =>
-            `/admin/course/${groupId}/grade/assignment/${assignmentId}/user/${data.id}/problem/${problemData[0].problemId}` as Route
-          }
-        />
+        {isAssignmentFinished ? (
+          <DataTable
+            getHref={(data) =>
+              `/admin/course/${groupId}/grade/assignment/${assignmentId}/user/${data.id}/problem/${problemData[0].problemId}` as Route
+            }
+          />
+        ) : (
+          <div
+            onClick={(e) => {
+              e.preventDefault()
+              toast.error('Only completed assignments can be graded')
+            }}
+          >
+            <DataTable />
+          </div>
+        )}
         <DataTablePagination />
       </DataTableRoot>
     </div>
@@ -213,7 +235,7 @@ export function ParticipantTableFallback() {
   return (
     <div>
       <Skeleton className="mb-3 h-[24px] w-2/12" />
-      <DataTableFallback columns={createColumns([], 0, 0)} />
+      <DataTableFallback columns={createColumns([], 0, 0, true)} />
     </div>
   )
 }

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/EditorLayout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/EditorLayout.tsx
@@ -4,8 +4,7 @@ import { HeaderAuthPanel } from '@/components/auth/HeaderAuthPanel'
 import { GET_ASSIGNMENT } from '@/graphql/assignment/queries'
 import { GET_ASSIGNMENT_LATEST_SUBMISSION } from '@/graphql/submission/queries'
 import codedangLogo from '@/public/logos/codedang-editor.svg'
-import type { Language } from '@/types/type'
-import { useSuspenseQuery } from '@apollo/client'
+import { useQuery, useSuspenseQuery } from '@apollo/client'
 import type { Session } from 'next-auth'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -36,14 +35,16 @@ export function EditorLayout({
     }
   }).data.getAssignment
 
-  const submissionData = useSuspenseQuery(GET_ASSIGNMENT_LATEST_SUBMISSION, {
+  const { data } = useQuery(GET_ASSIGNMENT_LATEST_SUBMISSION, {
     variables: {
       groupId: courseId,
       assignmentId,
       userId,
       problemId
     }
-  }).data?.getAssignmentLatestSubmission
+  })
+
+  const submissionData = data ? data?.getAssignmentLatestSubmission : null
 
   return (
     // Admin Layout의 Sidebar를 무시하기 위한 fixed
@@ -68,7 +69,7 @@ export function EditorLayout({
         <HeaderAuthPanel session={session} group="editor" />
       </header>
       <EditorMainResizablePanel
-        language={submissionData?.language as Language}
+        language={submissionData?.language ?? 'C'}
         code={submissionData?.code ?? ''}
         courseId={courseId}
         userId={userId}

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/EditorResizablePanel.tsx
@@ -14,7 +14,7 @@ import { BiSolidUser } from 'react-icons/bi'
 
 interface ProblemEditorProps {
   code: string
-  language: Language
+  language: string
   courseId: number
   userId: number
   children: React.ReactNode
@@ -68,7 +68,7 @@ export function EditorMainResizablePanel({
               <ScrollArea className="h-full bg-[#121728]">
                 <CodeEditor
                   value={code}
-                  language={language}
+                  language={language as Language}
                   readOnly
                   enableCopyPaste={true}
                   height="100%"

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/SubmissionSummary.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/SubmissionSummary.tsx
@@ -1,12 +1,27 @@
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
 import { dateFormatter, getResultColor } from '@/libs/utils'
+import infoIcon from '@/public/icons/info.svg'
 import type { SubmissionDetail } from '@generated/graphql'
+import Image from 'next/image'
 
 interface SubmissionSummaryProps {
-  submission: SubmissionDetail
+  submission: SubmissionDetail | null
 }
 
 export function SubmissionSummary({ submission }: SubmissionSummaryProps) {
+  if (!submission) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-4 text-center">
+        <Image src={infoIcon} alt="No Submission" width={50} height={50} />
+        <p className="text-xl font-medium">No Submission</p>
+        <div className="text-sm font-normal">
+          <p>No code has been submitted by this student.</p>
+          <p>You may still provide a final score or comment.</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <ScrollArea className="shrink-0 rounded-md">
       <div className="flex items-center justify-around gap-5 bg-[#384151] p-5 text-sm [&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-3 [&_*]:whitespace-nowrap [&_p]:text-[#B0B0B0]">

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/SubmissionTestcase.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/_components/SubmissionTestcase.tsx
@@ -9,10 +9,14 @@ import {
 import type { SubmissionDetail } from '@generated/graphql'
 
 interface SubmissionTestcaseProps {
-  submission: SubmissionDetail
+  submission: SubmissionDetail | null
 }
 
 export function SubmissionTestcase({ submission }: SubmissionTestcaseProps) {
+  if (!submission) {
+    return <div className="h-72" />
+  }
+
   return (
     <div>
       {submission.testcaseResult.length !== 0 && (

--- a/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/grade/assignment/[assignmentId]/user/[userId]/problem/[problemId]/page.tsx
@@ -6,7 +6,7 @@ import { SubmissionTestcase } from '@/app/admin/course/[courseId]/grade/assignme
 import { FetchErrorFallback } from '@/components/FetchErrorFallback'
 import { Skeleton } from '@/components/shadcn/skeleton'
 import { GET_ASSIGNMENT_LATEST_SUBMISSION } from '@/graphql/submission/queries'
-import { useSuspenseQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import type { SubmissionDetail } from '@generated/graphql'
 import { ErrorBoundary } from '@suspensive/react'
 import { Suspense } from 'react'
@@ -23,19 +23,48 @@ interface PageProps {
 export default function Page({ params }: PageProps) {
   const { courseId, assignmentId, userId, problemId } = params
 
-  const submission = useSuspenseQuery(GET_ASSIGNMENT_LATEST_SUBMISSION, {
+  const { data, error } = useQuery(GET_ASSIGNMENT_LATEST_SUBMISSION, {
     variables: {
       groupId: Number(courseId),
       assignmentId: Number(assignmentId),
       userId: Number(userId),
       problemId: Number(problemId)
     }
-  }).data?.getAssignmentLatestSubmission
+  })
+
+  if (error) {
+    return (
+      <div>
+        <div className="px-6 py-4">
+          <SubmissionSummary submission={null} />
+        </div>
+
+        <div className="h-3 bg-[#121728]" />
+
+        <div className="px-6 py-2">
+          <SubmissionTestcase submission={null} />
+        </div>
+
+        <div className="h-3 bg-[#121728]" />
+
+        <div className="px-6 py-6">
+          <SubmissionAssessment
+            groupId={Number(courseId)}
+            assignmentId={Number(assignmentId)}
+            userId={Number(userId)}
+            problemId={Number(problemId)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  const submission = data?.getAssignmentLatestSubmission
 
   return (
     <div className="flex flex-col gap-5 overflow-auto">
       <div className="z-20 flex items-center gap-3 px-6 pt-6">
-        <h1 className="text-xl font-bold">Submission #{submission.id}</h1>
+        <h1 className="text-xl font-bold">Submission #{submission?.id}</h1>
       </div>
       <ErrorBoundary fallback={FetchErrorFallback}>
         <Suspense


### PR DESCRIPTION
### Description
- submission 없을 때의 grade code-editor 구현했습니다 물론 여전히 finalScore 및 comment 입력은 가능합니다
- participant table에서 assignment가 finished가 아닐 때 토스트 노출하도록 했습니다
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Closes TAS-1427

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
