### PR TITLE
feat(fe): add problem preview when creating or editting

### DIFF
--- a/apps/frontend/app/admin/_components/ConfirmNavigation.tsx
+++ b/apps/frontend/app/admin/_components/ConfirmNavigation.tsx
@@ -8,16 +8,45 @@ export const useConfirmNavigation = (
   shouldSkipWarningRef: MutableRefObject<boolean>
 ) => {
   const router = useRouter()
+
   const handleBeforeUnload = (event: BeforeUnloadEvent) => {
     event.preventDefault()
     event.returnValue = ''
   }
 
   useEffect(() => {
+    // 페이지 로드 시 history state에 dummy 데이터 추가 (뒤로가기 감지용)
+    window.history.pushState({ page: 'current' }, '', window.location.href)
+
+    // 뒤로가기 이벤트 처리
+    const handlePopState = () => {
+      if (!shouldSkipWarningRef.current) {
+        const shouldLeave = window.confirm(
+          'Are you sure you want to leave this page? Changes you made may not be saved.'
+        )
+
+        if (shouldLeave) {
+          // 사용자가 확인을 누르면 뒤로가기 허용
+          shouldSkipWarningRef.current = true
+          window.history.back()
+        } else {
+          // 사용자가 취소하면 현재 상태를 history에 다시 추가하여 뒤로가기 취소
+          window.history.pushState(
+            { page: 'current' },
+            '',
+            window.location.href
+          )
+        }
+      }
+    }
+
+    // 페이지 이탈 시 경고
     window.addEventListener('beforeunload', handleBeforeUnload)
+    // 뒤로가기 이벤트 감지
+    window.addEventListener('popstate', handlePopState)
 
+    // Next.js router 확장
     const originalPush = router.push
-
     router.push = (href, ...args) => {
       if (shouldSkipWarningRef.current) {
         originalPush(href, ...args)
@@ -33,6 +62,7 @@ export const useConfirmNavigation = (
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload)
+      window.removeEventListener('popstate', handlePopState)
       router.push = originalPush
     }
   }, [router, shouldSkipWarningRef])
@@ -50,18 +80,41 @@ const ConfirmNavigationContext = createContext<Context | undefined>(undefined)
 
 export function ConfirmNavigation({ children }: ConfirmNavigationProps) {
   const shouldSkipWarning = useRef(false)
-
   const router = useRouter()
+
   const handleBeforeUnload = (event: BeforeUnloadEvent) => {
     event.preventDefault()
     event.returnValue = ''
   }
 
   useEffect(() => {
+    window.history.pushState({ page: 'current' }, '', window.location.href)
+
+    const handlePopState = () => {
+      if (!shouldSkipWarning.current) {
+        const shouldLeave = window.confirm(
+          'Are you sure you want to leave this page? Changes you made may not be saved.'
+        )
+
+        if (shouldLeave) {
+          shouldSkipWarning.current = true
+          console.log('yeses')
+          router.back()
+          router.back()
+        } else {
+          window.history.pushState(
+            { page: 'current' },
+            '',
+            window.location.href
+          )
+        }
+      }
+    }
+
     window.addEventListener('beforeunload', handleBeforeUnload)
+    window.addEventListener('popstate', handlePopState)
 
     const originalPush = router.push
-
     router.push = (href, ...args) => {
       if (shouldSkipWarning.current) {
         originalPush(href, ...args)
@@ -77,6 +130,7 @@ export function ConfirmNavigation({ children }: ConfirmNavigationProps) {
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload)
+      window.removeEventListener('popstate', handlePopState)
       router.push = originalPush
     }
   }, [router, shouldSkipWarning])

--- a/apps/frontend/app/admin/_components/ConfirmNavigation.tsx
+++ b/apps/frontend/app/admin/_components/ConfirmNavigation.tsx
@@ -98,8 +98,6 @@ export function ConfirmNavigation({ children }: ConfirmNavigationProps) {
 
         if (shouldLeave) {
           shouldSkipWarning.current = true
-          console.log('yeses')
-          router.back()
           router.back()
         } else {
           window.history.pushState(

--- a/apps/frontend/app/admin/_components/code-editor/CopyButton.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/CopyButton.tsx
@@ -1,0 +1,170 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/shadcn/tooltip'
+import { cn } from '@/libs/utils'
+import copyBlueIcon from '@/public/icons/copy-blue.svg'
+import { LazyMotion, m, domAnimation } from 'framer-motion'
+import Image from 'next/image'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef
+} from 'react'
+import { useCopyToClipboard } from 'react-use'
+import { toast } from 'sonner'
+
+const useCopy = () => {
+  const [, copyToClipboard] = useCopyToClipboard()
+
+  const [copied, setCopied] = useState(false)
+  const timeoutIDRef = useRef<NodeJS.Timeout | null>(null)
+
+  const copy = (value: string) => {
+    copyToClipboard(value)
+    setCopied(true)
+
+    if (timeoutIDRef.current) {
+      clearTimeout(timeoutIDRef.current)
+    }
+    timeoutIDRef.current = setTimeout(() => {
+      setCopied(false)
+      timeoutIDRef.current = null
+    }, 2000)
+  }
+
+  return { copied, copy }
+}
+
+interface CopyButtonProps extends ComponentPropsWithoutRef<'button'> {
+  iconSize?: number
+  value: string
+  withTooltip?: boolean
+}
+
+export function CopyButton({
+  value,
+  iconSize = 24,
+  withTooltip = true,
+  onClick,
+  className,
+  ...props
+}: CopyButtonProps) {
+  const { copied, copy } = useCopy()
+
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return (
+    <LazyMotion features={domAnimation}>
+      <m.div
+        key={copied ? 'check' : 'clipboard'}
+        initial={mounted ? { y: 10, opacity: 0 } : undefined}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: -10, opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        className={cn('flex items-center justify-center', className)}
+      >
+        {copied ? (
+          <CopyCompleteIcon width={iconSize} height={iconSize} />
+        ) : (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger
+                onClick={(e) => {
+                  onClick?.(e)
+                  copy(value)
+                  toast('Successfully copied', {
+                    unstyled: true,
+                    closeButton: false,
+                    icon: <Image src={copyBlueIcon} alt="copy" />,
+                    style: { backgroundColor: '#f0f8ff' },
+                    classNames: {
+                      toast: 'inline-flex items-center py-2 px-3 rounded gap-2',
+                      title: 'text-primary font-medium'
+                    }
+                  })
+                }}
+                className="transition-opacity hover:opacity-60"
+                {...props}
+              >
+                <CopyIcon width={iconSize} height={iconSize} />
+              </TooltipTrigger>
+              {withTooltip ? (
+                <TooltipContent>
+                  <p>Copy</p>
+                </TooltipContent>
+              ) : null}
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </m.div>
+    </LazyMotion>
+  )
+}
+
+function CopyIcon(props: ComponentPropsWithoutRef<'svg'>) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5 4H14V5.5H15V4C15 3.44772 14.5523 3 14 3H5C4.44772 3 4 3.44772 4 4V16C4 16.5523 4.44771 17 5 17H7.5V16H5L5 4Z"
+        fill="currentColor"
+      />
+      <rect
+        x="9.5"
+        y="7.5"
+        width="10"
+        height="13"
+        rx="0.5"
+        stroke="currentColor"
+      />
+    </svg>
+  )
+}
+
+function CopyCompleteIcon(props: ComponentPropsWithoutRef<'svg'>) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M19 12V20H10L10 18.7101C9.65475 18.6074 9.32067 18.4787 9 18.3264V20C9 20.5523 9.44771 21 10 21H19C19.5523 21 20 20.5523 20 20V8C20 7.44772 19.5523 7 19 7H16.899C17.2111 7.3058 17.4946 7.64059 17.7453 8H19V12Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5 4H14V5.28988C14.3452 5.39263 14.6793 5.5213 15 5.67363V4C15 3.44772 14.5523 3 14 3H5C4.44772 3 4 3.44772 4 4V16C4 16.5523 4.44771 17 5 17H7.10102C6.78895 16.6942 6.50539 16.3594 6.25469 16H5L5 12V4Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 17.5C15.0376 17.5 17.5 15.0376 17.5 12C17.5 8.96243 15.0376 6.5 12 6.5C8.96243 6.5 6.5 8.96243 6.5 12C6.5 15.0376 8.96243 17.5 12 17.5ZM15.3536 10.3536C15.5488 10.1583 15.5488 9.84171 15.3536 9.64645C15.1583 9.45118 14.8417 9.45118 14.6464 9.64645L11 13.2929L9.35355 11.6464C9.15829 11.4512 8.84171 11.4512 8.64645 11.6464C8.45118 11.8417 8.45118 12.1583 8.64645 12.3536L10.6464 14.3536L11 14.7071L11.3536 14.3536L15.3536 10.3536Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/apps/frontend/app/admin/_components/code-editor/EditorDescription.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/EditorDescription.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { KatexContent } from '@/components/KatexContent'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@/components/shadcn/accordion'
+import { Badge } from '@/components/shadcn/badge'
+import { convertToLetter } from '@/libs/utils'
+import type { ProblemDetail } from '@/types/type'
+import DOMPurify from 'isomorphic-dompurify'
+import { EditorSampleField } from './EditorSampleField'
+import { ReferenceDialog } from './ReferenceDialog'
+
+export function EditorDescription({
+  problem,
+  isContest = false,
+  isAssignment = false
+}: {
+  problem: ProblemDetail
+  isContest?: boolean
+  isAssignment?: boolean
+}) {
+  const level = problem.difficulty
+  const levelNumber = level.slice(-1)
+
+  return (
+    <div className="dark flex h-full w-full flex-col gap-6 bg-[#222939] py-6 text-lg">
+      <div className="px-6">
+        <div className="flex max-h-24 justify-between gap-4">
+          <h1 className="mb-3 overflow-hidden text-ellipsis whitespace-nowrap text-xl font-bold">{`#${problem?.order !== undefined ? convertToLetter(problem.order) : problem.id}. ${problem.title}`}</h1>
+          {!isContest && !isAssignment && (
+            <Badge
+              className="h-6 w-[52px] whitespace-nowrap rounded-[4px] bg-neutral-500 p-[6px] text-xs font-medium hover:bg-neutral-500"
+              textColors={level}
+            >
+              {`Level ${levelNumber}`}
+            </Badge>
+          )}
+        </div>
+        <div className="prose prose-invert max-w-full text-sm leading-relaxed text-slate-300">
+          <KatexContent content={problem.description} />
+        </div>
+        <hr className="border-slate-700" />
+      </div>
+
+      <div className="px-6">
+        <h2 className="mb-3 font-bold">Input</h2>
+        <div className="prose prose-invert mb-4 max-w-full text-sm leading-relaxed text-slate-300">
+          <KatexContent content={problem.inputDescription} />
+        </div>
+        <hr className="border-slate-700" />
+      </div>
+
+      <div className="px-6">
+        <h2 className="mb-3 font-bold">Output</h2>
+        <div className="prose prose-invert max-w-full text-sm leading-relaxed text-slate-300">
+          <KatexContent content={problem.outputDescription} />
+        </div>
+      </div>
+
+      <hr className="border-4 border-[#121728]" />
+
+      <EditorSampleField problemTestCase={problem.problemTestcase} />
+
+      <hr className="border-4 border-[#121728]" />
+
+      <div className="flex shrink-0 gap-11 px-6 text-base">
+        <div className="space-y-2 text-nowrap">
+          <h2>Time Limit</h2>
+          <h2>Memory Limit</h2>
+          <h2>Source</h2>
+        </div>
+        <div className="space-y-2 text-slate-300">
+          <p>{problem.timeLimit} ms</p>
+          <p>{problem.memoryLimit} MB</p>
+          <p>{problem.source}</p>
+        </div>
+      </div>
+
+      <hr className="border-4 border-[#121728]" />
+
+      <Accordion type="multiple">
+        <AccordionItem value="item-1" className="border-none px-6">
+          <AccordionTrigger className="hover:no-underline">
+            <div className="flex items-center text-base">Hint</div>
+          </AccordionTrigger>
+          <AccordionContent>
+            <pre
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(problem.hint)
+              }}
+              className="prose prose-invert max-w-full whitespace-pre-wrap break-keep text-sm leading-relaxed text-slate-300"
+            />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
+      <hr className="border-4 border-[#121728]" />
+
+      <ReferenceDialog />
+    </div>
+  )
+}

--- a/apps/frontend/app/admin/_components/code-editor/EditorSampleField.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/EditorSampleField.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import type { ProblemDetail } from '@/types/type'
+import { CopyButton } from './CopyButton'
+import { WhitespaceVisualizer } from './WhitespaceVisualizer'
+
+interface EditorSampleFieldProps {
+  problemTestCase: ProblemDetail['problemTestcase']
+}
+
+export function EditorSampleField({ problemTestCase }: EditorSampleFieldProps) {
+  return (
+    <div>
+      {problemTestCase.map(({ id, input, output }, index) => {
+        return (
+          <div key={id} className="mb-2 px-6">
+            <h2 className="mb-2 font-bold">Sample</h2>
+
+            <div className="flex space-x-2 text-base">
+              <div className="w-1/2 space-y-2">
+                <div className="flex items-center space-x-3">
+                  <h3 className="select-none text-sm font-semibold">
+                    Input {index + 1}
+                  </h3>
+                  <CopyButton value={input} />
+                </div>
+                <div className="rounded-md border border-[#555C66]">
+                  <WhitespaceVisualizer text={input} className="px-4 py-2" />
+                </div>
+              </div>
+
+              <div className="w-1/2 space-y-2">
+                <div className="flex items-center space-x-3">
+                  <h3 className="select-none text-sm font-semibold">
+                    Output {index + 1}
+                  </h3>
+                  <CopyButton value={output} />
+                </div>
+                <div className="rounded-md border-[1px] border-[#555C66]">
+                  <WhitespaceVisualizer text={output} className="px-4 py-2" />
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/frontend/app/admin/_components/code-editor/ReferenceDialog.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/ReferenceDialog.tsx
@@ -1,0 +1,123 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/shadcn/dialog'
+import compileIcon from '@/public/icons/compile-version.svg'
+import { FileText } from 'lucide-react'
+import Image from 'next/image'
+
+export function ReferenceDialog() {
+  return (
+    <div className="flex px-6">
+      <Dialog>
+        <DialogTrigger asChild>
+          <Image
+            className="cursor-pointer"
+            src={compileIcon}
+            alt="compile"
+            width={24}
+          />
+        </DialogTrigger>
+        <DialogContent
+          showDarkOverlay={true}
+          className="rounded-xl border-none bg-slate-900 text-gray-300 sm:max-w-md"
+        >
+          <DialogHeader>
+            <DialogTitle className="font-normal text-white">
+              Compiler Version Document
+            </DialogTitle>
+          </DialogHeader>
+          <div className="overflow-x-auto rounded border border-slate-600">
+            <table className="min-w-full bg-slate-900 text-left text-sm">
+              <thead className="border-b border-slate-600 bg-slate-800 text-xs">
+                <tr>
+                  <th className="px-6 py-3">Language</th>
+                  <th className="px-6 py-3">Compiler Version Document</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b border-slate-600">
+                  <td className="flex px-6 py-4">C</td>
+                  <td className="px-6 py-4">
+                    <div className="flex items-center space-x-2">
+                      <a
+                        href="https://cplusplus.com/reference/clibrary/"
+                        target="_blank"
+                      >
+                        <FileText size={18} />
+                      </a>
+                      <span>gcc 13.2.0</span>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <a
+                        href="https://cplusplus.com/reference/clibrary/"
+                        target="_blank"
+                      >
+                        <FileText size={18} />
+                      </a>
+                      <span>c11</span>
+                    </div>
+                  </td>
+                </tr>
+                <tr className="border-b border-slate-600">
+                  <td className="flex px-6 py-4">C++</td>
+                  <td className="px-6 py-4">
+                    <div className="flex items-center space-x-2">
+                      <a
+                        href="https://cplusplus.com/reference/"
+                        target="_blank"
+                      >
+                        <FileText size={18} />
+                      </a>
+                      <span>g++ 13.2.0</span>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <a
+                        href="https://cplusplus.com/reference/"
+                        target="_blank"
+                      >
+                        <FileText size={18} />
+                      </a>
+                      <span>c++ 14</span>
+                    </div>
+                  </td>
+                </tr>
+                <tr className="border-b border-slate-600">
+                  <td className="flex px-6 py-4">Java</td>
+                  <td className="px-6 py-4">
+                    <div className="flex items-center space-x-2">
+                      <a
+                        href="https://docs.oracle.com/en/java/javase/17/docs/api/index.html"
+                        target="_blank"
+                      >
+                        <FileText size={18} />
+                      </a>
+                      <span>openjdk 17.0.11</span>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td className="flex px-6 py-4">Python</td>
+                  <td className="px-6 py-4">
+                    <div className="flex items-center space-x-2">
+                      <a
+                        href="https://docs.python.org/3.12/library/index.html"
+                        target="_blank"
+                      >
+                        <FileText size={18} />
+                      </a>
+                      <span>python 3.12.3</span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/frontend/app/admin/_components/code-editor/WhitespaceVisualizer.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/WhitespaceVisualizer.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/libs/utils'
+import DOMPurify from 'isomorphic-dompurify'
+
+export function WhitespaceVisualizer({
+  text = '',
+  isTruncated = false,
+  className
+}: {
+  text: string
+  isTruncated?: boolean
+  className?: string
+}) {
+  const whitespaceStyle =
+    'color: rgb(53, 129, 250); min-width: 0.5em; display: inline-block;'
+
+  // NOTE: Skip highlighting if text exceeds 100,000 characters to avoid performance issues.
+  const highlightedWhitespaceText =
+    text.length >= 100000
+      ? text
+      : text
+          .replaceAll(/ /g, `<span style="${whitespaceStyle}">␣</span>`)
+          .replaceAll(/\n/g, `<span style="${whitespaceStyle}">↵</span>\n`)
+          .replaceAll(/\t/g, `<span style="${whitespaceStyle}">↹</span>`)
+
+  const lines = highlightedWhitespaceText.split('\n')
+  const visibleLines = lines.slice(0, 3).join('\n')
+  const truncatedText =
+    lines.length > 3
+      ? `${visibleLines}\n<span style="color: rgb(150, 150, 150);">...</span>`
+      : visibleLines
+
+  return (
+    <pre
+      className={cn(
+        'h-24 w-full select-none overflow-auto font-mono text-sm',
+        isTruncated && 'overflow-y-hidden',
+        className
+      )}
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(
+          isTruncated ? truncatedText : highlightedWhitespaceText
+        )
+      }}
+    />
+  )
+}

--- a/apps/frontend/app/admin/problem/[problemId]/edit/page.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/page.tsx
@@ -1,12 +1,16 @@
 'use client'
 
 import { ConfirmNavigation } from '@/app/admin/_components/ConfirmNavigation'
+import { EditorDescription } from '@/app/admin/_components/code-editor/EditorDescription'
 import { Button } from '@/components/shadcn/button'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
 import { useSession } from '@/libs/hooks/useSession'
+import type { ProblemDetail } from '@/types/type'
 import type { UpdateProblemInput } from '@generated/graphql'
 import { valibotResolver } from '@hookform/resolvers/valibot'
 import Link from 'next/link'
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useForm } from 'react-hook-form'
 import { FaAngleLeft } from 'react-icons/fa6'
 import { IoIosCheckmarkCircle } from 'react-icons/io'
@@ -18,12 +22,14 @@ import { VisibleForm } from '../../../_components/VisibleForm'
 import { InfoForm } from '../../_components/InfoForm'
 import { LimitForm } from '../../_components/LimitForm'
 import { PopoverVisibleInfo } from '../../_components/PopoverVisibleInfo'
+import { PreviewEditorLayout } from '../../_components/PreviewEditorLayout'
 import { TemplateField } from '../../_components/TemplateField'
 import { TestcaseField } from '../../_components/TestcaseField'
 import { editSchema } from '../../_libs/schemas'
 import { EditProblemForm } from './_components/EditProblemForm'
 
 export default function Page({ params }: { params: { problemId: string } }) {
+  const [isPreviewing, setIsPreviewing] = useState(false)
   const { problemId } = params
 
   const session = useSession()
@@ -33,6 +39,49 @@ export default function Page({ params }: { params: { problemId: string } }) {
     resolver: valibotResolver(editSchema),
     defaultValues: { template: [] }
   })
+
+  const PreviewPortal = () => {
+    const problem = {
+      id: 0,
+      title: methods.getValues('title'),
+      description: methods.getValues('description'),
+      inputDescription: methods.getValues('inputDescription'),
+      outputDescription: methods.getValues('outputDescription'),
+      problemTestcase: methods
+        .getValues('testcases')
+        ?.map((testcase, index) => ({
+          id: index + 1,
+          input: testcase.input,
+          output: testcase.output
+        })),
+      languages: methods.getValues('languages'),
+      timeLimit: methods.getValues('timeLimit'),
+      memoryLimit: methods.getValues('memoryLimit'),
+      source: methods.getValues('source'),
+      tags: [],
+      hint: methods.getValues('hint'),
+      template: methods
+        .getValues('template')
+        ?.map((template) =>
+          template.code.map((snippet) => snippet.text).join('\n')
+        ),
+      difficulty: methods.getValues('difficulty')
+    } as ProblemDetail
+
+    return createPortal(
+      <div className="fixed inset-0 z-50 flex bg-white">
+        <PreviewEditorLayout
+          problemTitle={problem.title}
+          language={problem.languages[0]}
+          code={problem.template[0]}
+          exitPreview={() => setIsPreviewing(false)}
+        >
+          <EditorDescription problem={problem} />
+        </PreviewEditorLayout>
+      </div>,
+      document.body
+    )
+  }
 
   return (
     <ConfirmNavigation>
@@ -113,15 +162,26 @@ export default function Page({ params }: { params: { problemId: string } }) {
               formElement="input"
               hasValue={methods.getValues('source') !== ''}
             />
-
-            <Button
-              type="submit"
-              className="flex h-[36px] w-[90px] items-center gap-2 px-0"
-            >
-              <IoIosCheckmarkCircle fontSize={20} />
-              <div className="text-base">Edit</div>
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                type="submit"
+                className="flex h-[36px] w-[90px] items-center gap-2 px-0"
+              >
+                <IoIosCheckmarkCircle fontSize={20} />
+                <div className="text-base">Edit</div>
+              </Button>
+              <Button
+                type="button"
+                variant={'slate'}
+                className="flex h-[36px] w-[120px] items-center gap-2 bg-slate-200 px-0"
+                onClick={() => setIsPreviewing(true)}
+              >
+                <IoIosCheckmarkCircle fontSize={20} />
+                <div className="text-base">Preview</div>
+              </Button>
+            </div>
           </EditProblemForm>
+          {isPreviewing && <PreviewPortal />}
         </main>
         <ScrollBar orientation="horizontal" />
       </ScrollArea>

--- a/apps/frontend/app/admin/problem/_components/PreviewEditorLayout.tsx
+++ b/apps/frontend/app/admin/problem/_components/PreviewEditorLayout.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@/components/shadcn/button'
+import codedangLogo from '@/public/logos/codedang-editor.svg'
+import Image from 'next/image'
+import Link from 'next/link'
+import { PreviewEditorResizablePanel } from './PreviewEditorResizablePanel'
+
+interface EditorLayoutProps {
+  problemTitle: string
+  language: string
+  code: string
+  exitPreview: () => void
+  children: React.ReactNode
+}
+
+export function PreviewEditorLayout({
+  problemTitle,
+  language,
+  code,
+  exitPreview,
+  children
+}: EditorLayoutProps) {
+  return (
+    // Admin Layout의 Sidebar를 무시하기 위한 fixed
+    <div className="grid-rows-editor fixed left-0 grid h-dvh w-full min-w-[1000px] overflow-x-auto bg-slate-800 text-white">
+      <header className="flex h-12 items-center justify-between bg-slate-900 px-6">
+        <div className="flex items-center justify-center gap-4 text-lg text-white">
+          <Link href="/">
+            <Image src={codedangLogo} alt="코드당" width={33} />
+          </Link>
+          <div className="flex items-center gap-1 font-medium">
+            {problemTitle}
+          </div>
+        </div>
+        <Button
+          onClick={exitPreview}
+          variant="destructive"
+          className="h-8 rounded-md"
+        >
+          Exit Preview
+        </Button>
+      </header>
+      <PreviewEditorResizablePanel language={language ?? 'C'} code={code ?? ''}>
+        {children}
+      </PreviewEditorResizablePanel>
+    </div>
+  )
+}

--- a/apps/frontend/app/admin/problem/_components/PreviewEditorResizablePanel.tsx
+++ b/apps/frontend/app/admin/problem/_components/PreviewEditorResizablePanel.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { CodeEditor } from '@/components/CodeEditor'
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup
+} from '@/components/shadcn/resizable'
+import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
+import { Tabs, TabsList, TabsTrigger } from '@/components/shadcn/tabs'
+import type { Language } from '@/types/type'
+
+interface ProblemEditorProps {
+  code: string
+  language: string
+  children: React.ReactNode
+}
+
+export function PreviewEditorResizablePanel({
+  code,
+  language,
+  children
+}: ProblemEditorProps) {
+  return (
+    <ResizablePanelGroup
+      direction="horizontal"
+      className="border border-slate-700"
+    >
+      <ResizablePanel
+        defaultSize={35}
+        style={{ minWidth: '500px' }}
+        minSize={20}
+        className="flex"
+      >
+        <div className="grid-rows-editor grid h-full w-full grid-cols-1">
+          <div className="flex h-full w-full items-center border-b border-slate-700 bg-[#222939] px-6">
+            <Tabs value={''} className="flex-grow">
+              <TabsList className="rounded bg-slate-900">
+                <TabsTrigger
+                  value="Description"
+                  className="text-primary-light rounded-tab-button bg-slate-700"
+                >
+                  Description
+                </TabsTrigger>
+                <TabsTrigger
+                  value="Submission"
+                  className="data-[state=active]:text-primary-light rounded-tab-button data-[state=active]:bg-slate-700"
+                >
+                  Submissions
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+
+          <ScrollArea className="[&>div>div]:!block">{children}</ScrollArea>
+        </div>
+      </ResizablePanel>
+
+      <ResizableHandle className="border-[0.5px] border-slate-700" />
+
+      <ResizablePanel defaultSize={65} className="bg-[#222939]">
+        <div className="grid-rows-editor grid h-full">
+          <div className="flex border-b border-b-slate-700 bg-[#222939]" />
+          <ResizablePanelGroup direction="vertical" className="h-32">
+            <ResizablePanel
+              defaultSize={60}
+              className="!overflow-x-auto !overflow-y-auto"
+            >
+              <ScrollArea className="h-full bg-[#121728]">
+                <CodeEditor
+                  value={code}
+                  language={language as Language}
+                  readOnly
+                  enableCopyPaste={true}
+                  height="100%"
+                  className="h-full"
+                />
+                <ScrollBar orientation="horizontal" />
+                <ScrollBar orientation="vertical" />
+              </ScrollArea>
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}

--- a/apps/frontend/app/admin/problem/create/_components/CreateProblemForm.tsx
+++ b/apps/frontend/app/admin/problem/create/_components/CreateProblemForm.tsx
@@ -1,45 +1,25 @@
 'use client'
 
 import { useConfirmNavigationContext } from '@/app/admin/_components/ConfirmNavigation'
-import { createSchema } from '@/app/admin/problem/_libs/schemas'
 import { CREATE_PROBLEM } from '@/graphql/problem/mutations'
-import { useSession } from '@/libs/hooks/useSession'
 import { useMutation } from '@apollo/client'
-import { Level, type CreateProblemInput } from '@generated/graphql'
-import { valibotResolver } from '@hookform/resolvers/valibot'
+import type { CreateProblemInput } from '@generated/graphql'
 import { useRouter } from 'next/navigation'
 import { useState, type ReactNode } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormProvider, type UseFormReturn } from 'react-hook-form'
 import { toast } from 'sonner'
 import { CautionDialog } from '../../_components/CautionDialog'
 import { validateScoreWeight } from '../../_libs/utils'
 
 interface CreateProblemFormProps {
+  methods: UseFormReturn<CreateProblemInput>
   children: ReactNode
 }
 
-export function CreateProblemForm({ children }: CreateProblemFormProps) {
-  const session = useSession()
-  const isAdmin = session?.user?.role !== 'User'
-
-  const methods = useForm<CreateProblemInput>({
-    resolver: valibotResolver(createSchema),
-    defaultValues: {
-      difficulty: Level.Level1,
-      tagIds: [],
-      testcases: [
-        { input: '', output: '', isHidden: false, scoreWeight: null },
-        { input: '', output: '', isHidden: true, scoreWeight: null }
-      ],
-      timeLimit: 2000,
-      memoryLimit: 512,
-      hint: '',
-      source: '',
-      template: [],
-      isVisible: isAdmin
-    }
-  })
-
+export function CreateProblemForm({
+  methods,
+  children
+}: CreateProblemFormProps) {
   const [message, setMessage] = useState('')
   const [showCautionModal, setShowCautionModal] = useState(false)
 

--- a/apps/frontend/app/admin/problem/create/page.tsx
+++ b/apps/frontend/app/admin/problem/create/page.tsx
@@ -1,9 +1,16 @@
 'use client'
 
+import { createSchema } from '@/app/admin/problem/_libs/schemas'
 import { Button } from '@/components/shadcn/button'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
 import { useSession } from '@/libs/hooks/useSession'
+import type { ProblemDetail } from '@/types/type'
+import { Level, type CreateProblemInput } from '@generated/graphql'
+import { valibotResolver } from '@hookform/resolvers/valibot'
 import Link from 'next/link'
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useForm } from 'react-hook-form'
 import { FaAngleLeft } from 'react-icons/fa6'
 import { IoMdCheckmarkCircleOutline } from 'react-icons/io'
 import { ConfirmNavigation } from '../../_components/ConfirmNavigation'
@@ -12,16 +19,81 @@ import { FormSection } from '../../_components/FormSection'
 import { SwitchField } from '../../_components/SwitchField'
 import { TitleForm } from '../../_components/TitleForm'
 import { VisibleForm } from '../../_components/VisibleForm'
+import { EditorDescription } from '../../_components/code-editor/EditorDescription'
 import { InfoForm } from '../_components/InfoForm'
 import { LimitForm } from '../_components/LimitForm'
 import { PopoverVisibleInfo } from '../_components/PopoverVisibleInfo'
+import { PreviewEditorLayout } from '../_components/PreviewEditorLayout'
 import { TemplateField } from '../_components/TemplateField'
 import { TestcaseField } from '../_components/TestcaseField'
 import { CreateProblemForm } from './_components/CreateProblemForm'
 
 export default function Page() {
+  const [isPreviewing, setIsPreviewing] = useState(false)
   const session = useSession()
   const isAdmin = session?.user?.role !== 'User'
+
+  const methods = useForm<CreateProblemInput>({
+    resolver: valibotResolver(createSchema),
+    defaultValues: {
+      difficulty: Level.Level1,
+      tagIds: [],
+      testcases: [
+        { input: '', output: '', isHidden: false, scoreWeight: null },
+        { input: '', output: '', isHidden: true, scoreWeight: null }
+      ],
+      timeLimit: 2000,
+      memoryLimit: 512,
+      hint: '',
+      source: '',
+      template: [],
+      isVisible: isAdmin
+    }
+  })
+
+  const PreviewPortal = () => {
+    const problem = {
+      id: 0,
+      title: methods.getValues('title'),
+      description: methods.getValues('description'),
+      inputDescription: methods.getValues('inputDescription'),
+      outputDescription: methods.getValues('outputDescription'),
+      problemTestcase: methods
+        .getValues('testcases')
+        ?.map((testcase, index) => ({
+          id: index + 1,
+          input: testcase.input,
+          output: testcase.output
+        })),
+      languages: methods.getValues('languages'),
+      timeLimit: methods.getValues('timeLimit'),
+      memoryLimit: methods.getValues('memoryLimit'),
+      source: methods.getValues('source'),
+      tags: [],
+      hint: methods.getValues('hint'),
+      template: methods
+        .getValues('template')
+        ?.map((template) =>
+          template.code.map((snippet) => snippet.text).join('\n')
+        ),
+      difficulty: methods.getValues('difficulty')
+    } as ProblemDetail
+
+    return createPortal(
+      <div className="fixed inset-0 z-50 flex bg-white">
+        <PreviewEditorLayout
+          problemTitle={problem.title}
+          language={problem.languages[0]}
+          code={problem.template[0]}
+          exitPreview={() => setIsPreviewing(false)}
+        >
+          <EditorDescription problem={problem} />
+        </PreviewEditorLayout>
+      </div>,
+      document.body
+    )
+  }
+
   return (
     <ConfirmNavigation>
       <ScrollArea className="shrink-0">
@@ -33,7 +105,7 @@ export default function Page() {
             <span className="text-4xl font-bold">Create Problem</span>
           </div>
 
-          <CreateProblemForm>
+          <CreateProblemForm methods={methods}>
             <div className="flex gap-32">
               <FormSection title="Title">
                 <TitleForm placeholder="Enter a problem name" />
@@ -88,14 +160,26 @@ export default function Page() {
               formElement="input"
             />
 
-            <Button
-              type="submit"
-              className="flex h-[36px] w-[100px] items-center gap-2 px-0"
-            >
-              <IoMdCheckmarkCircleOutline fontSize={20} />
-              <div className="mb-[2px] text-base">Create</div>
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                type="submit"
+                className="flex h-[36px] w-[100px] items-center gap-2 px-0"
+              >
+                <IoMdCheckmarkCircleOutline fontSize={20} />
+                <div className="mb-[2px] text-base">Create</div>
+              </Button>
+              <Button
+                type="button"
+                variant={'slate'}
+                className="flex h-[36px] w-[120px] items-center gap-2 bg-slate-200 px-0"
+                onClick={() => setIsPreviewing(true)}
+              >
+                <IoMdCheckmarkCircleOutline fontSize={20} />
+                <div className="text-base">Preview</div>
+              </Button>
+            </div>
           </CreateProblemForm>
+          {isPreviewing && <PreviewPortal />}
         </main>
         <ScrollBar orientation="horizontal" />
       </ScrollArea>


### PR DESCRIPTION
### Description

Problem Create/Edit 버튼 옆에 Preview 기능을 추가하였습니다. 서버에 저장된 값을 미리보는 게 아니라 현재 페이지 `Form`에 채워진 값을 가져와야 하기 때문에 createPortal와 methods.getValues를 이용하였습니다. CopyButton, EditorSampleField, ReferenceDialog, WhitespaceVisualizer는 client/(code-editor) 폴더에 있는 코드와 완전 동일하지만, 이를 위해 frontend/components 폴더로 옮기는 것은 맞지 않아 보여 일단 복붙해놓았습니다. 

![image](https://github.com/user-attachments/assets/d223ac99-575e-427d-82e7-7083e65c8071)

![image](https://github.com/user-attachments/assets/da3f3abe-2c0b-45f6-9acb-8d84a8857f49)

closes TAS-1465


### Additional context

이번에는 API를 이용하지 않기 때문에 `EditorLayout` 관련 컴포넌트들을 새로 만들었지만, Problem Table이나 상세 페이지 등에서 쓰일 Preview 페이지는 #2544 에서 옮긴 `EditorLayout`을 이용할 예정입니다. 채점 화면의 왼쪽 패널과 Preview 화면의 왼쪽 패널은 아예 다르기 때문에 아무래도 prop을 하나 만들어 grade인지, problem preview인지 확인해서 `EditorDescription`을 다르게 적용해야 할 것 같습니다. 

템플릿 코드가 여러 개인 경우는 고려하지 않았는데, 그냥 그 때 가서 하는 게 맞을 것 같습니다...ㅎㅎ

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
