### PR TITLE
feat(infra): add destroy acm-validation folder functionality in destroy workflows

### DIFF
--- a/.github/workflows/rc-destroy-target.yml
+++ b/.github/workflows/rc-destroy-target.yml
@@ -11,6 +11,7 @@ on:
           - 'network'
           - 'storage'
           - 'codedang'
+          - 'acm-validation'
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/rc-destroy.yml
+++ b/.github/workflows/rc-destroy.yml
@@ -62,6 +62,17 @@ jobs:
           terraform init -backend-config="bucket=codedang-tf-state-rc"
           terraform destroy -auto-approve
 
+      - name: Create Terraform variable file (ACM-Validation)
+        working-directory: ./apps/infra/rc/acm-validation
+        run: |
+          echo 'env = "rc"' >> terraform.tfvars
+
+      - name: Destroy ACM-Validation
+        working-directory: ./apps/infra/rc/acm-validation
+        run: |
+          terraform init -backend-config="bucket=codedang-tf-state-rc"
+          terraform destroy -auto-approve
+
       - name: Create Terraform variable file (Network)
         working-directory: ./apps/infra/rc/network
         run: |


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
새로 추가된 acm-validation폴더를 destroy하는 기능을 rc-destroy과 rc-destroy-target workflow에 추가하였습니다.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
