### PR TITLE
feat(infra): add goroutine in iris server for status check

### DIFF
--- a/apps/iris/main.go
+++ b/apps/iris/main.go
@@ -41,15 +41,6 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-
-	http.HandleFunc("/health", healthCheckHandler)
-	go func() {
-		if err := http.ListenAndServe("0.0.0.0:9999", nil); err != nil {
-			fmt.Println("Failed to start health checker:", err)
-			os.Exit(1)
-		}
-	}()
-
 	// profile()
 	env := Env(utils.Getenv("APP_ENV", "stage"))
 	logProvider := logger.NewLogger(logger.Console, env == Production)
@@ -74,6 +65,12 @@ func main() {
 		}
 	} else {
 		logProvider.Log(logger.INFO, "Running in stage mode")
+		http.HandleFunc("/health", healthCheckHandler)
+		go func() {
+			if err := http.ListenAndServe("0.0.0.0:9999", nil); err != nil {
+				logProvider.Log(logger.ERROR, fmt.Sprintf("Failed to start health checker: %v", err))
+			}
+		}()
 	}
 
 	database := postgres.NewPostgresDataSource(ctx)

--- a/apps/iris/main.go
+++ b/apps/iris/main.go
@@ -29,26 +29,23 @@ const (
 )
 
 func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")             // 모든 도메인에서 접근 허용
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS") // 허용할 메서드
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type") // 허용할 헤더
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, `{"status": "ok"}`)
 }
 
 func main() {
 
-	http.HandleFunc("/healthz", healthCheckHandler)
+	http.HandleFunc("/health", healthCheckHandler)
 	go func() {
-		fmt.Println("Starting health check server on port 3404...")
-		if err := http.ListenAndServe("0.0.0.0:3404", nil); err != nil {
-			fmt.Println("Failed to start server:", err)
+		if err := http.ListenAndServe("0.0.0.0:9999", nil); err != nil {
+			fmt.Println("Failed to start health checker:", err)
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
### Description
status.codedang.com 은 현재 codedang.com과 codedang API, stage.codedang.com 등만 상태를 확인할 수 있습니다.
채점 서버인 Iris 서버 또한 uptime kuma로 상태를 확인하기 위해서 main.go에 goroutine으로 http request에 응답하는 코드를 추가했습니다.

closes TAS-1564
### Additional context
CORS 문제를 해결하기 위해 추가해 둔 코드가 올바른 것인지, 9999번 포트를 사용하고 있는데 이것이 괜찮은 것인지 확인해주세요.
docker-compose.yml을 확인했을 때 iris는 network_mode가 host이므로, 호스트의 9999번 포트를 공유하는 것 같습니다.

---

### Before submitting the PR, please make sure you do the following

- [v] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [v] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [v] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
