### PR TITLE
fix(infra): remove bucket name conflict in rc

### DIFF
--- a/apps/infra/rc/codedang/fluentbit.tf
+++ b/apps/infra/rc/codedang/fluentbit.tf
@@ -1,6 +1,6 @@
 # Bucket for internal files, such as configuration files
 resource "aws_s3_bucket" "internal" {
-  bucket = "codedang-internal"
+  bucket = "codedang-internal-rc"
 
   tags = {
     Name = "Codedang-Internal"


### PR DESCRIPTION
### Description

#2703 에서 생긴 codedang-internal bucket의 이름 충돌을 해결합니다

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
