### PR TITLE
chore(fe): disable enter key for hide panel button

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -349,6 +349,7 @@ function HidePanelButton({
             ? '[clip-path:polygon(0%_0%,100%_16%,100%_84%,0%_100%)]'
             : '[clip-path:polygon(16%_0%,84%_0%,100%_100%,0%_100%)]'
         )}
+        onKeyDown={preventEnterKeyDown}
         onClick={() => {
           toggleIsPanelHidden()
         }}
@@ -375,4 +376,10 @@ function HidePanelButton({
       </Button>
     </div>
   )
+}
+
+const preventEnterKeyDown = (event: React.KeyboardEvent) => {
+  if (event.key === 'Enter') {
+    event.preventDefault()
+  }
 }


### PR DESCRIPTION
### Description

https://github.com/user-attachments/assets/fd07342f-f4d7-4e73-8ce7-36ce6d104629


좌측 혹은 TC Result 패널을 숨기는 버튼을 클릭하여 포커스된 상태에서
엔터키를 누르면 버튼이 동작되는 버그를 막기 위해

`HidePanelButton` 에서 Enter KeyDown을 막았습니다

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Closes TAS-1599

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
