### PR TITLE
chore(be): add username email realname on getContest and getUsernameByEmail

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -102,7 +102,18 @@ export class ContestService {
           },
           select: {
             userId: true,
-            role: true
+            role: true,
+            user: {
+              select: {
+                username: true,
+                email: true,
+                userProfile: {
+                  select: {
+                    realName: true
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/apps/backend/apps/client/src/user/user.service.ts
+++ b/apps/backend/apps/client/src/user/user.service.ts
@@ -60,7 +60,12 @@ export class UserService {
       },
       select: {
         username: true,
-        id: true
+        id: true,
+        userProfile: {
+          select: {
+            realName: true
+          }
+        }
       }
     })
 

--- a/collection/admin/Contest/Get Contest/Succeed.bru
+++ b/collection/admin/Contest/Get Contest/Succeed.bru
@@ -24,6 +24,13 @@ body:graphql {
       userContest {
         userId
         role
+        user {
+          username
+          email
+          userProfile {
+            realName
+          }
+        }
       }
     }
   }
@@ -42,7 +49,7 @@ assert {
 docs {
   ## Get Problem
   참가자수 정보를 포함한 Problem 정보를 가져옵니다.
-  
+
   ### Error Cases
   #### NOT_FOUND
   존재하는 contestId를 전달해야 합니다.


### PR DESCRIPTION
### Description

1. (REST) Get Username by Email에 realName을 추가로 반환합니다.
2. (gql) Get Contest - userContest에 username email realName을 추가로 반환합니다.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
