### PR TITLE
fix(fe): remove is visible switch when instructor

### DIFF
--- a/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { GET_PROBLEMS } from '@/graphql/problem/queries'
 import { useSuspenseQuery } from '@apollo/client'
 import { Language, Level } from '@generated/graphql'
@@ -10,10 +12,13 @@ import {
   DataTableRoot,
   DataTableSearchBar
 } from '../../_components/table'
-import { columns } from './ProblemTableColumns'
+import { createColumns } from './ProblemTableColumns'
 import { ProblemsDeleteButton } from './ProblemsDeleteButton'
 
-export function ProblemTable() {
+interface ProblemTableProps {
+  isUser: boolean
+}
+export function ProblemTable({ isUser }: ProblemTableProps) {
   const { data } = useSuspenseQuery(GET_PROBLEMS, {
     variables: {
       take: 500,
@@ -49,7 +54,7 @@ export function ProblemTable() {
   return (
     <DataTableRoot
       data={problems}
-      columns={columns}
+      columns={createColumns(isUser)}
       defaultSortState={[{ id: 'updateTime', desc: true }]}
     >
       <div className="flex gap-4">
@@ -64,6 +69,9 @@ export function ProblemTable() {
   )
 }
 
-export function ProblemTableFallback() {
-  return <DataTableFallback columns={columns} />
+interface ProblemTableFallbackProps {
+  isUser: boolean
+}
+export function ProblemTableFallback({ isUser }: ProblemTableFallbackProps) {
+  return <DataTableFallback columns={createColumns(isUser)} />
 }

--- a/apps/frontend/app/admin/problem/_components/ProblemTableColumns.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemTableColumns.tsx
@@ -52,7 +52,9 @@ function VisibleCell({ row }: { row: Row<DataTableProblem> }) {
   )
 }
 
-export const columns: ColumnDef<DataTableProblem>[] = [
+export const createColumns = (
+  isUser: boolean
+): ColumnDef<DataTableProblem>[] => [
   {
     id: 'select',
     header: ({ table }) => (
@@ -165,13 +167,13 @@ export const columns: ColumnDef<DataTableProblem>[] = [
       return <div>{acceptedRateFloat}%</div>
     }
   },
+
   {
     accessorKey: 'isVisible',
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Visible" />
-    ),
+    header: ({ column }) =>
+      !isUser && <DataTableColumnHeader column={column} title="Visible" />,
     cell: ({ row }) => {
-      return <VisibleCell row={row} />
+      return !isUser && <VisibleCell row={row} />
     }
   }
 ]

--- a/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
+++ b/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Button } from '@/components/shadcn/button'
 import {
   Dialog,

--- a/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
+++ b/apps/frontend/app/admin/problem/_components/UploadDialog.tsx
@@ -69,7 +69,7 @@ export function UploadDialog() {
       client.refetchQueries({
         include: [GET_PROBLEMS]
       })
-    } catch (error) {
+    } catch {
       toast.error('Failed to upload file')
     }
   }

--- a/apps/frontend/app/admin/problem/page.tsx
+++ b/apps/frontend/app/admin/problem/page.tsx
@@ -1,7 +1,6 @@
-'use client'
-
 import { FetchErrorFallback } from '@/components/FetchErrorFallback'
 import { Button } from '@/components/shadcn/button'
+import { auth } from '@/libs/auth'
 import { ErrorBoundary } from '@suspensive/react'
 import { PlusCircleIcon } from 'lucide-react'
 import Link from 'next/link'
@@ -10,7 +9,9 @@ import { ProblemTable, ProblemTableFallback } from './_components/ProblemTable'
 import { ProblemTabs } from './_components/ProblemTabs'
 import { UploadDialog } from './_components/UploadDialog'
 
-export default function Page() {
+export default async function Page() {
+  const session = await auth()
+  const isUser = session?.user.role === 'User'
   return (
     <div className="container mx-auto py-10">
       <div className="flex justify-between">
@@ -32,8 +33,8 @@ export default function Page() {
       </div>
       <ProblemTabs />
       <ErrorBoundary fallback={FetchErrorFallback}>
-        <Suspense fallback={<ProblemTableFallback />}>
-          <ProblemTable />
+        <Suspense fallback={<ProblemTableFallback isUser={isUser} />}>
+          <ProblemTable isUser={isUser} />
         </Suspense>
       </ErrorBoundary>
     </div>


### PR DESCRIPTION
### Description

Management - Problem
Instructor인 경우에는 isVisible을 설정할 수 없도록, 가렸습니다.

####Instructor인경우
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/088a5432-9661-40d4-8729-9ad5c32d7ec2" />

####Admin인경우
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/0ccaea08-317f-4ef5-8681-c82004970126" />

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1476
