### PR TITLE
docs(fe): make another getUsers query for setManager

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
@@ -13,7 +13,7 @@ import {
 import { GET_CONTEST } from '@/graphql/contest/queries'
 import { UPDATE_CONTEST_PROBLEMS_ORDER } from '@/graphql/problem/mutations'
 import { GET_CONTEST_PROBLEMS } from '@/graphql/problem/queries'
-import { GET_USER_SET_MANAGER } from '@/graphql/user/queries'
+import { GET_USERS_SET_MANAGER } from '@/graphql/user/queries'
 import { useMutation, useQuery, useSuspenseQuery } from '@apollo/client'
 import type { UpdateContestInput } from '@generated/graphql'
 import { useRouter } from 'next/navigation'
@@ -47,7 +47,7 @@ export function EditContestForm({
   const { setShouldSkipWarning } = useConfirmNavigationContext()
   const router = useRouter()
 
-  const { data: userData } = useSuspenseQuery(GET_USER_SET_MANAGER)
+  const { data: userData } = useSuspenseQuery(GET_USERS_SET_MANAGER)
 
   // 수정된 manager, reviewer 목록(managers) 으로 등록
   const formattedManagers = managers

--- a/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
@@ -13,7 +13,7 @@ import {
 import { GET_CONTEST } from '@/graphql/contest/queries'
 import { UPDATE_CONTEST_PROBLEMS_ORDER } from '@/graphql/problem/mutations'
 import { GET_CONTEST_PROBLEMS } from '@/graphql/problem/queries'
-import { GET_USERS } from '@/graphql/user/queries'
+import { GET_USER_SET_MANAGER } from '@/graphql/user/queries'
 import { useMutation, useQuery, useSuspenseQuery } from '@apollo/client'
 import type { UpdateContestInput } from '@generated/graphql'
 import { useRouter } from 'next/navigation'
@@ -47,11 +47,7 @@ export function EditContestForm({
   const { setShouldSkipWarning } = useConfirmNavigationContext()
   const router = useRouter()
 
-  const { data: userData } = useSuspenseQuery(GET_USERS, {
-    variables: {
-      take: 5000
-    }
-  })
+  const { data: userData } = useSuspenseQuery(GET_USER_SET_MANAGER)
 
   // 수정된 manager, reviewer 목록(managers) 으로 등록
   const formattedManagers = managers

--- a/apps/frontend/graphql/user/queries.ts
+++ b/apps/frontend/graphql/user/queries.ts
@@ -20,6 +20,20 @@ const GET_USERS = gql(`
   }
 `)
 
+const GET_USER_SET_MANAGER = gql(`
+  query GetUserSetManager{
+    getUsers {
+      id
+      username
+      email
+      userProfile {
+        realName
+      }
+      role
+    }
+  }
+`)
+
 const GET_GROUP_MEMBER =
   gql(`query GetGroupMember($groupId: Int!, $userId: Int!) {
     getGroupMember(groupId: $groupId, userId: $userId) {
@@ -49,4 +63,4 @@ const GET_GROUP_MEMBERS = gql(`
   }
 `)
 
-export { GET_USERS, GET_GROUP_MEMBER, GET_GROUP_MEMBERS }
+export { GET_USERS, GET_GROUP_MEMBER, GET_GROUP_MEMBERS, GET_USER_SET_MANAGER }

--- a/apps/frontend/graphql/user/queries.ts
+++ b/apps/frontend/graphql/user/queries.ts
@@ -20,7 +20,7 @@ const GET_USERS = gql(`
   }
 `)
 
-const GET_USER_SET_MANAGER = gql(`
+const GET_USERS_SET_MANAGER = gql(`
   query GetUserSetManager{
     getUsers {
       id
@@ -63,4 +63,4 @@ const GET_GROUP_MEMBERS = gql(`
   }
 `)
 
-export { GET_USERS, GET_GROUP_MEMBER, GET_GROUP_MEMBERS, GET_USER_SET_MANAGER }
+export { GET_USERS, GET_GROUP_MEMBER, GET_GROUP_MEMBERS, GET_USERS_SET_MANAGER }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Edit Contest 에서 setManager 를 위해 getUsers 를 queries.ts 에 추가하였습니다!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

 closes.

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
