### PR TITLE
feat(infra): update rc workflow (6)

### DIFF
--- a/.github/workflows/rc-deploy-target.yml
+++ b/.github/workflows/rc-deploy-target.yml
@@ -58,6 +58,22 @@ jobs:
         working-directory: ./apps/infra/rc/${{ github.event.inputs.terraform_project }}
         run: terraform init -backend-config="bucket=codedang-tf-state-rc"
 
+      - name: Check Existing AWS Storage Resources
+        if: github.event.inputs.terraform_project == 'storage'
+        working-directory: ./apps/infra/rc/storage
+        run: |
+          if terraform state list | grep -q .; then
+            echo "Resources found. Proceeding with destroy."
+            echo "STORAGE_DESTROY_REQUIRED=true" >> $GITHUB_ENV
+          else
+            echo "No resources found. Skipping destroy."
+            echo "STORAGE_DESTROY_REQUIRED=false" >> $GITHUB_ENV
+          fi
+      - name: Terraform Destroy If There's Existing Storage Resources
+        if: ${{(github.event.inputs.terraform_project == 'storage') && (env.STORAGE_DESTROY_REQUIRED == 'true')}}
+        working-directory: ./apps/infra/rc/storage
+        run: terraform destroy -auto-approve
+
       - name: Terraform Plan
         working-directory: ./apps/infra/rc/${{ github.event.inputs.terraform_project }}
         run: terraform plan -input=false -out=plan.out


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
rc-deploy-target.yml에서 storage배포 옵션을 선택하였을때, 다시 storage폴더에서 terraform apply를 하는 것 만으로는 network변경사항을 storage폴더에 반영을 하지 못합니다. (terraform destroy후 terraform apply필요)
따라서, storage폴더에 테라폼 리소스가 없는걸 보장시킨후(리소스가 있다면 terraform destroy실행) terraform plan&appply실행을 함.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
