### PR TITLE
fix(infra): fix RC's superuser password problem

### DIFF
--- a/.github/workflows/rc-mask-db.yml
+++ b/.github/workflows/rc-mask-db.yml
@@ -95,7 +95,7 @@ jobs:
               email = 'masked' || id || '@example.com',
               student_id = 'xxxxxxxxxx',
               major = 'masked'
-          WHERE username NOT IN ('test123', 'admin');
+          WHERE username NOT IN ('test123', 'super');
 
           UPDATE "submission"
           SET
@@ -104,7 +104,7 @@ jobs:
               code_size = '-1',
               user_ip = 'masked',
               score = '-1'
-          WHERE user_id NOT IN (71755, 1);
+          WHERE user_id NOT IN (71755, 2);
 
           UPDATE public.contest_record
           SET
@@ -112,6 +112,6 @@ jobs:
               total_penalty = -1,
               score = -1,
               finish_time = '1970-01-01 00:00:00.000'
-          WHERE user_id NOT IN (71755, 1);
+          WHERE user_id NOT IN (71755, 2);
           SQL
           EOF


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

RC서버에서 존재하는 관리자 계정을 admin계정에서 비번을 알고 있는 super계정으로 대체합니다. 그럼으로써 이전에는 RC에서 admin계정으로  비밀번호를 모르고 있어 로그인이 불가했지만, super계정을 비밀번호를 알고 있음으로 로그인이 가능할 것으로 예상합니다.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
