### PR TITLE
fix(fe): editor text color theme

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
@@ -231,7 +231,6 @@ function AssignmentAccordionItem({
                       <DetailButton
                         isActivated={
                           (record?.isFinalScoreVisible ?? false) &&
-                          (problem.problemRecord?.isSubmitted ?? false) &&
                           dayjs().isAfter(dayjs(assignment.endTime))
                         }
                       />

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/SubmissionDetailModal.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/SubmissionDetailModal.tsx
@@ -50,187 +50,185 @@ export function SubmissionDetailModal({
   )
 
   return (
-    submission && (
-      <DialogContent
-        className="max-h-[80vh] overflow-auto p-14 sm:max-w-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <DialogHeader>
-          <DialogTitle>
-            <div className="flex items-center gap-2 overflow-hidden truncate whitespace-nowrap text-lg font-medium">
-              <span
-                title={`Week ${assignment.week}`}
-                className="max-w-[80px] truncate"
-              >
-                Week {assignment.week}
-              </span>
-              <MdArrowForwardIos />
-              <span
-                title={assignment.title}
-                className="text-primary max-w-[200px] overflow-hidden truncate"
-              >
-                {assignment.title}
-              </span>
-              <MdArrowForwardIos />
-              <span
-                title={
-                  assignmentProblemRecord?.problems.find(
-                    (problem) => problem.id === problemId
-                  )?.title || 'Not found'
-                }
-                className="max-w-[200px] overflow-hidden truncate"
-              >
-                {assignmentProblemRecord?.problems.find(
+    <DialogContent
+      className="max-h-[80vh] overflow-auto p-14 sm:max-w-2xl"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <DialogHeader>
+        <DialogTitle>
+          <div className="flex items-center gap-2 overflow-hidden truncate whitespace-nowrap text-lg font-medium">
+            <span
+              title={`Week ${assignment.week}`}
+              className="max-w-[80px] truncate"
+            >
+              Week {assignment.week}
+            </span>
+            <MdArrowForwardIos />
+            <span
+              title={assignment.title}
+              className="text-primary max-w-[200px] overflow-hidden truncate"
+            >
+              {assignment.title}
+            </span>
+            <MdArrowForwardIos />
+            <span
+              title={
+                assignmentProblemRecord?.problems.find(
                   (problem) => problem.id === problemId
-                )?.title || 'Not found'}
-              </span>
-            </div>
-          </DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-2">
-            <span className="flex h-[30px] w-[140px] items-center justify-center gap-1 rounded-full border border-blue-500 font-bold text-blue-500">
-              <span className="text-lg">
-                {assignmentProblemRecord?.problems.find(
-                  (problem) => problem.id === problemId
-                )?.problemRecord?.finalScore ?? '-'}
-              </span>
-              {'  /  '}
-              <span className="text-lg">
-                {
-                  assignmentProblemRecord?.problems.find(
-                    (problem) => problem.id === problemId
-                  )?.maxScore
-                }
-              </span>
+                )?.title || 'Not found'
+              }
+              className="max-w-[200px] overflow-hidden truncate"
+            >
+              {assignmentProblemRecord?.problems.find(
+                (problem) => problem.id === problemId
+              )?.title || 'Not found'}
             </span>
           </div>
-
-          <div className="flex flex-col gap-2">
-            <span className="text-sm font-medium">Comment</span>
-            <div className="flex-col rounded border p-4">
-              <span className="text-xs">
-                {assignmentProblemRecord?.problems.find(
+        </DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <span className="flex h-[30px] w-[140px] items-center justify-center gap-1 rounded-full border border-blue-500 font-bold text-blue-500">
+            <span className="text-lg">
+              {assignmentProblemRecord?.problems.find(
+                (problem) => problem.id === problemId
+              )?.problemRecord?.finalScore ?? '-'}
+            </span>
+            {'  /  '}
+            <span className="text-lg">
+              {
+                assignmentProblemRecord?.problems.find(
                   (problem) => problem.id === problemId
-                )?.problemRecord?.comment || ''}
-              </span>
-            </div>
-          </div>
+                )?.maxScore
+              }
+            </span>
+          </span>
+        </div>
 
-          {submission && (
-            <div className="flex flex-col gap-2">
-              <span className="text-sm font-medium">Last Submission</span>
-              <ScrollArea className="rounded-md">
-                <div className="flex items-center justify-around gap-5 rounded-lg border border-[#E6E6E6] bg-gray-50 p-5 text-xs [&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-[14px] [&_*]:whitespace-nowrap [&_p]:text-slate-400">
-                  <div>
-                    <h2>User ID</h2>
-                    <p>{submission?.user.username}</p>
-                  </div>
-                  <Separator
-                    orientation="vertical"
-                    className="h-[60px] w-[0.5px] bg-[#E6E6E6]"
-                  />
-                  <div>
-                    <h2>Language</h2>
-                    <p>{submission?.language}</p>
-                  </div>
-                  <Separator
-                    orientation="vertical"
-                    className="h-[60px] w-[0.5px] bg-[#E6E6E6]"
-                  />
-                  <div>
-                    <h2>Code Size</h2>
-                    <p>{submission?.codeSize} B</p>
-                  </div>
-                  <Separator
-                    orientation="vertical"
-                    className="h-[60px] w-[0.5px] bg-[#E6E6E6]"
-                  />
-                  <div>
-                    <h2>Submission Time</h2>
-                    <p>
-                      {dateFormatter(
-                        submission?.createTime ?? '',
-                        'MMM DD, YYYY HH:mm'
-                      )}
-                    </p>
-                  </div>
-                </div>
-                <ScrollBar orientation="horizontal" />
-              </ScrollArea>
-            </div>
-          )}
-          {testResults && (
-            <div className="flex flex-col gap-2">
-              {testResults && (
-                <div>
-                  <span className="text-sm font-medium">Testcase Result</span>
-
-                  {(() => {
-                    const sortedResults = [...testResults.testcaseResult].sort(
-                      (a, b) =>
-                        Number(a.problemTestcase.isHidden) -
-                        Number(b.problemTestcase.isHidden)
-                    )
-
-                    // 인덱스 관리
-                    let sampleCount = 0
-                    let hiddenCount = 0
-
-                    return (
-                      <table className="w-full border-collapse text-center text-sm">
-                        <thead className="bg-gray-50 text-[#737373]">
-                          <tr>
-                            {sortedResults.map((result, index) => {
-                              const isHidden = result.problemTestcase.isHidden
-                              const label = isHidden
-                                ? `Hidden #${++hiddenCount}`
-                                : `Sample #${++sampleCount}`
-                              return (
-                                <th
-                                  key={index}
-                                  className="border px-4 py-2 text-xs font-normal"
-                                >
-                                  {label}
-                                </th>
-                              )
-                            })}
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            {sortedResults.map((result, index) => (
-                              <td
-                                key={result.id || index}
-                                className={`border px-4 py-3 text-xs font-semibold ${
-                                  result.result === 'Accepted'
-                                    ? 'text-blue-500'
-                                    : 'text-red-500'
-                                }`}
-                              >
-                                {result.result === 'Accepted' ? 'P' : 'F'}
-                              </td>
-                            ))}
-                          </tr>
-                        </tbody>
-                      </table>
-                    )
-                  })()}
-                </div>
-              )}
-            </div>
-          )}
-          <div className="flex flex-col gap-2">
-            <span className="text-sm font-medium">Source Code</span>
-            <CodeEditor
-              value={testResults?.code ?? ''}
-              language={testResults?.language ?? 'C'}
-              readOnly
-              className="max-h-96 min-h-16 w-full"
-            />
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Comment</span>
+          <div className="flex-col rounded border p-4">
+            <span className="text-xs">
+              {assignmentProblemRecord?.problems.find(
+                (problem) => problem.id === problemId
+              )?.problemRecord?.comment || ''}
+            </span>
           </div>
         </div>
-      </DialogContent>
-    )
+
+        {submission && (
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium">Last Submission</span>
+            <ScrollArea className="rounded-md">
+              <div className="flex items-center justify-around gap-5 rounded-lg border border-[#E6E6E6] bg-gray-50 p-5 text-xs [&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-[14px] [&_*]:whitespace-nowrap [&_p]:text-slate-400">
+                <div>
+                  <h2>User ID</h2>
+                  <p>{submission?.user.username}</p>
+                </div>
+                <Separator
+                  orientation="vertical"
+                  className="h-[60px] w-[0.5px] bg-[#E6E6E6]"
+                />
+                <div>
+                  <h2>Language</h2>
+                  <p>{submission?.language}</p>
+                </div>
+                <Separator
+                  orientation="vertical"
+                  className="h-[60px] w-[0.5px] bg-[#E6E6E6]"
+                />
+                <div>
+                  <h2>Code Size</h2>
+                  <p>{submission?.codeSize} B</p>
+                </div>
+                <Separator
+                  orientation="vertical"
+                  className="h-[60px] w-[0.5px] bg-[#E6E6E6]"
+                />
+                <div>
+                  <h2>Submission Time</h2>
+                  <p>
+                    {dateFormatter(
+                      submission?.createTime ?? '',
+                      'MMM DD, YYYY HH:mm'
+                    )}
+                  </p>
+                </div>
+              </div>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
+          </div>
+        )}
+        {testResults && (
+          <div className="flex flex-col gap-2">
+            {testResults && (
+              <div>
+                <span className="text-sm font-medium">Testcase Result</span>
+
+                {(() => {
+                  const sortedResults = [...testResults.testcaseResult].sort(
+                    (a, b) =>
+                      Number(a.problemTestcase.isHidden) -
+                      Number(b.problemTestcase.isHidden)
+                  )
+
+                  // 인덱스 관리
+                  let sampleCount = 0
+                  let hiddenCount = 0
+
+                  return (
+                    <table className="w-full border-collapse text-center text-sm">
+                      <thead className="bg-gray-50 text-[#737373]">
+                        <tr>
+                          {sortedResults.map((result, index) => {
+                            const isHidden = result.problemTestcase.isHidden
+                            const label = isHidden
+                              ? `Hidden #${++hiddenCount}`
+                              : `Sample #${++sampleCount}`
+                            return (
+                              <th
+                                key={index}
+                                className="border px-4 py-2 text-xs font-normal"
+                              >
+                                {label}
+                              </th>
+                            )
+                          })}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          {sortedResults.map((result, index) => (
+                            <td
+                              key={result.id || index}
+                              className={`border px-4 py-3 text-xs font-semibold ${
+                                result.result === 'Accepted'
+                                  ? 'text-blue-500'
+                                  : 'text-red-500'
+                              }`}
+                            >
+                              {result.result === 'Accepted' ? 'P' : 'F'}
+                            </td>
+                          ))}
+                        </tr>
+                      </tbody>
+                    </table>
+                  )
+                })()}
+              </div>
+            )}
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Source Code</span>
+          <CodeEditor
+            value={testResults?.code ?? ''}
+            language={testResults?.language ?? 'C'}
+            readOnly
+            className="max-h-96 min-h-16 w-full"
+          />
+        </div>
+      </div>
+    </DialogContent>
   )
 }

--- a/apps/frontend/app/(client)/_libs/apis/assignmentSubmission.ts
+++ b/apps/frontend/app/(client)/_libs/apis/assignmentSubmission.ts
@@ -1,4 +1,4 @@
-import { safeFetcherWithAuth } from '@/libs/utils'
+import { isHttpError, safeFetcherWithAuth } from '@/libs/utils'
 import type {
   AssignmentProblemRecord,
   AssignmentSubmission,
@@ -93,15 +93,21 @@ export const getLatestProblemSubmissionResult = async ({
   assignmentId,
   problemId
 }: GetLatestProblemSubmissionResultRequest) => {
-  const response = await safeFetcherWithAuth.get(
-    `assignment/${assignmentId}/submission/latest`,
-    {
-      searchParams: { problemId }
-    }
-  )
+  try {
+    const response = await safeFetcherWithAuth.get(
+      `assignment/${assignmentId}/submission/latest`,
+      {
+        searchParams: { problemId }
+      }
+    )
 
-  const data = await response.json<ProblemSubmissionResult>()
-  return data
+    const data = await response.json<ProblemSubmissionResult>()
+    return data
+  } catch (error) {
+    if (isHttpError(error) && error.response.status === 403) {
+      return null
+    }
+  }
 }
 
 export interface GetProblemSubmissionResultsRequest {

--- a/apps/frontend/app/admin/_components/DescriptionForm.tsx
+++ b/apps/frontend/app/admin/_components/DescriptionForm.tsx
@@ -14,8 +14,8 @@ interface DescriptionFormProps {
 // NOTE: Contest는 description이 null일 수 있음(필수 항목이 아님)
 export function DescriptionForm({
   name,
-  isContest = false
-  // isDarkmode = false
+  isContest = false,
+  isDarkmode = false
 }: DescriptionFormProps) {
   const {
     control,
@@ -44,7 +44,7 @@ export function DescriptionForm({
         placeholder="Enter a description..."
         onChange={field.onChange}
         defaultValue={field.value as string}
-        // isDarkMode={isDarkmode}
+        isDarkMode={isDarkmode}
       />
       {errors[name] && (
         <ErrorMessage

--- a/apps/frontend/app/admin/_components/TextEditor.tsx
+++ b/apps/frontend/app/admin/_components/TextEditor.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/shadcn/popover'
 import { Toggle } from '@/components/shadcn/toggle'
 import { UPLOAD_IMAGE, UPLOAD_FILE } from '@/graphql/problem/mutations'
+import { cn } from '@/libs/utils'
 import { useMutation } from '@apollo/client'
 import type { Range } from '@tiptap/core'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
@@ -80,15 +81,19 @@ import { getSuggestionItems } from './tiptap/items'
 import { renderItems } from './tiptap/renderItems'
 import './tiptap/styles.css'
 
-export function TextEditor({
-  placeholder,
-  onChange,
-  defaultValue
-}: {
+interface TextEditorProps {
   placeholder: string
   onChange: (richText: string) => void
   defaultValue?: string
-}) {
+  isDarkMode?: boolean
+}
+
+export function TextEditor({
+  placeholder,
+  onChange,
+  defaultValue,
+  isDarkMode = false
+}: TextEditorProps) {
   const lowlight = createLowlight(common)
 
   const editor = useEditor({
@@ -647,7 +652,10 @@ export function TextEditor({
         onClose={() => setIsCautionDialogOpen(false)}
         description={dialogDescription}
       />
-      <EditorContent editor={editor} className="prose prose-invert max-w-5xl" />
+      <EditorContent
+        editor={editor}
+        className={cn('prose max-w-5xl', isDarkMode && 'prose-invert')}
+      />
     </div>
   )
 }

--- a/apps/frontend/components/CodeEditor.tsx
+++ b/apps/frontend/components/CodeEditor.tsx
@@ -177,8 +177,8 @@ export function CodeEditor({
         />
         <ScrollBar orientation="horizontal" />
       </ScrollArea>
-      <div className="flex w-full flex-none items-center justify-end gap-1 border-t border-slate-700 bg-[#121728] px-4 py-1.5">
-        {showZoom && (
+      {showZoom && (
+        <div className="flex w-full flex-none items-center justify-end gap-1 border-t border-slate-700 bg-[#121728] px-4 py-1.5">
           <TooltipProvider>
             <AnimatePresence>
               {fontSize !== 16 && (
@@ -247,8 +247,8 @@ export function CodeEditor({
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### Management - TextEditor
- DarkMode여부에 따라서, 글자색을 다르게 했습니다.
![image](https://github.com/user-attachments/assets/2ab3b922-bc82-4b88-a8c2-8b8c8f70c3ff)
![image](https://github.com/user-attachments/assets/684552a7-8189-45ca-b8c9-b34f146c09bd)

### Client - Course - Assignment - 제출모달
- 제출하지 않은 경우에도, 모달을 열 수 있도록 했습니다.
- CodeEditor의 showZoom분기 위치를 수정하여, 보이지 않아야하는 막대를 없앴습니다.
<img width="2016" alt="image" src="https://github.com/user-attachments/assets/3a7a6317-5e94-405f-b2bb-03feb212df34" />


---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1610
