### PR TITLE
feat(be): make ProblemTestcase input/output field optional for migration

### DIFF
--- a/apps/backend/apps/admin/src/submission/submission.service.ts
+++ b/apps/backend/apps/admin/src/submission/submission.service.ts
@@ -269,6 +269,8 @@ export class SubmissionService {
         problem: true,
         contest: true,
         assignment: true,
+        // TODO: Let's not include this here.
+        // Instead, we should use @ResolveField to get this value.
         submissionResult: {
           include: {
             problemTestcase: {
@@ -288,6 +290,12 @@ export class SubmissionService {
     const results = submission.submissionResult.map((result) => {
       return {
         ...result,
+        // TODO: Handle this separately.
+        // If input/output is null, the values should be read from S3.
+        problemTestcase: {
+          input: result.problemTestcase.input ?? '',
+          output: result.problemTestcase.output ?? ''
+        },
         cpuTime:
           result.cpuTime || result.cpuTime === BigInt(0)
             ? result.cpuTime.toString()

--- a/apps/backend/prisma/migrations/20250331141128_optional_problem_testcase_io_field/migration.sql
+++ b/apps/backend/prisma/migrations/20250331141128_optional_problem_testcase_io_field/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "problem_testcase" ALTER COLUMN "input" DROP NOT NULL,
+ALTER COLUMN "output" DROP NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -298,8 +298,13 @@ model ProblemTestcase {
   id          Int      @id @default(autoincrement())
   problem     Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   problemId   Int      @map("problem_id")
-  input       String // url to corresponding file
-  output      String
+  // NOTE: Actual input/output value is going to be stored in S3.
+  // These fields are only for backward compatibility.
+  // All the new testcases are going to be stored in S3.
+  // These fields are expected to be null for new testcases.
+  // In future these fields will be removed after migration to S3.
+  input       String?
+  output      String?
   scoreWeight Int      @default(1) @map("score_weight")
   isHidden    Boolean  @default(false) @map("is_hidden_testcase")
   createTime  DateTime @default(now()) @map("create_time")


### PR DESCRIPTION
### Description

> Detail: https://www.notion.so/skkuding/Testcase-S3-180ef9cff54580459becdd2bfb2609f3?pvs=4

테스트케이스 값을 데이터베이스에서 S3로 migration하기 위해, `ProblemTestcase` 테이블의 `input`과 `output` field 값을 optional로 변경합니다.

- 앞으로 새로 생성되는 테스트케이스들은 `input`과 `output` 값이 null로 저장될 예정입니다.
- 대신 `input`과 `output`은 S3에 파일로 저장됩니다.
- 대부분의 마이그레이션이 완료되면, 기존 테스트케이스들도 S3에 파일 생성 후 `input`과 `output` 필드를 null로 변경 예정입니다.
- 모든 마이그레이션이 완료되면 `input`과 `output` 필드를 제거할 예정입니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
