### PR TITLE
chore(fe): put priority for Banner img

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/Cover.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/Cover.tsx
@@ -39,6 +39,7 @@ export function Cover({ title, description }: CoverProps) {
           alt={title}
           className="absolute"
           fill
+          priority
         />
         <div className="absolute z-10 justify-self-center pb-[91px] pt-[157px] text-center md:w-[1440px] md:flex-col md:items-center md:pl-[240.12px] md:pr-[838px] md:text-left">
           <Image


### PR DESCRIPTION
### Description

1. contest inner banner 또는 problem 배너의 이미지가 늦게 렌더링되는 문제가 있었습니다.
2. next 의 이미지 컴포넌트에서 사용할 수 있는 priority 속성을 활용하여 렌더링 속도를 빠르게 했습니다.

![image](https://github.com/user-attachments/assets/651038d6-3e9a-4a06-b262-e4140fbfe83b)
첫 번째 사진은 우선순위가 앞에 있지 않아 x-cache가 miss 된 모습입니다.

![image](https://github.com/user-attachments/assets/f41f93ec-6485-4897-be3a-15555f9da5a6)
두 번째 사진은 캐시도 잘 들어가고, 우선순위가 높아져 렌더링이 빨라진 모습입니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


closes.
---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
