### PR TITLE
feat(fe): make error handling of client leaderboard

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/error.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/error.tsx
@@ -18,7 +18,7 @@ export default function LeaderboardErrorPage({ error }: { error: Error }) {
         </p>
       </div>
     )
-  } else {
+  } else if (errorContent === 'ongoing') {
     return (
       <div className="flex flex-col items-center pb-[245px] pt-[245px]">
         <Image src={welcomeImage} alt="welcome_image" />
@@ -28,6 +28,14 @@ export default function LeaderboardErrorPage({ error }: { error: Error }) {
         <p className="mt-2 text-[#00000080]">
           The leaderboard will be released after the end of the contest
         </p>
+      </div>
+    )
+  } else {
+    return (
+      <div className="flex flex-col items-center pb-[245px] pt-[245px]">
+        <Image src={welcomeImage} alt="welcome_image" />
+        <p className="mt-[50px] text-2xl font-semibold">No Data Here </p>
+        <p className="mt-2 text-[#00000080]">This leaderboard has no Data</p>
       </div>
     )
   }

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
@@ -71,8 +71,14 @@ export default function ContestLeaderBoard() {
     const now = new Date()
     if (!isLoading && !isError) {
       console.log('leaderboard: ', contestLeaderboard.leaderboard)
+      const contestEndTime = new Date(fetchedContest?.endTime)
+      const contestStartTime = new Date(fetchedContest?.startTime)
+      if (contestEndTime > now && contestStartTime < now) {
+        throw new Error('Error(ongoing): The contest has not ended yet.')
+      }
       if (contestLeaderboard.leaderboard.length === 0) {
         const contestStartTime = new Date(fetchedContest?.startTime)
+
         if (contestStartTime > now) {
           throw new Error(
             'Error(before start): There is no data in leaderboard yet.'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
1. 현재 진행중인 대회일 때 error 페이지로 갈 수 있도록 하였습니다.
2. 끝난 대회의 데이터가 없을 때 데이터가 없음을 명시하였습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
