### PR TITLE
feat(fe): improve datatable link

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/SubmissionTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/SubmissionTable.tsx
@@ -19,7 +19,6 @@ import {
 } from '@tanstack/react-table'
 import type { Route } from 'next'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 
 interface Item {
   id: number
@@ -51,7 +50,6 @@ export function SubmissionTable<
     columns,
     getCoreRowModel: getCoreRowModel()
   })
-  const router = useRouter()
 
   return (
     <Table className="table-fixed">
@@ -82,16 +80,15 @@ export function SubmissionTable<
           table.getRowModel().rows.map((row) => {
             const href = getHref?.(row)
 
-            return (
-              <TableRow
+            return href ? (
+              <Link
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
-                className="cursor-pointer border-t border-slate-600 text-slate-300 hover:bg-slate-600/50 hover:font-semibold"
-                onClick={() => {
-                  if (href) {
-                    router.replace(href)
-                  }
-                }}
+                className={
+                  'table-row cursor-pointer border-t border-slate-600 text-slate-300 hover:bg-slate-600/50 hover:font-semibold'
+                }
+                href={href as Route}
+                replace={true}
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
@@ -110,8 +107,32 @@ export function SubmissionTable<
                         cell.getContext()
                       )}
                     </div>
-                    {/* for prefetch */}
-                    {href && <Link replace href={href} />}
+                  </TableCell>
+                ))}
+              </Link>
+            ) : (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && 'selected'}
+                className="cursor-pointer border-t border-slate-600 text-slate-300 hover:bg-slate-600/50 hover:font-semibold"
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell
+                    key={cell.id}
+                    style={{
+                      paddingTop: 10,
+                      paddingBottom: 10,
+                      paddingLeft: 2,
+                      paddingRight: 2
+                    }}
+                    className="border-b-2 border-slate-700"
+                  >
+                    <div className="text-center text-xs">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </div>
                   </TableCell>
                 ))}
               </TableRow>

--- a/apps/frontend/app/(client)/(code-editor)/_components/SubmissionTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/SubmissionTable.tsx
@@ -87,7 +87,7 @@ export function SubmissionTable<
                 className={
                   'table-row cursor-pointer border-t border-slate-600 text-slate-300 hover:bg-slate-600/50 hover:font-semibold'
                 }
-                href={href as Route}
+                href={href}
                 replace={true}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/apps/frontend/app/(client)/(main)/_components/DataTable.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/DataTable.tsx
@@ -17,7 +17,7 @@ import {
 } from '@tanstack/react-table'
 import type { Route } from 'next'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 
 interface Item {
   id: number | string
@@ -86,7 +86,6 @@ export function DataTable<TData extends Item, TValue>({
     columns,
     getCoreRowModel: getCoreRowModel()
   })
-  const router = useRouter()
   const currentPath = usePathname()
 
   return (
@@ -121,14 +120,33 @@ export function DataTable<TData extends Item, TValue>({
             const href = pathSegment
               ? `${currentPath}/${pathSegment}/${row.original.id}`
               : `${currentPath}/${row.original.id}`
-            const handleClick = linked
-              ? () => {
-                  router.push(href as Route)
-                }
-              : (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-                  e.currentTarget.classList.toggle('expanded')
-                }
-            return (
+            const handleClick = (
+              e: React.MouseEvent<HTMLDivElement, MouseEvent>
+            ) => {
+              e.currentTarget.classList.toggle('expanded')
+            }
+            return linked ? (
+              <Link
+                key={row.id}
+                data-state={row.getIsSelected() && 'selected'}
+                className={cn(
+                  'table-row cursor-pointer border-b-[1.5px] border-[#80808040] hover:bg-[#80808014]',
+                  tableRowStyle
+                )}
+                href={href as Route}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="align-top">
+                    <div className="text-center text-xs md:text-sm">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </div>
+                  </TableCell>
+                ))}
+              </Link>
+            ) : (
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
@@ -146,8 +164,6 @@ export function DataTable<TData extends Item, TValue>({
                         cell.getContext()
                       )}
                     </div>
-                    {/* for prefetch */}
-                    <Link href={href as Route} />
                   </TableCell>
                 ))}
               </TableRow>


### PR DESCRIPTION
### Description

client datatable에 링크가 연결되어 있을 때 `<Link>`가 아닌 `onClick={router.push()}`로 구현되어 있어서 해당 row를 Ctrl + 클릭하거나 우클릭을 통해 새 탭에서 여는 등의 동작이 불가능해 개선했습니다. admin에 도입하지 않은 이유는 버그도 있고, assignment grade의 경우 cell 단위로 링크가 연결되어 있는데, <Link>를 사용할 시 충돌이 발생할 수 있으며 애초에 grade 관련 대격변이 있을 것 같았기 때문입니다.
딱히 복잡한 건 없고 핵심은 그냥 TableRow를 `'table-row'` tailwind className을 가진 Link로 바꾼 것입니다.

closes TAS-1574

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
