### PR TITLE
fix(fe): resolve freeze query error

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -21,7 +21,7 @@ import bottomCenterIcon from '@/public/icons/bottom-center.svg'
 import syncIcon from '@/public/icons/sync.svg'
 import { useLanguageStore, useCodeStore } from '@/stores/editor'
 import type { ProblemDetail, Contest } from '@/types/type'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import type { Route } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -66,7 +66,7 @@ export function EditorMainResizablePanel({
     ? ['leaderboard freeze date', contestId]
     : ['leaderboard freeze date', 'no-contest']
 
-  const { data: freezeTime } = useSuspenseQuery({
+  const { data: freezeTime } = useQuery({
     queryKey: freezeQueryKey,
     queryFn: () => {
       if (!contestId) {


### PR DESCRIPTION
### Description

suspenseQuery를 useQuery로 바꿨습니다!

상황: 공용 컴포넌트에서 reactQuery의 useSuspenseQuery를 사용할 때

문제:  contestId가 있을 때는 문제가 없지만, contestId가 없는 경우에도 공용 로직을 유지하기 위해 다음과 같이 queryFn에서 null을 반환하는 구조를 사용함

const { data: freezeTime } = useSuspenseQuery({
    queryKey: freezeQueryKey,
    queryFn: () => {
      if (!contestId) {
        return Promise.resolve(null)
      }
      return fetchFreezeTime(contestId)
    }
  })
처음에는 문제가 없어 보였지만, 새로고침 등의 상황에서 React Query가 캐시된 null 값을 사용하지 않고, queryFn을 다시 실행하는 현상이 발생함
이때 Promise.resolve(null)을 반환하더라도, React Query가 이를 성공(fulfilled) 상태로 인식하지 못해,
Suspense fallback에서 빠져나오지 못하는 문제가  생김

이 문제는 queryKey에 contestId가 포함되지 않아 React Query가 쿼리를 제대로 식별하거나 캐싱을 활용하지 못한 것이 주요 원인으로 보임. 그래서 useQuery를 써서 suspense에 빠지지 않도록 바꿨습니당...


### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
