### PR TITLE
feat(fe): try to fix bug Confetti-add-setIsSubmitting

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -135,7 +135,7 @@ export function EditorHeader({
         toast.error('Please try again later.')
       }
     },
-    loading && submissionId ? 500 : null
+    isSubmitting && submissionId ? 500 : null
   )
 
   useEffect(() => {

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -410,6 +410,7 @@ export function EditorHeader({
           language={language}
           disabled={loading}
           saveCode={storeCodeToLocalStorage}
+          setIsSubmitting={setIsSubmitting}
         />
         <Button
           className="h-8 shrink-0 gap-1 rounded-[4px] px-2 font-normal"

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -410,7 +410,6 @@ export function EditorHeader({
           language={language}
           disabled={loading}
           saveCode={storeCodeToLocalStorage}
-          setIsSubmitting={setIsSubmitting}
         />
         <Button
           className="h-8 shrink-0 gap-1 rounded-[4px] px-2 font-normal"

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
@@ -13,6 +13,7 @@ import { useTestcaseStore } from '../context/TestcaseStoreProvider'
 interface RunTestButtonProps extends ButtonProps {
   problemId: number
   language: string
+  setIsSubmitting: (state: boolean) => void
   saveCode: (code: string) => void
 }
 
@@ -20,6 +21,7 @@ export function RunTestButton({
   problemId,
   language,
   saveCode,
+  setIsSubmitting,
   ...props
 }: RunTestButtonProps) {
   const session = useSession()
@@ -111,6 +113,7 @@ export function RunTestButton({
     }
 
     setIsTesting(true)
+    setIsSubmitting(false)
     mutate({ code, testcases })
   }
 

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
@@ -13,7 +13,6 @@ import { useTestcaseStore } from '../context/TestcaseStoreProvider'
 interface RunTestButtonProps extends ButtonProps {
   problemId: number
   language: string
-  setIsSubmitting: (state: boolean) => void
   saveCode: (code: string) => void
 }
 
@@ -21,7 +20,6 @@ export function RunTestButton({
   problemId,
   language,
   saveCode,
-  setIsSubmitting,
   ...props
 }: RunTestButtonProps) {
   const session = useSession()

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/RunTestButton.tsx
@@ -113,7 +113,6 @@ export function RunTestButton({
     }
 
     setIsTesting(true)
-    setIsSubmitting(false)
     mutate({ code, testcases })
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
1. 기존에 문제를 풀 때 유저케이스를 추가한 다음, submit을 누른 후 test를 누르면 터지지 않아야 하는 컨페티가 터지는 경우가 발생했습니다.
2. 컨페티는 useInterval 안에 있는데, useInterval 가 작동하는 조건은 isSubmitting 이 true일때와 submissionId가 true일 때 입니다.
3. 다른 컴포넌트(EditorHeader)에 있는 useInterval가 test 버튼을 눌렀을 때 작동하는 이유는 useInterval가 setIsSubmitting을 false로 바꾸기 전에 컨페티가 비동기적으로 터지기 때문이라고 생각했습니다. 
4. 따라서 test button 안에 isSubmitting 을 false 를 넣었습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
