### PR TITLE
feat(fix): fix update rc workflow (5) and remove repeated db replacement

### DIFF
--- a/.github/workflows/rc-deploy-target.yml
+++ b/.github/workflows/rc-deploy-target.yml
@@ -73,7 +73,7 @@ jobs:
 
   rc-deploy-codedang:
     if: github.event.inputs.terraform_project == 'codedang'
-    name: RC - Build & Upload Docker Image and Deploy Terraform Codedang Project
+    name: RC - Deploy Terraform Codedang Project
     runs-on: ubuntu-latest
     needs: [rc-build-image]
     environment: production

--- a/.github/workflows/rc-deploy.yml
+++ b/.github/workflows/rc-deploy.yml
@@ -129,7 +129,7 @@ jobs:
     needs: [rc-deploy-storage]
 
   rc-deploy-codedang:
-    name: RC - Build & Upload Docker Image and Deploy Terraform Codedang Project
+    name: RC - Deploy Terraform Codedang Project
     runs-on: ubuntu-latest
     needs: [rc-build-image]
     environment: production

--- a/apps/infra/rc/storage/database.tf
+++ b/apps/infra/rc/storage/database.tf
@@ -30,4 +30,11 @@ resource "aws_db_instance" "postgres" {
   db_subnet_group_name   = aws_db_subnet_group.db_subnet_group.name
 
   skip_final_snapshot = true
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore attributes that don’t require replacement
+      username
+    ]
+  }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
rc-deploy.yml과 rc-deploy-target.yml의 rc-deploy-codedang job에 종속되있던 ecs image build&upload image step이 별도의 job으로 분리되면서 rc-deploy-codedang job의 name을 image build&upload는 하지않고 deploy만 한다고 명시하였습니다.

또한, storage가 terraform apply될때마다 RDS instance설정이 변경되지 않았음에도 불구하고, 재생성되는 것을 방지 하도록 재생성을 강제하는 attribute인 RDS instance의 username의 변경사항을 테라폼이 재생성 여부를 결정할때 무시하도록 설정합니다.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
