### PR TITLE
feat(fe): update design of client assignment

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
@@ -12,12 +12,14 @@ import { cn, convertToLetter, dateFormatter } from '@/libs/utils'
 import type {
   Assignment,
   AssignmentStatus,
-  AssignmentSummary
+  AssignmentSummary,
+  ProblemGrade
 } from '@/types/type'
 import { useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import { useEffect, useState } from 'react'
+import { FaCircleCheck } from 'react-icons/fa6'
 import { useInterval } from 'react-use'
 import { AssignmentLink } from './AssignmentLink'
 import { DetailButton } from './DetailButton'
@@ -122,7 +124,7 @@ function AssignmentAccordionItem({
             </p>
           )}
           <div className="flex w-[13%] justify-center">
-            {assignment.startTime < new Date() ? (
+            {dayjs().isAfter(dayjs(assignment.startTime)) ? (
               <SubmissionBadge grade={grade} />
             ) : null}
           </div>
@@ -166,7 +168,7 @@ function AssignmentAccordionItem({
                       {problem.title}
                     </span>
                   </div>
-                  <div className="w-[25%]">
+                  <div className="w-[30%]">
                     {problem.submissionTime && (
                       <p className="font-normal text-[#8A8A8A]">
                         Last submission:{' '}
@@ -178,15 +180,9 @@ function AssignmentAccordionItem({
                     )}
                   </div>
 
-                  {/* <div className="flex w-[13%] justify-center">
-                    {record.problems.every(
-                      (problem) => !problem.problemRecord?.isSubmitted
-                    ) ? null : (
-                      <AcceptedBadge
-                        isAccepted={problem.problemRecord?.isSubmitted ?? false}
-                      />
-                    )}
-                  </div> */}
+                  <div className="flex w-[13%] justify-center">
+                    <AcceptedBadge problem={problem} />
+                  </div>
                   <div className="flex w-[10%] justify-center font-medium">
                     {problem.problemRecord?.finalScore ?? '-'} /{' '}
                     {problem.maxScore}
@@ -315,20 +311,38 @@ interface SubmissionBadgeProps {
 
 function SubmissionBadge({ className, grade }: SubmissionBadgeProps) {
   const badgeStyle = grade.userAssignmentFinalScore
-    ? 'border-transparent bg-primary text-white'
-    : 'border-primary text-primary'
+    ? 'border-primary text-primary'
+    : 'border-transparent bg-primary text-white'
   return (
     <div
       className={cn(
-        'flex h-[30px] w-[106px] items-center justify-center rounded-full border',
+        'flex h-[34px] w-[100px] items-center justify-center rounded-full border',
         badgeStyle,
         className
       )}
     >
       <p className="text-sm font-medium">
-        {grade.userAssignmentFinalScore ?? grade.userAssignmentJudgeScore} {'/'}
-        {grade.assignmentPerfectScore}
+        {grade.submittedCount}
+        {'/'}
+        {grade.problemCount}
       </p>
+    </div>
+  )
+}
+
+interface AcceptedBadgeProps {
+  problem: ProblemGrade
+}
+// TODO: Accepted를 boolen으로 받아와야할 것 같아요...!
+function AcceptedBadge({ problem }: AcceptedBadgeProps) {
+  if (problem.submissionResult !== 'Accepted') {
+    return null
+  }
+
+  return (
+    <div className="flex h-[25px] w-[100px] items-center justify-between rounded-full bg-green-100 px-[11px] py-[4px] text-green-500">
+      <FaCircleCheck />
+      <p className="text-sm font-medium">Accepted</p>
     </div>
   )
 }

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/CourseSidebar.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/CourseSidebar.tsx
@@ -10,9 +10,8 @@ import { useState } from 'react'
 import { FaAnglesLeft, FaAnglesRight } from 'react-icons/fa6'
 import { CourseInfoBox } from './CourseInfoBox'
 import {
-  AssignmentIcon,
+  AssignmentIcon
   // ExamIcon,
-  GradeIcon
   // HomeIcon,
   // MemberIcon,
   // NoticeIcon,

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/GradeDetailModal.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/GradeDetailModal.tsx
@@ -13,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/shadcn/dialog'
-import type { Assignment, AssignmentProblemRecord } from '@/types/type'
+import type { Assignment } from '@/types/type'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useCallback, useMemo } from 'react'
 import { MdArrowForwardIos } from 'react-icons/md'

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/SubmissionDetailModal.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/SubmissionDetailModal.tsx
@@ -11,7 +11,7 @@ import {
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
 import { Separator } from '@/components/shadcn/separator'
 import { dateFormatter } from '@/libs/utils'
-import type { Assignment, AssignmentProblemRecord } from '@/types/type'
+import type { Assignment } from '@/types/type'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { MdArrowForwardIos } from 'react-icons/md'
 

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/assignment/[assignmentId]/_components/Columns.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/assignment/[assignmentId]/_components/Columns.tsx
@@ -8,8 +8,6 @@ import type { AssignmentProblemRecord, ProblemGrade } from '@/types/type'
 import { ErrorBoundary } from '@suspensive/react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Suspense, useState } from 'react'
-import { DetailButton } from '../../../_components/DetailButton'
-import { SubmissionDetailModal } from '../../../_components/SubmissionDetailModal'
 
 export const columns = (
   assignment: AssignmentProblemRecord

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/assignment/page.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/assignment/page.tsx
@@ -1,5 +1,5 @@
 import { FetchErrorFallback } from '@/components/FetchErrorFallback'
-import { ErrorBoundary, Suspense } from '@suspensive/react'
+import { ErrorBoundary } from '@suspensive/react'
 import { AssignmentAccordion } from '../_components/AssignmentAccordion'
 
 interface AssignmentProps {

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -399,6 +399,7 @@ export interface ProblemGrade {
   maxScore: number
   problemRecord: ProblemRecord | null
   submissionTime: string
+  submissionResult: string
 }
 
 export interface ProblemRecord {


### PR DESCRIPTION
### Description

#### Client - Course - Assignment
- 기존 Client - Course - Grade에 있던 내용을 Assignment페이지에 합쳐놨습니다.
- Accordion의 과제 명을 클릭하면, 과제 상세 페이지로 넘어갑니다. (다른 브랜치에서 detail페이지 작업 중)

#### 현재 진행 중
- 교수 입장에서 의도한 작업 (예: 과제 점수 숨기기 등) 및 기타 버그(예: upcoming과제의 표출방식)의
  정상 작동 여부를 테스트하고 있습니다.

<img width="1806" alt="image" src="https://github.com/user-attachments/assets/9d7a4806-b0a2-4a37-9de9-ad05a4136c53" />


---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1494
