### PR TITLE
fix(fe): contest more description cover with katex

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/page.tsx
@@ -1,4 +1,5 @@
 import { ContestStatusTimeDiff } from '@/components/ContestStatusTimeDiff'
+import { KatexContent } from '@/components/KatexContent'
 import {
   Accordion,
   AccordionContent,
@@ -194,7 +195,7 @@ export default async function ContestTop({
             More Description
           </AccordionTrigger>
           <AccordionContent className="pb-8 text-base text-[#00000080]">
-            {description}
+            <KatexContent content={description} />
           </AccordionContent>
         </AccordionItem>
       </Accordion>


### PR DESCRIPTION
### Description

KatexContent 를 사용하여 tag가 적용되어 보이도록 하였습니다.

- 기존 more description
![image](https://github.com/user-attachments/assets/57b238e5-a6c7-46cd-a7d5-553dde21a0c2)

- 현재 more description
![image](https://github.com/user-attachments/assets/eaaf7db2-fcef-4556-9a10-ba0ebc44e89b)

closes TAS-1543

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
