### PR TITLE
fix(infra): fix rc workflow and rabbitmq username mismatch

### DIFF
--- a/.github/workflows/rc-build-image.yml
+++ b/.github/workflows/rc-build-image.yml
@@ -16,6 +16,10 @@ jobs:
   build-client-api:
     name: Build client-api image
     runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/rc-deploy.yml
+++ b/.github/workflows/rc-deploy.yml
@@ -76,12 +76,16 @@ jobs:
         run: |
           if [ -n "$(terraform state list)" ]; then
             echo "Resources found. Proceeding with destroy."
+            echo "$TFVARS_RC" >> terraform.tfvars
             echo 'env = "rc"' >> terraform.tfvars
             echo "STORAGE_DESTROY_REQUIRED=true" >> $GITHUB_ENV
           else
             echo "No resources found. Skipping destroy."
             echo "STORAGE_DESTROY_REQUIRED=false" >> $GITHUB_ENV
           fi
+        env:
+          TFVARS_RC: ${{ secrets.TFVARS_RC }}
+
       - name: Terraform Destroy If There's Existing Storage Resources
         if: env.STORAGE_DESTROY_REQUIRED == 'true'
         working-directory: ./apps/infra/rc/storage
@@ -119,7 +123,10 @@ jobs:
       - name: Create Terraform variable file
         working-directory: ./apps/infra/rc/storage
         run: |
+          echo "$TFVARS_RC" >> terraform.tfvars
           echo 'env = "rc"' >> terraform.tfvars
+        env:
+          TFVARS_RC: ${{ secrets.TFVARS_RC }}
 
       - name: Terraform Init Storage
         working-directory: ./apps/infra/rc/storage

--- a/.github/workflows/rc-deploy.yml
+++ b/.github/workflows/rc-deploy.yml
@@ -180,10 +180,6 @@ jobs:
         working-directory: ./apps/infra/rc/codedang
         run: terraform init -backend-config="bucket=codedang-tf-state-rc"
 
-      - name: Terraform Destroy
-        working-directory: ./apps/infra/rc/codedang
-        run: terraform destroy -auto-approve
-
       - name: Terraform Plan
         working-directory: ./apps/infra/rc/codedang
         run: terraform plan -input=false -out=plan.out

--- a/apps/infra/rc/storage/variables.tf
+++ b/apps/infra/rc/storage/variables.tf
@@ -1,7 +1,7 @@
 variable "postgres_username" {
   description = "Username for Postgres DB"
   type        = string
-  default     = "skkuding"
+  default     = "skkudingpostgres"
   sensitive   = true
 }
 

--- a/apps/infra/rc/storage/variables.tf
+++ b/apps/infra/rc/storage/variables.tf
@@ -1,7 +1,7 @@
 variable "postgres_username" {
   description = "Username for Postgres DB"
   type        = string
-  default     = "skkudingpostgres"
+  default     = "skkuding"
   sensitive   = true
 }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
rc-deploy workflow중 codedang배포과정 중 중복되는 terraform destroy 구문을 제거하고, postgres및 rabbitmq username을 rc용 tfvars파일로 부터 각각 주입받습니다. 
rc-deploy workflow로 codedang폴더 배포 중, storage에서 생성된 rabbitmq username과 codedang에서 주입받는 rabbitmq username간 불일치가 발생하여 생긴 오류를 해결합니다. storage와 codedang폴더 모두 rc용 tfvars파일로 부터 각각 주입 받도록 바꿉니다. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
