### PR TITLE
chore(fe): unactivate unfreeze tooltip

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/_components/LeaderboardRow.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/_components/LeaderboardRow.tsx
@@ -68,6 +68,18 @@ export function LeaderboardRow({
                 transition={{ type: 'tween', duration: 0.5, ease: 'easeOut' }}
               >
                 {problemRecords.map((problem, index) => {
+                  if (problem.isFrozen) {
+                    return (
+                      <th
+                        key={index}
+                        className={`flex h-11 w-[114px] flex-row items-center justify-center text-xl font-semibold ${
+                          index !== 0 ? 'border-l-2 border-[#DCE3E5]' : ''
+                        }`}
+                      >
+                        <LeaderboardPenalty problem={problem} />
+                      </th>
+                    )
+                  }
                   return index === 0 ? (
                     <Tooltip.Root key={index}>
                       <Tooltip.Trigger asChild>
@@ -164,6 +176,19 @@ export function LeaderboardRow({
                 transition={{ type: 'tween', duration: 0.5, ease: 'easeOut' }}
               >
                 {problemRecords.map((problem, index) => {
+                  if (problem.isFrozen) {
+                    return (
+                      <th
+                        key={index}
+                        className={`flex h-11 w-[114px] flex-row items-center justify-center text-xl font-semibold ${
+                          index !== 0 ? 'border-l-2 border-[#DCE3E5]' : ''
+                        }`}
+                      >
+                        <LeaderboardPenalty problem={problem} />
+                      </th>
+                    )
+                  }
+
                   return index === 0 ? (
                     <Tooltip.Root key={index}>
                       <Tooltip.Trigger asChild>


### PR DESCRIPTION
### Description

원래 테이블 값에 마우스를 갖다 대면 submission이 나오도록 되있는데요,
unfreeze 상태인 값에 갖다 대면 나오지 않는 것이 맞는 것 같아서 그렇게 수정했습니다. 

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
