### PR TITLE
feat(fe): redesign datatable delete modal

### DIFF
--- a/apps/frontend/app/admin/_components/table/DataTableDeleteButton.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableDeleteButton.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from '@/components/shadcn/button'
 import { useState } from 'react'
 import { FaTrash } from 'react-icons/fa'
+import { FaCircleExclamation } from 'react-icons/fa6'
 import { toast } from 'sonner'
 import { useDataTable } from './context'
 
@@ -84,6 +85,8 @@ export function DataTableDeleteButton<TData extends { id: number }, TPromise>({
       toast.error(`Failed to delete ${target}`)
     }
   }
+  const capitalizeFirstLetter = (str: string) =>
+    str.charAt(0).toUpperCase() + str.slice(1)
 
   return (
     <>
@@ -96,22 +99,27 @@ export function DataTableDeleteButton<TData extends { id: number }, TPromise>({
         <FaTrash fontSize={13} color={'#8A8A8A'} />
       </Button>
       <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <AlertDialogContent className="gap-6 shadow-lg sm:rounded-lg md:h-[159px] md:w-[408px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete?</AlertDialogTitle>
+        <AlertDialogContent className="flex h-[304px] w-[432px] flex-col justify-between gap-6 p-10 shadow-lg sm:rounded-lg">
+          <AlertDialogHeader className="flex flex-col gap-[14px]">
+            <AlertDialogTitle>
+              <div className="flex flex-col items-center justify-center gap-[24px]">
+                <FaCircleExclamation color="#FF3B2F" size={50} />
+                <p className="text-2xl font-medium">{`Delete ${capitalizeFirstLetter(target)}?`}</p>
+              </div>
+            </AlertDialogTitle>
             <AlertDialogDescription className="text-xs">
               Are you sure you want to permanently delete{' '}
               {table.getSelectedRowModel().rows.length} {target}(s)?
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel className="border-[#80808040] text-sm font-bold text-[#3333334D]">
+            <AlertDialogCancel className="w-full border-[#80808040] text-sm font-bold text-[#3333334D]">
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction asChild>
               <Button
                 onClick={handleDeleteRows}
-                className="bg-[#FF3B2F] text-sm font-bold hover:bg-red-500/90"
+                className="w-full bg-[#FF3B2F] text-sm font-bold hover:bg-red-500/90"
               >
                 Delete
               </Button>

--- a/apps/frontend/app/admin/_components/table/DataTableDeleteButton.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableDeleteButton.tsx
@@ -11,6 +11,7 @@ import {
   AlertDialogTitle
 } from '@/components/shadcn/alert-dialog'
 import { Button } from '@/components/shadcn/button'
+import { capitalizeFirstLetter } from '@/libs/utils'
 import { useState } from 'react'
 import { FaTrash } from 'react-icons/fa'
 import { FaCircleExclamation } from 'react-icons/fa6'
@@ -85,8 +86,6 @@ export function DataTableDeleteButton<TData extends { id: number }, TPromise>({
       toast.error(`Failed to delete ${target}`)
     }
   }
-  const capitalizeFirstLetter = (str: string) =>
-    str.charAt(0).toUpperCase() + str.slice(1)
 
   return (
     <>

--- a/apps/frontend/libs/utils.ts
+++ b/apps/frontend/libs/utils.ts
@@ -139,3 +139,11 @@ export const getStatusColor = (status: string): string => {
     return 'text-[#8A8A8A] border-[#C4C4C4]'
   }
 }
+
+/**
+ *
+ * @param text text to capitalize
+ * @returns text with first letter capitalized
+ */
+export const capitalizeFirstLetter = (text: string) =>
+  text.charAt(0).toUpperCase() + text.slice(1)


### PR DESCRIPTION
### Description

DataTable의 기본 Delete모달을 수정하였습니다.
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/9900cadf-23bc-4cc0-b78f-275172fa4066" />



### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1477
