### PR TITLE
fix(fe): fix codedang-with-text logo cursor bug

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/Header.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/Header.tsx
@@ -18,6 +18,7 @@ export async function Header() {
               alt="코드당"
               width={135.252}
               height={28}
+              className="cursor-pointer"
             />
           </Link>
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
![image](https://github.com/user-attachments/assets/ad475c0d-3105-456b-9dfc-badbd63ea281)

- 맥의 라이브텍스트 기능 때문에 코드당 로고를 텍스트로 인식하여 커서가 저렇게 나옵니다.
    - cursor-pointer만 적용해주면 해결됩니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

Closes TAS-1446

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
