### PR TITLE
fix(fe): prevent toggle change when template is cleared

### DIFF
--- a/apps/frontend/app/admin/problem/_components/CodeForm.tsx
+++ b/apps/frontend/app/admin/problem/_components/CodeForm.tsx
@@ -30,7 +30,7 @@ export function CodeForm({ name, language, hasValue = false }: CodeFormProps) {
 
   useEffect(() => {
     setIsEnabled(hasValue)
-  }, [hasValue])
+  }, [])
 
   const handleFormat = useCallback(async () => {
     try {


### PR DESCRIPTION
### Description
Template 필드에서 내용을 전부 지우면 자동으로 토글이 닫혀버리는 버그를 해결했습니다.

`hasValue` 값의 변화에 따라 토글을 열고 닫는 로직에서, 사용자가 입력을 모두 지운 후 `setValue`가 트리거되면서 다시 `hasValue`가 `false`가 되고, 이에 따라 `useEffect`가 다시 호출되는 문제가 있었습니다. 이로 인해 의도치 않게 토글이 닫히는 현상이 발생했습니다.

이를 해결하기 위해, `CodeForm`이 초기 렌더링될 때만 `hasValue`를 기준으로 토글을 열지 말지를 결정하도록 수정했습니다. 이후에는 `hasValue`의 변화로 인한 불필요한 토글 상태 변경을 막아 UX를 안정화했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Closes TAS-1573

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
