### PR TITLE
fix(be): throw error when contest problemId is missing from orders

### DIFF
--- a/apps/backend/apps/admin/src/problem/problem.service.spec.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.spec.ts
@@ -678,7 +678,17 @@ describe('ProblemService', () => {
       expect(result).to.deep.equals(exampleOrderUpdatedContestProblems)
     })
 
-    it("should Error when orders's element is not unique", async () => {
+    it('should Error when orders length is not same with problems length', async () => {
+      //given
+      db.contest.findFirstOrThrow.resolves(exampleContest)
+      db.contestProblem.findMany.resolves(exampleContestProblems)
+      //when & then
+      await expect(
+        service.updateContestProblemsOrder(1, [2, 3, 4, 5, 6, 7, 8, 9, 10])
+      ).to.be.rejectedWith(UnprocessableDataException)
+    })
+
+    it('should Error when orders dont have full imported problems', async () => {
       //given
       db.contest.findFirstOrThrow.resolves(exampleContest)
       db.contestProblem.findMany.resolves(exampleContestProblems)

--- a/apps/backend/apps/admin/src/problem/problem.service.spec.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.spec.ts
@@ -678,6 +678,16 @@ describe('ProblemService', () => {
       expect(result).to.deep.equals(exampleOrderUpdatedContestProblems)
     })
 
+    it("should Error when orders's element is not unique", async () => {
+      //given
+      db.contest.findFirstOrThrow.resolves(exampleContest)
+      db.contestProblem.findMany.resolves(exampleContestProblems)
+      //when & then
+      await expect(
+        service.updateContestProblemsOrder(1, [2, 2, 4, 5, 6, 7, 8, 9, 10, 1])
+      ).to.be.rejectedWith(UnprocessableDataException)
+    })
+
     it('should handle NotFound error', async () => {
       //given
       db.contest.findFirstOrThrow.rejects(

--- a/apps/backend/apps/admin/src/problem/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.ts
@@ -961,6 +961,10 @@ export class ProblemService {
       )
     }
 
+    if (new Set(orders).size !== orders.length) {
+      throw new UnprocessableDataException("orders's elements are duplicated.")
+    }
+
     const queries = contestProblems.map((record) => {
       const newOrder = orders.indexOf(record.problemId)
       return this.prisma.contestProblem.update({

--- a/apps/backend/apps/admin/src/problem/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/problem.service.ts
@@ -961,12 +961,13 @@ export class ProblemService {
       )
     }
 
-    if (new Set(orders).size !== orders.length) {
-      throw new UnprocessableDataException("orders's elements are duplicated.")
-    }
-
     const queries = contestProblems.map((record) => {
       const newOrder = orders.indexOf(record.problemId)
+      if (newOrder === -1) {
+        throw new UnprocessableDataException(
+          'There is a problemId in the contest that is missing from the provided orders.'
+        )
+      }
       return this.prisma.contestProblem.update({
         where: {
           // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
### Description

버그 재현 방법

1. 문제를 2개 이상 import 한다
2. update contest problems order 시 order 배열에 중복 값을 넣어서 하나 이상의 problem Id를 포함하지 않도록 배열을 구성하여 요청한다 (ex. [1, 2, 3, 1, 1, 1])
3. 포함되지 않은 problemId 의 order가 -1이 된다

해결방법

contest problem 의 problemId 중 order에 포함되지 않는 것이 있다면 unprocessable data exception을 throw 하도록 한다.

---
closes TAS-1500

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
