### PR TITLE
feat(be): use isJudgeResultVisible as isHiddenTestcaseVisible

### DIFF
--- a/apps/backend/apps/client/src/assignment/assignment.service.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { Prisma, ResultStatus } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import {
   ConflictFoundException,
   EntityNotExistException,

--- a/apps/backend/apps/client/src/assignment/assignment.service.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.ts
@@ -216,6 +216,21 @@ export class AssignmentService {
     })
   }
 
+  /**
+   * Assignment 통계 모달을 위해 익명화된 모든 참여자의 점수를 가져옵니다
+   * Autofinalize가 true인 경우 score를 finalScore로 사용합니다
+   * isFinalScoreVisible이 false인 경우 finalScore를 null로 설정합니다
+   * @param {number} groupId assignment의 groupId
+   * @param {number} assignmentId 점수를 조회하려는 Assignment ID
+   * @returns {Promise<{
+   *   assignmentId: number;
+   *   title: string;
+   *   totalParticipants: number;
+   *   finalScores?: number[];
+   *   autoFinalizeScore: boolean;
+   *   isFinalScoreVisible: boolean;
+   * }>}
+   */
   async getAnonymizedScores(assignmentId: number, groupId: number) {
     const assignment = await this.prisma.assignment.findUnique({
       where: { id: assignmentId },
@@ -287,6 +302,34 @@ export class AssignmentService {
     return result
   }
 
+  /**
+   * 특정 사용자의 과제 문제 기록을 가져옵니다.
+   * - 과제의 문제별 점수, 제출 여부, 코멘트 등을 포함합니다.
+   * - 과제의 자동 점수 산정 여부 및 최종 점수 공개 여부에 따라 반환 값이 달라질 수 있습니다.
+   *
+   * @param {number} assignmentId 조회하려는 과제의 ID
+   * @param {number} userId 조회하려는 사용자의 ID
+   * @returns {Promise<{
+   *   id: number;
+   *   autoFinalizeScore: boolean;
+   *   isFinalScoreVisible: boolean;
+   *   isJudgeResultVisible: boolean;
+   *   userAssignmentFinalScore: number | null;
+   *   assignmentPerfectScore: number;
+   *   comment: string | null;
+   *   problems: Array<{
+   *     id: number;
+   *     title: string;
+   *     order: number;
+   *     maxScore: number;
+   *     problemRecord: {
+   *       finalScore: number | null;
+   *       isSubmitted: boolean;
+   *       comment: string | null;
+   *     } | null;
+   *   }>;
+   * }>}
+   */
   async getMyAssignmentProblemRecord(assignmentId: number, userId: number) {
     const assignment = await this.prisma.assignment.findUnique({
       where: {

--- a/apps/backend/apps/client/src/problem/mock/problem.mock.ts
+++ b/apps/backend/apps/client/src/problem/mock/problem.mock.ts
@@ -161,33 +161,27 @@ export const assignmentProblemsWithScore = [
     order: 1,
     assignmentId: 1,
     problemId: 1,
-    score: null,
     createTime: faker.date.past(),
     updateTime: faker.date.past(),
     assignment: {
       startTime: new Date()
     },
-    maxScore: 0,
-    submissionTime: null
+    maxScore: 0
   },
   {
     order: 2,
     assignmentId: 1,
     problemId: 2,
-    score: null,
     createTime: faker.date.past(),
     updateTime: faker.date.past(),
     assignment: {
       startTime: new Date()
     },
-    maxScore: 0,
-    submissionTime: null
+    maxScore: 0
   }
 ] satisfies Array<
   Omit<AssignmentProblem, 'score'> & { assignment: Partial<Assignment> } & {
     maxScore: number
-    submissionTime: Date | null
-    score: number | null
   }
 >
 

--- a/apps/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.spec.ts
@@ -14,10 +14,7 @@ import { GroupService } from '@client/group/group.service'
 import { WorkbookService } from '@client/workbook/workbook.service'
 import { ProblemResponseDto } from './dto/problem.response.dto'
 import { _ProblemsResponseDto } from './dto/problems.response.dto'
-import {
-  _RelatedProblemResponseDto,
-  RelatedProblemResponseDto
-} from './dto/related-problem.response.dto'
+import { _RelatedProblemResponseDto } from './dto/related-problem.response.dto'
 import { _RelatedProblemsResponseDto } from './dto/related-problems.response.dto'
 import {
   assignmentProblems,

--- a/apps/backend/apps/client/src/problem/problem.service.spec.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.spec.ts
@@ -655,7 +655,6 @@ describe('AssignmentProblemService', () => {
 
   describe('getAssignmentProblems', () => {
     it('should return public assignment problems', async () => {
-      // given
       const getAssignmentSpy = stub(assignmentService, 'getAssignment')
       getAssignmentSpy.resolves(mockAssignment)
       db.assignmentProblem.findMany.resolves(mockAssignmentProblems)
@@ -664,7 +663,6 @@ describe('AssignmentProblemService', () => {
         { problemId: 1, score: null }
       ])
 
-      // when
       const result = await service.getAssignmentProblems({
         assignmentId,
         userId,
@@ -672,18 +670,32 @@ describe('AssignmentProblemService', () => {
         take: 1
       })
 
-      // then
-      expect(result).to.deep.equal(
-        // Deprecated
-        plainToInstance(_RelatedProblemsResponseDto, {
-          data: mockAssignmentProblemsWithScore,
-          total: mockAssignmentProblemsWithScore.length
-        })
-      )
+      expect(result).to.deep.equal({
+        data: [
+          {
+            acceptedRate: 0.5,
+            difficulty: 'Level1',
+            id: 1,
+            maxScore: 0,
+            order: 1,
+            submissionCount: 10,
+            title: 'public problem'
+          },
+          {
+            acceptedRate: 0.5,
+            difficulty: 'Level1',
+            id: 1,
+            maxScore: 0,
+            order: 2,
+            submissionCount: 10,
+            title: 'public problem'
+          }
+        ],
+        total: mockAssignmentProblemsWithScore.length
+      })
     })
 
     it('should return group assignment problems', async () => {
-      // given
       const getAssignmentSpy = stub(assignmentService, 'getAssignment')
       getAssignmentSpy.resolves(mockAssignment)
       db.assignmentProblem.findMany.resolves(mockAssignmentProblems)
@@ -692,7 +704,6 @@ describe('AssignmentProblemService', () => {
         { problemId: 1, score: null }
       ])
 
-      // when
       const result = await service.getAssignmentProblems({
         assignmentId,
         userId,
@@ -700,22 +711,35 @@ describe('AssignmentProblemService', () => {
         take: 1
       })
 
-      // then
-      expect(result).to.deep.equal(
-        // Deprecated
-        plainToInstance(_RelatedProblemsResponseDto, {
-          data: mockAssignmentProblemsWithScore,
-          total: mockAssignmentProblemsWithScore.length
-        })
-      )
+      expect(result).to.deep.equal({
+        data: [
+          {
+            acceptedRate: 0.5,
+            difficulty: 'Level1',
+            id: 1,
+            maxScore: 0,
+            order: 1,
+            submissionCount: 10,
+            title: 'public problem'
+          },
+          {
+            acceptedRate: 0.5,
+            difficulty: 'Level1',
+            id: 1,
+            maxScore: 0,
+            order: 2,
+            submissionCount: 10,
+            title: 'public problem'
+          }
+        ],
+        total: mockAssignmentProblemsWithScore.length
+      })
     })
 
     it('should throw PrismaClientKnownRequestError when the assignment is not visible', async () => {
-      // given
       const getAssignmentSpy = stub(assignmentService, 'getAssignment')
       getAssignmentSpy.rejects(prismaNotFoundError)
 
-      // then
       await expect(
         service.getAssignmentProblems({
           assignmentId,
@@ -742,19 +766,16 @@ describe('AssignmentProblemService', () => {
 
   describe('getAssignmentProblem', () => {
     it('should return the public assignment problem', async () => {
-      // given
       const getAssignmentSpy = stub(assignmentService, 'getAssignment')
       getAssignmentSpy.resolves(mockAssignment)
       db.assignmentProblem.findUniqueOrThrow.resolves(mockAssignmentProblem)
 
-      // when
       const result = await service.getAssignmentProblem({
         assignmentId,
         problemId,
         userId
       })
 
-      // then
       expect(result).to.be.deep.equal(
         // Deprecated
         plainToInstance(_RelatedProblemResponseDto, mockAssignmentProblem)
@@ -762,19 +783,16 @@ describe('AssignmentProblemService', () => {
     })
 
     it('should return the group assignment problem', async () => {
-      // given
       const getAssignmentSpy = stub(assignmentService, 'getAssignment')
       getAssignmentSpy.resolves(mockAssignment)
       db.assignmentProblem.findUniqueOrThrow.resolves(mockAssignmentProblem)
 
-      // when
       const result = await service.getAssignmentProblem({
         assignmentId,
         problemId,
         userId
       })
 
-      // then
       expect(result).to.be.deep.equal(
         // Deprecated
         plainToInstance(_RelatedProblemResponseDto, mockAssignmentProblem)

--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -524,13 +524,12 @@ export class AssignmentProblemService {
 
   /**
    * 주어진 옵션에 따라 과제 문제를 여러개 가져옵니다.
-   * 이때, 사용자의 제출기록을 확인하여 각 문제의 점수를 계산합니다.
    *
    * 액세스 정책
    *
-   * 대회 시작 전: 문제 액세스 불가 (Register 안하면 에러 메시지가 다름) //
-   * 대회 진행 중: Register한 경우 문제 액세스 가능 //
-   * 대회 종료 후: 누구나 문제 액세스 가능
+   * 과제 시작 전: 문제 액세스 불가 (Register 안하면 에러 메시지가 다름) //
+   * 과제 진행 중: Participate한 경우 문제 액세스 가능 //
+   * 과제 종료 후: Participate한 경우 문제 액세스 가능
    * @returns {RelatedProblemsResponseDto} data: 과제 문제 목록, total: 과제 문제 총 개수
    */
   async getAssignmentProblems({

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -920,10 +920,12 @@ export class SubmissionService {
    * 3. 해당 문제에 대한 총 제출 기록 수 계산
    * 4. 제출물 목록과 총 개수를 포함하는 객체를 반환
    *
+   * @param {number} id - Submission ID
    * @param {number} problemId - 제출 기록을 조회할 문제 ID
-   * @param {number} groupId - 문제의 그룹 ID
-   * @param {number | null} [cursor=null] - 페이징 처리를 위한 커서 값 (기본값: null)
-   * @param {number} [take=10] - 가져올 제출 기록의 수 (기본값: 10)
+   * @param {number} userId - 제출 기록을 조회할 사용자 ID
+   * @param {Role} userRole - 사용자의 역할 (Admin, SuperAdmin 등)
+   * @param {number | null} contestId - 대회 ID (null인 경우 대회 제출 아님)
+   * @param {number | null} assignmentId - 과제 ID (null인 경우 과제 제출 아님)
    * @returns 문제에 대한 제출 기록 목록과 총 제출 기록 수
    * @throws {EntityNotExistException} 주어진 조건에 맞는 문제가 존재하지 않을 경우
    */
@@ -1297,6 +1299,23 @@ export class SubmissionService {
     return { data: submissions, total }
   }
 
+  /**
+   * 주어진 문제에 대한 제출 기록 목록을 불러옵니다.
+   *
+   * 1. 지정된 문제와 그룹에 대해 visibleLockTime이 초기값(MIN_DATE)인 문제를 조회
+   * 2. 페이징 옵션을 적용하여 해당 문제에 대한 제출 기록 목록을 조회
+   * 3. 해당 문제에 대한 총 제출 기록 수 계산
+   * 4. 제출물 목록과 총 개수를 포함하는 객체를 반환
+   *
+   * @param {Object} params - 제출 기록 조회를 위한 파라미터
+   * @param {number} params.problemId - 제출 기록을 조회할 문제 ID
+   * @param {number} params.assignmentId - 제출 기록을 조회할 과제 ID
+   * @param {number} params.userId - 제출 기록을 조회할 사용자 ID
+   * @param {number | null} [params.cursor=null] - 페이징을 위한 커서 값
+   * @param {number} [params.take=10] - 한 번에 가져올 제출 기록의 개수
+   * @returns 제출 기록 목록과 총 개수를 포함하는 객체
+   * @throws {EntityNotExistException} 주어진 조건에 맞는 문제가 존재하지 않을 경우
+   */
   @Span()
   async getAssignmentSubmissions({
     problemId,
@@ -1416,6 +1435,21 @@ export class SubmissionService {
     return { data: submissions, total, assignmentProblem }
   }
 
+  /**
+   * 특정 과제 문제에 대한 사용자의 가장 최근 제출 기록을 가져옵니다.
+   *
+   * 1. 사용자가 과제에 참여했는지 확인
+   * 2. 과제의 채점 결과 공개 여부를 확인
+   * 3. 가장 최근 제출 기록을 조회
+   * 4. 히든 테스트케이스 결과를 필터링하여 반환
+   *
+   * @param {number} problemId - 제출 기록을 조회할 문제 ID
+   * @param {number} assignmentId - 제출 기록을 조회할 과제 ID
+   * @param {number} userId - 제출 기록을 조회할 사용자 ID
+   * @returns 가장 최근 제출 기록 객체
+   * @throws {ForbiddenAccessException} 사용자가 과제에 참여하지 않은 경우
+   * @throws {NotFoundException} 과제 또는 제출 기록이 존재하지 않는 경우
+   */
   async getLatestAssignmentProblemSubmission(
     problemId: number,
     assignmentId: number,
@@ -1500,6 +1534,19 @@ export class SubmissionService {
     return { ...rawSubmission, submissionResult: filteredSubmissionResult }
   }
 
+  /**
+   * 특정 과제에 과제에 속한 문제별로 사용자의 제출 요약 정보를 가져옵니다.
+   * Submission Result, Testcase 개수와 accepted Testcase 개수를 포함합니다.
+   *
+   * 1. 사용자가 과제에 참여했는지 확인
+   * 2. 과제의 문제 목록을 조회
+   * 3. 사용자의 제출 기록을 조회하고 문제별로 요약 정보 생성
+   *
+   * @param {number} assignmentId - 제출 요약 정보를 조회할 과제 ID
+   * @param {number} userId - 제출 요약 정보를 조회할 사용자 ID
+   * @returns 과제 문제별 제출 요약 정보 배열
+   * @throws {ForbiddenAccessException} 사용자가 과제에 참여하지 않은 경우
+   */
   async getAssignmentSubmissionSummary(assignmentId: number, userId: number) {
     const [isParticipated, assignmentProblems] = await Promise.all([
       this.prisma.assignmentRecord.findUnique({
@@ -1598,6 +1645,21 @@ export class SubmissionService {
     }))
   }
 
+  /**
+   * 히든 테스트케이스를 제외한 제출 결과를 기반으로 샘플 테스트케이스의 결과를 계산합니다.
+   *
+   * 1. 히든 테스트케이스를 필터링하여 제외
+   * 2. 모든 테스트케이스가 Accepted 상태인지 확인
+   * 3. 모든 테스트케이스가 Accepted 상태라면 Accepted를 반환
+   * 4. 그렇지 않으면 첫 번째 실패한 테스트케이스의 결과를 반환
+   * 5. 실패한 테스트케이스가 없으면 ServerError를 반환
+   *
+   * @param {Array<{
+   *   result: ResultStatus;
+   *   problemTestcase: { isHidden: boolean };
+   * }>} submissionResults - Testcase result 배열
+   * @returns {ResultStatus} 샘플 테스트케이스만 반영한 Submission Result
+   */
   private getSampleTestcaseSubmissionResult(
     submissionResults: Array<{
       result: ResultStatus

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -1121,7 +1121,7 @@ export class SubmissionService {
       }
 
       if (assignmentId && !isHiddenTestcaseVisible) {
-        submission.result = this.getHiddenTestcaseExcludedSubmissionResult(
+        submission.result = this.getSampleTestcaseSubmissionResult(
           submission.submissionResult
         )
       }
@@ -1403,7 +1403,7 @@ export class SubmissionService {
 
     if (!isHiddenTestcaseVisible) {
       submissions.forEach((submission) => {
-        submission.result = this.getHiddenTestcaseExcludedSubmissionResult(
+        submission.result = this.getSampleTestcaseSubmissionResult(
           submission.submissionResult
         )
       })
@@ -1492,7 +1492,7 @@ export class SubmissionService {
       }))
 
     if (!isHiddenTestcaseVisible) {
-      rawSubmission.result = this.getHiddenTestcaseExcludedSubmissionResult(
+      rawSubmission.result = this.getSampleTestcaseSubmissionResult(
         rawSubmission.submissionResult
       )
     }
@@ -1577,7 +1577,7 @@ export class SubmissionService {
           submissionTime: submission.createTime,
           submissionResult: isHiddenTestcaseVisible
             ? submission.result
-            : this.getHiddenTestcaseExcludedSubmissionResult(
+            : this.getSampleTestcaseSubmissionResult(
                 submission.submissionResult
               ),
           testcaseCount: filteredSubmissionResult.length,
@@ -1598,7 +1598,7 @@ export class SubmissionService {
     }))
   }
 
-  private getHiddenTestcaseExcludedSubmissionResult(
+  private getSampleTestcaseSubmissionResult(
     submissionResults: Array<{
       result: ResultStatus
       problemTestcase: {

--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -750,36 +750,6 @@ describe('SubmissionService', () => {
       expect(db.submission.findMany.calledOnce).to.be.true
     })
 
-    it('should return submission with blind results when isJudgeResultVisible is false', async () => {
-      const assignmentId = 1
-      const userId = 1
-      const mockAssignmentProblems = [{ problemId: 1 }]
-      const mockSubmissions = [
-        {
-          problemId: 1,
-          createTime: new Date(),
-          result: 'Accepted',
-          submissionResult: [{ result: 'Accepted' }, { result: 'Accepted' }]
-        }
-      ]
-
-      db.assignmentRecord.findUnique.resolves({
-        assignment: { isJudgeResultVisible: false }
-      })
-      db.assignmentProblem.findMany.resolves(mockAssignmentProblems)
-      db.submission.findMany.resolves(mockSubmissions)
-
-      const result = await service.getAssignmentSubmissionSummary(
-        assignmentId,
-        userId
-      )
-
-      expect(result).to.have.lengthOf(1)
-      expect(result[0].problemId).to.equal(1)
-      expect(result[0].submission?.submissionResult).to.equal('Blind')
-      expect(result[0].submission?.acceptedTestcaseCount).to.be.null
-    })
-
     it('should return empty array when there are no assignment problems', async () => {
       const assignmentId = 1
       const userId = 1


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
이제 무조건 judge result는 다 보여줍니다.
isHiddenTestcaseVisible이 false면 isHidden이 true인 테스트케이스는 학생에게 아예 없는 존재처럼 나타납니다.
또한, raw score는 이제 학생에게 보이지 않습니다. 

예) 
- 샘플테스트케이스 전부 맞았는데 히든테스트케이스에 오답이 있어도 isHiddenTestcaseVisible이 false일 경우 submissionResult는 Accepted
- TC Result에서 개수를 보여줄때 isHiddenTestcaseVisible이 false이면 히든 테스트케이스는 개수에 포함하지 않음

이번 배포때 급하게 포함되어야 해서 필드명을 변경하지 않고 isJudgeResultVisible을 그대로 사용했습니다. 추후 태스크에서 정리할 예정입니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Submission 모듈에서 assignment와 contest가 지독하게 엮여있는데(getSubmission), isHiddenTestcaseVisible로 필드명을 변경하게 되면 분기가 진짜 폭발할 것 같습니다... 아예 서로 메서드를 분리하는게 어떤지...?

---

### Before submitting the PR, please make sure you do the following

Closes TAS-1597

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
