### PR TITLE
fix(fe): switch last submission api

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/grade/_components/SubmissionDetailModal.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/grade/_components/SubmissionDetailModal.tsx
@@ -22,8 +22,8 @@ export function SubmissionDetailModal({
   problemId,
   gradedAssignment
 }: SubmissionDetailModalProps) {
-  const { data: submissions } = useQuery(
-    assignmentSubmissionQueries.submissionResults({
+  const { data: submission } = useQuery(
+    assignmentSubmissionQueries.lastestSubmissionResult({
       assignmentId: gradedAssignment.id,
       problemId
     })
@@ -33,7 +33,7 @@ export function SubmissionDetailModal({
     assignmentSubmissionQueries.testResult({
       assignmentId: gradedAssignment.id,
       problemId,
-      submissionId: submissions?.data?.[0]?.id ?? 0
+      submissionId: submission?.id ?? 0
     })
   )
   const getResultStyle = (result: string) => {
@@ -46,9 +46,9 @@ export function SubmissionDetailModal({
     return 'rounded-full border border-gray-400 px-2 py-1 text-xs font-light text-gray-400'
   }
 
-  const result = submissions?.data[0]?.result
+  const result = submission?.result
   return (
-    submissions && (
+    submission && (
       <DialogContent
         className="max-h-[80vh] overflow-auto p-14 sm:max-w-2xl"
         onClick={(e) => e.stopPropagation()}
@@ -107,14 +107,14 @@ export function SubmissionDetailModal({
             </span>
           </div>
 
-          {submissions?.data[0] && (
+          {submission && (
             <div>
               <span className="text-sm font-medium">Last Submission</span>
               <ScrollArea className="rounded-md">
                 <div className="flex items-center justify-around gap-5 rounded-lg border border-[#E6E6E6] bg-gray-50 p-5 text-xs [&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-3 [&_*]:whitespace-nowrap [&_p]:text-slate-400">
                   <div>
                     <h2>User ID</h2>
-                    <p>{submissions?.data[0]?.user.username}</p>
+                    <p>{submission?.user.username}</p>
                   </div>
                   <Separator
                     orientation="vertical"
@@ -122,7 +122,7 @@ export function SubmissionDetailModal({
                   />
                   <div>
                     <h2>Language</h2>
-                    <p>{submissions?.data[0]?.language}</p>
+                    <p>{submission?.language}</p>
                   </div>
                   <Separator
                     orientation="vertical"
@@ -130,7 +130,7 @@ export function SubmissionDetailModal({
                   />
                   <div>
                     <h2>Code Size</h2>
-                    <p>{submissions?.data[0]?.codeSize} B</p>
+                    <p>{submission?.codeSize} B</p>
                   </div>
                   <Separator
                     orientation="vertical"
@@ -140,7 +140,7 @@ export function SubmissionDetailModal({
                     <h2>Submission Time</h2>
                     <p>
                       {dateFormatter(
-                        submissions?.data[0]?.createTime ?? '',
+                        submission?.createTime ?? '',
                         'YYYY-MM-DD HH:mm:ss'
                       )}
                     </p>

--- a/apps/frontend/app/(client)/_libs/apis/assignmentSubmission.ts
+++ b/apps/frontend/app/(client)/_libs/apis/assignmentSubmission.ts
@@ -79,6 +79,27 @@ export const getAnonymizedScores = async ({
   return data
 }
 
+export interface GetLatestProblemSubmissionResultRequest {
+  assignmentId: number
+  problemId: number
+}
+
+export const getLatestProblemSubmissionResult = async ({
+  assignmentId,
+  problemId
+}: GetLatestProblemSubmissionResultRequest) => {
+  const response = await safeFetcherWithAuth.get(
+    `assignment/${assignmentId}/submission/latest`,
+    {
+      searchParams: { problemId }
+    }
+  )
+
+  const data = await response.json<ProblemSubmissionResult>()
+  console.log('Fetched data:', data)
+  return data
+}
+
 export interface GetProblemSubmissionResultsRequest {
   assignmentId: number
   problemId: number

--- a/apps/frontend/app/(client)/_libs/apis/assignmentSubmission.ts
+++ b/apps/frontend/app/(client)/_libs/apis/assignmentSubmission.ts
@@ -75,7 +75,6 @@ export const getAnonymizedScores = async ({
   )
 
   const data = await response.json<AnonymizedScore>()
-  console.log('Fetched data:', data)
   return data
 }
 
@@ -96,7 +95,6 @@ export const getLatestProblemSubmissionResult = async ({
   )
 
   const data = await response.json<ProblemSubmissionResult>()
-  console.log('Fetched data:', data)
   return data
 }
 
@@ -132,7 +130,6 @@ export const getProblemSubmissionResults = async ({
   )
 
   const data = await response.json<ProblemSubmissionResultsResponse>()
-  console.log('Fetched data:', data)
   return data
 }
 
@@ -172,7 +169,6 @@ export const getTestResult = async ({
   })
 
   const data = await response.json<SubmissionResponse>()
-  console.log('Fetched data:', data)
   return data
 }
 
@@ -215,6 +211,5 @@ export const getAssignmentGrades = async ({
 }: GetAssignmentGradesRequest) => {
   const response = await safeFetcherWithAuth.get(`course/${groupId}/grade`)
   const data = await response.json<GetAssignmentGradesResponse>()
-  console.log('Fetched data:', data)
   return data
 }

--- a/apps/frontend/app/(client)/_libs/queries/assignmentSubmission.ts
+++ b/apps/frontend/app/(client)/_libs/queries/assignmentSubmission.ts
@@ -4,12 +4,14 @@ import {
   getAssignmentGrades,
   getAssignmentSubmissionDetail,
   getAssignmentSubmissionList,
+  getLatestProblemSubmissionResult,
   getProblemSubmissionResults,
   getTestResult,
   type GetAnonymizedScoresRequest,
   type GetAssignmentGradesRequest,
   type GetAssignmentSubmissionDetailRequest,
   type GetAssignmentSubmissionListRequest,
+  type GetLatestProblemSubmissionResultRequest,
   type GetProblemSubmissionResultsRequest,
   type GetTestResultRequest
 } from '../apis/assignmentSubmission'
@@ -72,6 +74,19 @@ export const assignmentSubmissionQueries = {
     queryOptions({
       queryKey: ['assignment', assignmentId, courseId],
       queryFn: () => getAnonymizedScores({ assignmentId, courseId })
+    }),
+
+  lastestSubmissionResult: ({
+    assignmentId,
+    problemId
+  }: GetLatestProblemSubmissionResultRequest) =>
+    queryOptions({
+      queryKey: ['assignment', assignmentId, problemId],
+      queryFn: () =>
+        getLatestProblemSubmissionResult({
+          assignmentId,
+          problemId
+        })
     }),
 
   submissionResults: ({


### PR DESCRIPTION
### Description

Get Assignment Submissions → 마지막 제출 결과만 필요한데 → 모든 제출결과가 오고 있어서 →
Get Latest Assignment Submission를 사용하도록 변경하였습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

<img width="1806" alt="image" src="https://github.com/user-attachments/assets/e74c6784-b677-43e0-8f5b-e5b495e8c58c" />

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1438
