### PR TITLE
fix(be): fix finalScore not visible on management page bug

### DIFF
--- a/apps/backend/apps/admin/src/assignment/assignment.service.spec.ts
+++ b/apps/backend/apps/admin/src/assignment/assignment.service.spec.ts
@@ -1,7 +1,12 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { SchedulerRegistry } from '@nestjs/schedule'
 import { Test, type TestingModule } from '@nestjs/testing'
-import { AssignmentProblem, Group, AssignmentRecord } from '@generated'
+import {
+  AssignmentProblem,
+  Group,
+  AssignmentRecord,
+  AssignmentProblemRecord
+} from '@generated'
 import { Problem } from '@generated'
 import { Assignment } from '@generated'
 import { faker } from '@faker-js/faker'
@@ -226,7 +231,8 @@ const db = {
     create: stub().resolves(AssignmentRecord)
   },
   assignmentProblemRecord: {
-    createMany: stub().resolves([])
+    createMany: stub().resolves([]),
+    findMany: stub().resolves([AssignmentProblemRecord])
   },
   problem: {
     update: stub().resolves(Problem),
@@ -385,6 +391,185 @@ describe('AssignmentService', () => {
       expect(
         service.importProblemsToAssignment(groupId, 9999, [problemIdsWithScore])
       ).to.be.rejectedWith(EntityNotExistException)
+    })
+  })
+
+  describe('getAssignmentScoreSummary', () => {
+    it('should return score summary', async () => {
+      db.assignmentProblem.findMany.resolves([assignmentProblem])
+      db.assignmentProblemRecord.findMany.resolves([
+        {
+          problemId,
+          score: 30,
+          finalScore: 25,
+          isSubmitted: true
+        }
+      ])
+
+      const summary = await service.getAssignmentScoreSummary(
+        userId,
+        assignmentId
+      )
+
+      expect(summary).to.deep.equal({
+        submittedProblemCount: 1,
+        totalProblemCount: 1,
+        userAssignmentScore: 30,
+        assignmentPerfectScore: 50,
+        userAssignmentFinalScore: 25,
+        problemScores: [
+          {
+            problemId,
+            score: 30,
+            maxScore: 50,
+            finalScore: 25
+          }
+        ]
+      })
+    })
+
+    it('should handle finalScore as null', async () => {
+      db.assignmentProblem.findMany.resolves([assignmentProblem])
+      db.assignmentProblemRecord.findMany.resolves([
+        {
+          problemId,
+          score: 40,
+          finalScore: null,
+          isSubmitted: true
+        }
+      ])
+
+      const summary = await service.getAssignmentScoreSummary(
+        userId,
+        assignmentId
+      )
+
+      expect(summary).to.deep.equal({
+        submittedProblemCount: 1,
+        totalProblemCount: 1,
+        userAssignmentScore: 40,
+        assignmentPerfectScore: 50,
+        userAssignmentFinalScore: 0,
+        problemScores: [
+          {
+            problemId,
+            score: 40,
+            maxScore: 50,
+            finalScore: null
+          }
+        ]
+      })
+    })
+
+    it('should handle no submitted problems', async () => {
+      db.assignmentProblem.findMany.resolves([assignmentProblem])
+      db.assignmentProblemRecord.findMany.resolves([
+        {
+          problemId,
+          score: 0,
+          finalScore: null,
+          isSubmitted: false
+        }
+      ])
+
+      const summary = await service.getAssignmentScoreSummary(
+        userId,
+        assignmentId
+      )
+
+      expect(summary).to.deep.equal({
+        submittedProblemCount: 0,
+        totalProblemCount: 1,
+        userAssignmentScore: 0,
+        assignmentPerfectScore: 50,
+        userAssignmentFinalScore: 0,
+        problemScores: [
+          {
+            problemId,
+            score: 0,
+            maxScore: 50,
+            finalScore: null
+          }
+        ]
+      })
+    })
+
+    it('should handle user with no records', async () => {
+      db.assignmentProblem.findMany.resolves([assignmentProblem])
+      db.assignmentProblemRecord.findMany.resolves([])
+
+      const summary = await service.getAssignmentScoreSummary(
+        userId,
+        assignmentId
+      )
+
+      expect(summary).to.deep.equal({
+        submittedProblemCount: 0,
+        totalProblemCount: 1,
+        userAssignmentScore: 0,
+        assignmentPerfectScore: 50,
+        userAssignmentFinalScore: 0,
+        problemScores: []
+      })
+    })
+  })
+
+  describe('getAssignmentScoreSummaries', () => {
+    it('should return list of users with their score summaries', async () => {
+      db.assignment.findUnique.resolves(assignment)
+      db.assignmentRecord.findMany.resolves([
+        {
+          userId,
+          user: {
+            username: 'user01',
+            studentId: '1234567890',
+            userProfile: {
+              realName: '홍길동'
+            },
+            major: 'CS'
+          }
+        }
+      ])
+      db.assignmentProblem.findMany.resolves([assignmentProblem])
+      db.assignmentProblemRecord.findMany.resolves([
+        {
+          userId,
+          problemId,
+          score: 50,
+          finalScore: 45,
+          isSubmitted: true
+        }
+      ])
+
+      const summaries = await service.getAssignmentScoreSummaries(
+        assignmentId,
+        groupId,
+        10,
+        null
+      )
+
+      expect(summaries).to.deep.equal([
+        {
+          userId,
+          username: 'user01',
+          studentId: '1234567890',
+          realName: '홍길동',
+          major: 'CS',
+          submittedProblemCount: 1,
+          totalProblemCount: 1,
+          userAssignmentScore: 50,
+          assignmentPerfectScore: 50,
+          userAssignmentFinalScore: 45,
+          problemScores: [
+            {
+              problemId,
+              score: 50,
+              maxScore: 50,
+              finalScore: 45
+            }
+          ]
+        }
+      ])
     })
   })
 

--- a/apps/backend/apps/admin/src/assignment/assignment.service.ts
+++ b/apps/backend/apps/admin/src/assignment/assignment.service.ts
@@ -756,14 +756,10 @@ export class AssignmentService {
         (total, { score }) => total + score,
         0
       ), // Assignment의 만점
-      userAssignmentFinalScore: assignmentProblemRecords.some(
-        (record) => record.finalScore === null
-      )
-        ? null
-        : assignmentProblemRecords.reduce(
-            (total, { finalScore }) => total + finalScore!,
-            0
-          ),
+      userAssignmentFinalScore: assignmentProblemRecords.reduce(
+        (total, { finalScore }) => total + (finalScore ?? 0),
+        0
+      ),
       problemScores // 개별 Problem의 점수 리스트 (각 문제에서 몇 점을 획득했는지)
     }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Management 페이지에서 isFinalScoreVisible이 true임에도 finalScore가 오지 않는 버그 해결

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
