### PR TITLE
fix(fe): route to assignment detail when click exit

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/finished/problem/[problemId]/page.tsx
@@ -56,9 +56,7 @@ export default async function AssignmentFinishedPage({
             </Link>
           )}
           <Link
-            href={
-              `/course/${courseId}/assignment/${assignmentId}/problem` as Route
-            }
+            href={`/course/${courseId}/assignment/${assignmentId}` as Route}
           >
             <Button
               size="icon"


### PR DESCRIPTION
### Client - Course - Assignment - Detail - CodeEditor
- 과제 마감기간이 지나서, 뒤로 돌아가려는 exit버튼을 누를때, Assignment Detail페이지로  이동합니다.
- 이전에 Info/Problem 탭이 분리됐을  당시, 로직이 그대로 남아있었어용..

<img width="1806" alt="image" src="https://github.com/user-attachments/assets/4af28ef1-7377-4eca-bcb6-8aabd1fe19ef" />


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
