### PR TITLE
feat(fe): add zoom in/out button to code editor

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -7,7 +7,7 @@ import {
   ResizablePanel,
   ResizablePanelGroup
 } from '@/components/shadcn/resizable'
-import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
+import { ScrollArea } from '@/components/shadcn/scroll-area'
 import { Tabs, TabsList, TabsTrigger } from '@/components/shadcn/tabs'
 import {
   Tooltip,
@@ -268,16 +268,12 @@ export function EditorMainResizablePanel({
                   defaultSize={60}
                   className="!overflow-x-auto !overflow-y-auto"
                 >
-                  <ScrollArea className="h-full bg-[#121728]">
-                    <CodeEditorInEditorResizablePanel
-                      problemId={problem.id}
-                      contestId={contestId}
-                      assignmentId={assignmentId}
-                      enableCopyPaste={enableCopyPaste}
-                    />
-                    <ScrollBar orientation="horizontal" />
-                    <ScrollBar orientation="vertical" />
-                  </ScrollArea>
+                  <CodeEditorInEditorResizablePanel
+                    problemId={problem.id}
+                    contestId={contestId}
+                    assignmentId={assignmentId}
+                    enableCopyPaste={enableCopyPaste}
+                  />
                 </ResizablePanel>
                 <ResizableHandle className="border-[0.5px] border-slate-700" />
                 <ResizablePanel defaultSize={40}>
@@ -314,8 +310,7 @@ function CodeEditorInEditorResizablePanel({
       language={language}
       onChange={setCode}
       enableCopyPaste={enableCopyPaste}
-      height="100%"
-      className="h-full"
+      showZoom
     />
   )
 }

--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -9,8 +9,18 @@ import { tags as t } from '@lezer/highlight'
 import { createTheme } from '@uiw/codemirror-themes'
 import type { ReactCodeMirrorProps } from '@uiw/react-codemirror'
 import ReactCodeMirror, { EditorView } from '@uiw/react-codemirror'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useState, useEffect } from 'react'
+import { FaPlus, FaMinus, FaArrowRotateLeft } from 'react-icons/fa6'
 import { toast } from 'sonner'
+import { Button } from './shadcn/button'
 import { ScrollArea, ScrollBar } from './shadcn/scroll-area'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider
+} from './shadcn/tooltip'
 
 const editorTheme = createTheme({
   settings: {
@@ -49,15 +59,13 @@ const editorTheme = createTheme({
   theme: 'dark'
 })
 
-const fontSize = EditorView.baseTheme({
-  '&': {
-    fontSize: '17px'
-  }
-})
-
 const editorPadding = EditorView.baseTheme({
   '.cm-editor': {
-    padding: '8px'
+    padding: '8px',
+    height: '100%'
+  },
+  '.cm-gutter.cm-lineNumbers .cm-gutterElement': {
+    'padding-left': '32px'
   }
 })
 
@@ -71,6 +79,7 @@ const languageParser: Record<Language, () => LanguageSupport> = {
 interface Props extends ReactCodeMirrorProps {
   language: Language
   enableCopyPaste?: boolean
+  showZoom?: boolean
 }
 
 const copyPasteHandler = () => {
@@ -90,30 +99,149 @@ const copyPasteHandler = () => {
   })
 }
 
+const useLongPress = (callback: () => void) => {
+  const [startLongPress, setStartLongPress] = useState(false)
+
+  useEffect(() => {
+    let longPressTimer: NodeJS.Timeout
+    let longPressInterval: NodeJS.Timeout
+    if (startLongPress) {
+      longPressTimer = setTimeout(() => {
+        longPressInterval = setInterval(() => {
+          callback()
+        }, 100)
+      }, 500)
+    }
+    return () => {
+      clearTimeout(longPressTimer)
+      clearInterval(longPressInterval)
+    }
+  }, [startLongPress, callback])
+
+  return {
+    onPointerDown: () => setStartLongPress(true),
+    onPointerUp: () => setStartLongPress(false)
+  }
+}
+
+const MotionButton = motion.create(Button)
+
 export function CodeEditor({
   value,
   language,
   onChange,
   enableCopyPaste = true,
   readOnly = false,
+  showZoom = false,
   ...props
 }: Props) {
+  const [fontSize, setFontSize] = useState(16)
+  const theme = EditorView.theme({
+    '&': {
+      fontSize: `${fontSize}px`
+    }
+  })
+
+  const { onPointerDown: startLongPlus, onPointerUp: stopLongPlus } =
+    useLongPress(() => {
+      setFontSize((prev) => Math.min(prev + 2, 120))
+    })
+  const { onPointerDown: startLongMinus, onPointerUp: stopLongMinus } =
+    useLongPress(() => {
+      setFontSize((prev) => Math.max(prev - 2, 6))
+    })
+
   return (
-    <ScrollArea className="rounded-lg [&>div>div]:h-full">
-      <ReactCodeMirror
-        theme={editorTheme}
-        extensions={[
-          fontSize,
-          languageParser[language](),
-          enableCopyPaste ? [] : copyPasteHandler(),
-          editorPadding
-        ]}
-        value={value}
-        onChange={onChange}
-        readOnly={readOnly}
-        {...props}
-      />
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+    <div className="flex h-full flex-col">
+      <ScrollArea className="flex-1 rounded-lg bg-[#121728]">
+        <ReactCodeMirror
+          theme={editorTheme}
+          extensions={[
+            theme,
+            languageParser[language](),
+            enableCopyPaste ? [] : copyPasteHandler(),
+            editorPadding
+          ]}
+          className="h-full"
+          value={value}
+          onChange={onChange}
+          readOnly={readOnly}
+          {...props}
+        />
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+      <div className="flex w-full flex-none items-center justify-end gap-1 border-t border-slate-700 bg-[#121728] px-4 py-1.5">
+        {showZoom && (
+          <TooltipProvider>
+            <AnimatePresence>
+              {fontSize !== 16 && (
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <MotionButton
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 rounded-lg text-slate-100/60 hover:bg-slate-500/30 active:bg-slate-500/40"
+                        initial={{ opacity: 0, scale: 0 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0 }}
+                        onClick={() => setFontSize(16)}
+                      >
+                        <FaArrowRotateLeft />
+                      </MotionButton>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Reset Font Size</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <motion.div
+                    className="px-1 text-sm text-slate-100/60"
+                    initial={{ opacity: 0, scale: 0 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0 }}
+                  >
+                    {fontSize}px
+                  </motion.div>
+                </>
+              )}
+            </AnimatePresence>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 rounded-lg text-slate-100/60 hover:bg-slate-500/30 active:bg-slate-500/40"
+                  onPointerDown={() => startLongPlus()}
+                  onPointerUp={() => stopLongPlus()}
+                  onClick={() => setFontSize((prev) => Math.min(prev + 2, 120))}
+                >
+                  <FaPlus />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Increase Font Size</p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 rounded-lg text-slate-100/60 hover:bg-slate-500/30 active:bg-slate-500/40"
+                  onPointerDown={() => startLongMinus()}
+                  onPointerUp={() => stopLongMinus()}
+                  onClick={() => setFontSize((prev) => Math.max(prev - 2, 6))}
+                >
+                  <FaMinus />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Decrease Font Size</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+    </div>
   )
 }

--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -76,7 +76,7 @@ const languageParser: Record<Language, () => LanguageSupport> = {
   Python3: python
 }
 
-interface Props extends ReactCodeMirrorProps {
+interface CodeEditorProps extends ReactCodeMirrorProps {
   language: Language
   enableCopyPaste?: boolean
   showZoom?: boolean
@@ -134,7 +134,7 @@ export function CodeEditor({
   readOnly = false,
   showZoom = false,
   ...props
-}: Props) {
+}: CodeEditorProps) {
   const [fontSize, setFontSize] = useState(16)
   const theme = EditorView.theme({
     '&': {

--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -10,7 +10,7 @@ import { createTheme } from '@uiw/codemirror-themes'
 import type { ReactCodeMirrorProps } from '@uiw/react-codemirror'
 import ReactCodeMirror, { EditorView } from '@uiw/react-codemirror'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { FaPlus, FaMinus, FaArrowRotateLeft } from 'react-icons/fa6'
 import { toast } from 'sonner'
 import { Button } from './shadcn/button'
@@ -145,14 +145,17 @@ export function CodeEditor({
     }
   })
 
+  const increaseFontSize = useCallback(() => {
+    setFontSize((prev) => Math.min(prev + 2, 120))
+  }, [])
+  const decreaseFontSize = useCallback(() => {
+    setFontSize((prev) => Math.max(prev - 2, 6))
+  }, [])
+
   const { onPointerDown: startLongPlus, onPointerUp: stopLongPlus } =
-    useLongPress(() => {
-      setFontSize((prev) => Math.min(prev + 2, 120))
-    })
+    useLongPress(increaseFontSize)
   const { onPointerDown: startLongMinus, onPointerUp: stopLongMinus } =
-    useLongPress(() => {
-      setFontSize((prev) => Math.max(prev - 2, 6))
-    })
+    useLongPress(decreaseFontSize)
 
   return (
     <div className="flex h-full flex-col">
@@ -199,7 +202,7 @@ export function CodeEditor({
                     </TooltipContent>
                   </Tooltip>
                   <motion.div
-                    className="px-1 text-sm text-slate-100/60"
+                    className="w-12 px-1 text-center text-sm text-slate-100/60"
                     initial={{ opacity: 0, scale: 0 }}
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0, scale: 0 }}

--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -139,7 +139,7 @@ export function CodeEditor({
   ...props
 }: CodeEditorProps) {
   const [fontSize, setFontSize] = useState(16)
-  const theme = EditorView.theme({
+  const fontSizeTheme = EditorView.theme({
     '&': {
       fontSize: `${fontSize}px`
     }
@@ -160,11 +160,11 @@ export function CodeEditor({
         <ReactCodeMirror
           theme={editorTheme}
           extensions={[
-            theme,
             languageParser[language](),
             enableCopyPaste ? [] : copyPasteHandler(),
             editorPadding,
-            gutterStyle
+            gutterStyle,
+            fontSizeTheme
           ]}
           className="h-full"
           value={value}

--- a/apps/frontend/components/shadcn/scroll-area.tsx
+++ b/apps/frontend/components/shadcn/scroll-area.tsx
@@ -13,7 +13,7 @@ const ScrollArea = React.forwardRef<
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:h-full">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
### Description

코드 에디터에 글씨 크기 조절 버튼을 추가합니다.

- 글씨 크기는 최솟값 6px, 최댓값 120px로 설정했습니다.
- 글씨 크기가 기본값(16px)이 아니면 reset 버튼과 현재 글씨 크기를 보여줍니다. (애니메이션도 넣었어요!)
- 길게 누르면 글씨 크기가 빠르게 변경됩니다.

https://github.com/user-attachments/assets/e4cbce7b-1bd8-41a8-a84f-87d86838b7da

### Additional context

- 스크롤 관련해서 리팩토링 했습니다. (불필요한 `ScrollArea` 삭제)
- 이제 CodeEditor가 항상 height가 100%입니다. (어디를 클릭하든 커서 focus 가능!)

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
