### PR TITLE
fix(be): contest description nullable

### DIFF
--- a/apps/backend/apps/admin/src/contest/model/contest.input.ts
+++ b/apps/backend/apps/admin/src/contest/model/contest.input.ts
@@ -16,8 +16,8 @@ export class CreateContestInput {
   @Field(() => String, { nullable: false })
   title!: string
 
-  @Field(() => String, { nullable: false })
-  description!: string
+  @Field(() => String, { nullable: true })
+  description?: string
 
   @Field(() => Int, { nullable: true })
   penalty?: number

--- a/apps/backend/prisma/migrations/20250330014034_contest_description_nullable/migration.sql
+++ b/apps/backend/prisma/migrations/20250330014034_contest_description_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "contest" ALTER COLUMN "description" DROP NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -424,7 +424,7 @@ model Contest {
   createdBy   User?   @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdById Int?    @map("created_by_id")
   title       String
-  description String
+  description String?
   // 대회의 페널티 (0 ≤ penalty ≤ 100),
   penalty     Int     @default(20)
   lastPenalty Boolean @default(false) @map("last_penalty")

--- a/collection/admin/Contest/Create Contest/Succeed.bru
+++ b/collection/admin/Contest/Create Contest/Succeed.bru
@@ -62,15 +62,15 @@ assert {
 
 docs {
   # Create Contest
-
+  
   ## Description
   사용자가 새로운 콘테스트를 생성할 수 있도록 합니다. 콘테스트 생성 권한이 있는 사용자만 사용할 수 있으며, 시작 및 종료 시간이 유효해야 합니다.
-
+  
   ## 요청 필드
   | 필드명 | 타입 | 필수 여부 | 설명 |
   |--------|------|----------|------|
   | title | String | ✅ | 콘테스트 제목 |
-  | description | String | ✅ | 콘테스트 설명 |
+  | description | String | ❌ | 콘테스트 설명 |
   | penalty | Int | ❌ | 패널티 점수 |
   | lastPenalty | Boolean | ❌ | 마지막 패널티 적용 여부 |
   | posterUrl | String | ❌ | 포스터 이미지 URL |
@@ -83,7 +83,7 @@ docs {
   | evaluateWithSampleTestcase | Boolean | ❌ | 샘플 테스트케이스로 평가 여부 |
   | userContest | [UserContestInput] | ❌ | Manager, Reviewer 역할 부여용 |
   | summary | GraphQLJSON | ❌ | 다국어 요약 정보 |
-
+  
   ## 응답 필드
   | 필드명 | 타입 | 설명 |
   |--------|------|------|
@@ -94,10 +94,10 @@ docs {
   | endTime | GraphQLISODateTime | 종료 시간 |
   | isJudgeResultVisible | Boolean | 채점 결과 공개 여부 |
   | createdById | Int | 콘테스트 생성자 ID |
-
+  
   ## 권한
   - `canCreateContest` 권한이 있는 사용자만 사용할 수 있습니다.
   - 권한이 없는 경우 `UnauthorizedException` 오류가 반환됩니다.
-
-
+  
+  
 }


### PR DESCRIPTION
### Description

contest description이 null이어도 되는데, 현재는 그렇지 못하게 되어있어 수정합니다

closes TAS-1539

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
