### PR TITLE
fix(fe): change default score to 1 when importing problem to contest

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
@@ -117,7 +117,7 @@ export function EditContestForm({
           title: problem.problem.title,
           order: problem.order,
           difficulty: problem.problem.difficulty,
-          score: problem.score ?? 0 // Score 기능 완료되면 수정해주세요!!
+          score: problem.score ?? 1 // Score 기능 완료되면 수정해주세요!!
         }
       })
       setProblems(contestProblems)


### PR DESCRIPTION
### Description

- change default score to 1 when importing problem to contest

### Additional context

closes TAS-1521

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
