### PR TITLE
fix(fe): change admin problem and course assignment create edit layout

### DIFF
--- a/apps/frontend/app/admin/_components/FormSection.tsx
+++ b/apps/frontend/app/admin/_components/FormSection.tsx
@@ -1,25 +1,24 @@
 import { cn } from '@/libs/utils'
 
+interface FormSectionProps {
+  children: React.ReactNode | React.ReactNode[]
+  title: string
+  isLabeled?: boolean
+  isFlexColumn?: boolean
+}
+
 export function FormSection({
   children,
   title,
   isLabeled = true,
   isFlexColumn = false
-}: {
-  children: React.ReactNode | React.ReactNode[]
-  title: string
-  isLabeled?: boolean
-  isFlexColumn?: boolean
-}) {
+}: FormSectionProps) {
   const isChildrenArray = Array.isArray(children)
   const [badge, content] = isChildrenArray ? children : [null, children]
 
   return (
     <div
-      className={cn(
-        'flex w-full justify-between',
-        isFlexColumn && 'flex-col gap-[18px]'
-      )}
+      className={cn('flex w-full justify-between', isFlexColumn && 'flex-col')}
     >
       <div className="flex items-center gap-3 text-lg">
         <span className="font-semibold">{title}</span>

--- a/apps/frontend/app/admin/_components/FormSection.tsx
+++ b/apps/frontend/app/admin/_components/FormSection.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/libs/utils'
 interface FormSectionProps {
   children: React.ReactNode | React.ReactNode[]
   title: string
+  isContest?: boolean
   isLabeled?: boolean
   isFlexColumn?: boolean
 }
@@ -10,6 +11,7 @@ interface FormSectionProps {
 export function FormSection({
   children,
   title,
+  isContest = false,
   isLabeled = true,
   isFlexColumn = false
 }: FormSectionProps) {
@@ -18,10 +20,10 @@ export function FormSection({
 
   return (
     <div
-      className={cn(
-        'flex w-full justify-between',
-        isFlexColumn && 'flex-col gap-[18px]'
-      )}
+      className={cn('flex w-full justify-between', {
+        'flex-col': isFlexColumn,
+        'gap-[18px]': isContest && isFlexColumn
+      })}
     >
       <div className="flex items-center gap-3 text-lg">
         <span className="font-semibold">{title}</span>

--- a/apps/frontend/app/admin/_components/FormSection.tsx
+++ b/apps/frontend/app/admin/_components/FormSection.tsx
@@ -18,7 +18,10 @@ export function FormSection({
 
   return (
     <div
-      className={cn('flex w-full justify-between', isFlexColumn && 'flex-col')}
+      className={cn(
+        'flex w-full justify-between',
+        isFlexColumn && 'flex-col gap-[18px]'
+      )}
     >
       <div className="flex items-center gap-3 text-lg">
         <span className="font-semibold">{title}</span>

--- a/apps/frontend/app/admin/_components/TimeForm.tsx
+++ b/apps/frontend/app/admin/_components/TimeForm.tsx
@@ -4,10 +4,15 @@ import { ErrorMessage } from './ErrorMessage'
 
 interface TimeFormProps {
   name: string
+  isContest?: boolean
   defaultTimeOnSelect?: { hours: number; minutes: number; seconds: number }
 }
 
-export function TimeForm({ name, defaultTimeOnSelect }: TimeFormProps) {
+export function TimeForm({
+  name,
+  isContest = false,
+  defaultTimeOnSelect
+}: TimeFormProps) {
   const {
     control,
     formState: { errors }
@@ -24,6 +29,7 @@ export function TimeForm({ name, defaultTimeOnSelect }: TimeFormProps) {
         onChange={field.onChange}
         defaultValue={field.value}
         defaultTimeOnSelect={defaultTimeOnSelect}
+        isContest={isContest}
       />
       {errors[name] && <ErrorMessage />}
     </div>

--- a/apps/frontend/app/admin/_components/TitleForm.tsx
+++ b/apps/frontend/app/admin/_components/TitleForm.tsx
@@ -24,7 +24,7 @@ export function TitleForm({ placeholder }: TitleFormProps) {
 
   return (
     <div className="flex flex-col">
-      <div className="flex w-[491px] items-center rounded-full border bg-white pr-4">
+      <div className="flex w-[492px] items-center rounded-full border bg-white pr-4">
         <Input
           id="title"
           type="text"

--- a/apps/frontend/app/admin/_components/TitleForm.tsx
+++ b/apps/frontend/app/admin/_components/TitleForm.tsx
@@ -7,7 +7,11 @@ import { useFormContext } from 'react-hook-form'
 import { inputStyle } from '../_libs/utils'
 import { ErrorMessage } from './ErrorMessage'
 
-export function TitleForm({ placeholder }: { placeholder: string }) {
+interface TitleFormProps {
+  placeholder: string
+}
+
+export function TitleForm({ placeholder }: TitleFormProps) {
   const {
     register,
     formState: { errors }

--- a/apps/frontend/app/admin/_components/VisibleForm.tsx
+++ b/apps/frontend/app/admin/_components/VisibleForm.tsx
@@ -18,7 +18,7 @@ export function VisibleForm({ blockEdit = false }: { blockEdit?: boolean }) {
 
   return (
     <>
-      <div className="mt-3 flex items-center gap-2">
+      <div className="mb-3 flex items-center">
         <div className="flex gap-14">
           <label className="flex gap-2">
             <input

--- a/apps/frontend/app/admin/contest/[contestId]/edit/page.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/edit/page.tsx
@@ -82,11 +82,13 @@ export default function Page({ params }: { params: { contestId: string } }) {
                 </FormSection>
                 <FormSection title="Start Time">
                   {methods.getValues('startTime') && (
-                    <TimeForm name="startTime" />
+                    <TimeForm isContest name="startTime" />
                   )}
                 </FormSection>
                 <FormSection title="End Time">
-                  {methods.getValues('endTime') && <TimeForm name="endTime" />}
+                  {methods.getValues('endTime') && (
+                    <TimeForm isContest name="endTime" />
+                  )}
                 </FormSection>
 
                 {methods.getValues('freezeTime') !== undefined && (
@@ -100,12 +102,18 @@ export default function Page({ params }: { params: { contestId: string } }) {
               </div>
             </div>
 
-            <FormSection title="Summary" isLabeled={false} isFlexColumn={true}>
+            <FormSection
+              title="Summary"
+              isContest
+              isLabeled={false}
+              isFlexColumn
+            >
               <SummaryForm name="summary" />
             </FormSection>
 
             <FormSection
               title="More Description"
+              isContest
               isLabeled={false}
               isFlexColumn={true}
             >

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -53,21 +53,27 @@ export default function Page() {
                   <TitleForm placeholder="Name your contest" />
                 </FormSection>
                 <FormSection title="Start Time">
-                  <TimeForm name="startTime" />
+                  <TimeForm isContest name="startTime" />
                 </FormSection>
                 <FormSection title="End Time">
-                  <TimeForm name="endTime" />
+                  <TimeForm isContest name="endTime" />
                 </FormSection>
 
                 <FreezeForm name="freezeTime" />
               </div>
             </div>
 
-            <FormSection title="Summary" isLabeled={false} isFlexColumn={true}>
+            <FormSection
+              isContest
+              title="Summary"
+              isLabeled={false}
+              isFlexColumn
+            >
               <SummaryForm name="summary" />
             </FormSection>
 
             <FormSection
+              isContest
               title="More Description"
               isLabeled={false}
               isFlexColumn={true}

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/edit/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/edit/page.tsx
@@ -60,28 +60,28 @@ export default function Page({
             setIsLoading={setIsLoading}
             methods={methods}
           >
-            <FormSection title="Title">
+            <FormSection isFlexColumn title="Title">
               <TitleForm placeholder="Name your assignment" />
             </FormSection>
 
             <div className="flex gap-6">
-              <FormSection title="Start Time">
+              <FormSection isFlexColumn title="Start Time">
                 {methods.getValues('startTime') && (
                   <TimeForm name="startTime" />
                 )}
               </FormSection>
-              <FormSection title="End Time">
+              <FormSection isFlexColumn title="End Time">
                 {methods.getValues('endTime') && <TimeForm name="endTime" />}
               </FormSection>
 
-              <FormSection title="Week">
+              <FormSection isFlexColumn title="Week">
                 {methods.getValues('week') && (
                   <WeekComboBox name="week" courseId={Number(courseId)} />
                 )}
               </FormSection>
             </div>
 
-            <FormSection title="Description">
+            <FormSection isFlexColumn title="Description">
               {methods.getValues('description') && (
                 <DescriptionForm name="description" />
               )}

--- a/apps/frontend/app/admin/course/[courseId]/assignment/create/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/create/page.tsx
@@ -41,26 +41,26 @@ export default function Page({ params }: { params: { courseId: string } }) {
             problems={problems}
             setIsCreating={setIsCreating}
           >
-            <FormSection title="Title">
+            <FormSection isFlexColumn title="Title">
               <TitleForm placeholder="Name your Assignment" />
             </FormSection>
 
             <div className="flex gap-6">
-              <FormSection title="Start Time" isLabeled={false}>
+              <FormSection isFlexColumn title="Start Time">
                 <TimeForm name="startTime" />
               </FormSection>
-              <FormSection title="End Time" isLabeled={false}>
+              <FormSection isFlexColumn title="End Time">
                 <TimeForm
                   name="endTime"
                   defaultTimeOnSelect={{ hours: 23, minutes: 59, seconds: 59 }}
                 />
               </FormSection>
-              <FormSection title="Week">
+              <FormSection isFlexColumn title="Week">
                 <WeekComboBox name="week" courseId={Number(courseId)} />
               </FormSection>
             </div>
 
-            <FormSection title="Description">
+            <FormSection isFlexColumn title="Description">
               <DescriptionForm name="description" />
             </FormSection>
 

--- a/apps/frontend/app/admin/problem/[problemId]/edit/page.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/page.tsx
@@ -96,11 +96,11 @@ export default function Page({ params }: { params: { problemId: string } }) {
 
           <EditProblemForm problemId={Number(problemId)} methods={methods}>
             <div className="flex gap-32">
-              <FormSection title="Title">
+              <FormSection isFlexColumn title="Title">
                 <TitleForm placeholder="Enter a problem name" />
               </FormSection>
 
-              <FormSection title="Visible">
+              <FormSection isFlexColumn title="Visible">
                 <PopoverVisibleInfo />
                 <VisibleForm
                   blockEdit={
@@ -110,11 +110,11 @@ export default function Page({ params }: { params: { problemId: string } }) {
               </FormSection>
             </div>
 
-            <FormSection title="Info">
+            <FormSection isFlexColumn title="Info">
               <InfoForm />
             </FormSection>
 
-            <FormSection title="Description">
+            <FormSection isFlexColumn title="Description">
               {methods.getValues('description') && (
                 <DescriptionForm name="description" />
               )}
@@ -122,14 +122,22 @@ export default function Page({ params }: { params: { problemId: string } }) {
 
             <div className="flex justify-between">
               <div className="w-[360px]">
-                <FormSection title="Input Description" isLabeled={false}>
+                <FormSection
+                  isFlexColumn
+                  title="Input Description"
+                  isLabeled={false}
+                >
                   {methods.getValues('inputDescription') && (
                     <DescriptionForm name="inputDescription" />
                   )}
                 </FormSection>
               </div>
               <div className="w-[360px]">
-                <FormSection title="Output Description" isLabeled={false}>
+                <FormSection
+                  isFlexColumn
+                  title="Output Description"
+                  isLabeled={false}
+                >
                   {methods.getValues('outputDescription') && (
                     <DescriptionForm name="outputDescription" />
                   )}
@@ -141,7 +149,7 @@ export default function Page({ params }: { params: { problemId: string } }) {
               <TestcaseField blockEdit={false} />
             )}
 
-            <FormSection title="Limit">
+            <FormSection isFlexColumn title="Limit">
               <LimitForm blockEdit={false} />
             </FormSection>
 

--- a/apps/frontend/app/admin/problem/create/page.tsx
+++ b/apps/frontend/app/admin/problem/create/page.tsx
@@ -109,32 +109,32 @@ export default function Page() {
 
           <CreateProblemForm methods={methods}>
             <div className="flex gap-32">
-              <FormSection title="Title">
+              <FormSection isFlexColumn title="Title">
                 <TitleForm placeholder="Enter a problem name" />
               </FormSection>
 
-              <FormSection title="Visible">
+              <FormSection isFlexColumn title="Visible">
                 <PopoverVisibleInfo />
                 <VisibleForm blockEdit={!isAdmin} />
               </FormSection>
             </div>
 
-            <FormSection title="Info">
+            <FormSection isFlexColumn title="Info">
               <InfoForm />
             </FormSection>
 
-            <FormSection title="Description">
+            <FormSection isFlexColumn title="Description">
               <DescriptionForm name="description" />
             </FormSection>
 
             <div className="flex justify-between">
               <div className="w-[360px]">
-                <FormSection title="Input Description" isLabeled={false}>
+                <FormSection isFlexColumn title="Input Description">
                   <DescriptionForm name="inputDescription" />
                 </FormSection>
               </div>
               <div className="w-[360px]">
-                <FormSection title="Output Description" isLabeled={false}>
+                <FormSection isFlexColumn title="Output Description">
                   <DescriptionForm name="outputDescription" />
                 </FormSection>
               </div>
@@ -142,7 +142,7 @@ export default function Page() {
 
             <TestcaseField />
 
-            <FormSection title="Limit">
+            <FormSection isFlexColumn title="Limit">
               <LimitForm />
             </FormSection>
 

--- a/apps/frontend/components/shadcn/date-time-picker-demo.tsx
+++ b/apps/frontend/components/shadcn/date-time-picker-demo.tsx
@@ -16,12 +16,14 @@ import { useEffect, useState } from 'react'
 
 interface DateTimePickerDemoProps {
   onChange: (date: Date) => void
+  isContest?: boolean
   defaultValue?: Date
   defaultTimeOnSelect?: { hours: number; minutes: number; seconds: number }
 }
 
 export const DateTimePickerDemo = ({
   onChange,
+  isContest = false,
   defaultValue,
   defaultTimeOnSelect
 }: DateTimePickerDemoProps) => {
@@ -46,10 +48,10 @@ export const DateTimePickerDemo = ({
           variant={'outline'}
           className={cn(
             'w-[492px] justify-start text-left font-normal',
+            isContest ? 'w-[492px]' : 'w-[280px]',
             !date && 'text-muted-foreground'
           )}
         >
-          {/* <CalendarIcon className="mr-2 h-4 w-4" /> */}
           <Image
             className="mr-2 h-4 w-4"
             style={{ filter: 'grayscale(100%)' }}


### PR DESCRIPTION
### Description

- admin contest create/edit 작업하면서 problem, course assignment created/edit 페이지의 레이아웃이 깨져서 레이아웃 수정 해놓았습니다
- 추가로 글씨 폰트 및 캘린더 아이콘은 유자차 피그마 디자인 기준으로 수정됐습니다
<img width="1177" alt="스크린샷 2025-03-29 오전 3 56 21" src="https://github.com/user-attachments/assets/1b9304a5-d5c1-449a-98d3-0cbb2bd02ea0" />
<img width="404" alt="스크린샷 2025-03-29 오전 3 56 55" src="https://github.com/user-attachments/assets/d67ff68a-cf17-4273-aa97-29a159df0b04" />

closes TAS-1526

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
