### PR TITLE
fix(fe): use correct type of problem testcase from graphql schema

### DIFF
--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/EditProblemForm.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/EditProblemForm.tsx
@@ -5,7 +5,7 @@ import { useConfirmNavigationContext } from '@/app/admin/_components/ConfirmNavi
 import { UPDATE_PROBLEM } from '@/graphql/problem/mutations'
 import { GET_PROBLEM } from '@/graphql/problem/queries'
 import { useMutation, useQuery } from '@apollo/client'
-import type { Template, Testcase, UpdateProblemInput } from '@generated/graphql'
+import type { Template, UpdateProblemInput, Testcase } from '@generated/graphql'
 import { useRouter } from 'next/navigation'
 import { useRef, useState, type ReactNode } from 'react'
 import { FormProvider, type UseFormReturn } from 'react-hook-form'
@@ -45,8 +45,16 @@ export function EditProblemForm({
     onCompleted: (problemData) => {
       const data = problemData.getProblem
 
+      // HACK: This is a workaround for migrating testcase to separated query/mutation.
+      // After migration, testcase input/output is not going to passed through 'getProblem' and 'updateProblem'
+      const testcases = data.testcase.map((testcase) => ({
+        ...testcase,
+        input: testcase.input ?? '',
+        output: testcase.output ?? ''
+      }))
+
       const initialFormValues = {
-        testcases: data.testcase,
+        testcases,
         timeLimit: data.timeLimit,
         memoryLimit: data.memoryLimit
       }
@@ -65,7 +73,7 @@ export function EditProblemForm({
         description: data.description,
         inputDescription: data.inputDescription || '<p></p>',
         outputDescription: data.outputDescription || '<p></p>',
-        testcases: data.testcase,
+        testcases,
         timeLimit: data.timeLimit,
         memoryLimit: data.memoryLimit,
         hint: data.hint,


### PR DESCRIPTION
### Description

#2632 에서 `ProblemTestcase` model의 `input`, `output` field가 optional로 바뀌면서 frontend 페이지에서 타입 에러가 발생하였습니다.
추후 testcases만 get 또는 update할 graphql query/mutation을 만들 예정이지만, 그 전에 임시로 type 에러를 해결하기 위해 input/output field에 빈 string 값을 저장합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
