### PR TITLE
feat(fe): hide 'run code' tab on contest

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -275,7 +275,7 @@ export function EditorMainResizablePanel({
                   defaultSize={40}
                   className={cn(isBottomPanelHidden && 'hidden')}
                 >
-                  <TestcasePanel />
+                  <TestcasePanel isContest={Boolean(courseId)} />
                 </ResizablePanel>
               </ResizablePanelGroup>
             </TestPollingStoreProvider>

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -10,13 +10,17 @@ import {
 } from '@/stores/editorTabs'
 import type { TestResultDetail } from '@/types/type'
 import { DiffMatchPatch } from 'diff-match-patch-typescript'
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { IoMdClose } from 'react-icons/io'
 import { WhitespaceVisualizer } from '../WhitespaceVisualizer'
 import { AddUserTestcaseDialog } from './AddUserTestcaseDialog'
 import { RunnerTab } from './RunnerTab'
 import { TestcaseTable } from './TestcaseTable'
 import { useTestResults } from './useTestResults'
+
+interface TestcasePanelProps {
+  isContest: boolean
+}
 
 function getWidthClass(length: number) {
   if (length < 5) {
@@ -28,7 +32,7 @@ function getWidthClass(length: number) {
   }
 }
 
-export function TestcasePanel() {
+export function TestcasePanel({ isContest }: TestcasePanelProps) {
   const [testcaseTabList, setTestcaseTabList] = useState<TestResultDetail[]>([])
   const { activeTab, setActiveTab } = useTestcaseTabStore()
   const [detailTabId, setDetailTabId] = useState<number | null>(null)
@@ -55,6 +59,14 @@ export function TestcasePanel() {
     }
   }
 
+  // TODO: remove this after 'run' feature gets stable
+  useEffect(() => {
+    if (isContest) {
+      setActiveTab(TESTCASE_RESULT_TAB)
+      setDetailTabId(null)
+    }
+  }, [isContest])
+
   const MAX_OUTPUT_LENGTH = 100000
   const testResults = useTestResults()
   const processedData = testResults.map((testcase) => ({
@@ -78,35 +90,36 @@ export function TestcasePanel() {
   return (
     <>
       <div className="flex h-12 w-full items-center overflow-x-auto">
-        <TestcaseTab
-          isActive={currentVisibleTab === RUN_CODE_TAB}
-          onClickTab={() => {
-            setActiveTab(RUN_CODE_TAB)
-            setDetailTabId(null)
-          }}
-          isLeftmost
-          isRightOfActive={currentVisibleTab === TESTCASE_RESULT_TAB}
-          className={cn(
-            'h-full flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap',
-            getWidthClass(testcaseTabList.length)
-          )}
-        >
-          <div className="flex h-full w-full items-center justify-center gap-2">
-            <span
-              className={
-                'block overflow-hidden text-ellipsis whitespace-nowrap'
-              }
-            >
-              Run Code
-            </span>
-            <div className="flex items-center">
-              <Badge type="upcoming">
-                <div className="text-[10px]">Beta</div>
-              </Badge>
+        {!isContest && (
+          <TestcaseTab
+            isActive={currentVisibleTab === RUN_CODE_TAB}
+            onClickTab={() => {
+              setActiveTab(RUN_CODE_TAB)
+              setDetailTabId(null)
+            }}
+            isLeftmost
+            isRightOfActive={currentVisibleTab === TESTCASE_RESULT_TAB}
+            className={cn(
+              'h-full flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap',
+              getWidthClass(testcaseTabList.length)
+            )}
+          >
+            <div className="flex h-full w-full items-center justify-center gap-2">
+              <span
+                className={
+                  'block overflow-hidden text-ellipsis whitespace-nowrap'
+                }
+              >
+                Run Code
+              </span>
+              <div className="flex items-center">
+                <Badge type="upcoming">
+                  <div className="text-[10px]">Beta</div>
+                </Badge>
+              </div>
             </div>
-          </div>
-        </TestcaseTab>
-
+          </TestcaseTab>
+        )}
         <TestcaseTab
           isActive={currentVisibleTab === TESTCASE_RESULT_TAB}
           onClickTab={() => {
@@ -132,7 +145,6 @@ export function TestcasePanel() {
             </span>
           </div>
         </TestcaseTab>
-
         <ScrollArea className={cn('relative h-12 w-full overflow-x-auto')}>
           <div className="flex h-12">
             {testcaseTabList.map((testcase, index) => (
@@ -180,7 +192,6 @@ export function TestcasePanel() {
           </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
-
         <div
           className={cn(
             'flex flex-shrink-0 items-center bg-[#121728] px-2 py-2',


### PR DESCRIPTION
### Description

다가오는 NPC 대회에서 아직 'run' 기능을 제공하기엔 안정화가 되지 않았기 때문에 대회에서만 run 기능을 숨겨둡니다.

| Contest | Non-contest |
|----------|---------------|
| <img width="396" alt="image" src="https://github.com/user-attachments/assets/091ae19f-2c03-4b9c-bd39-feacdd259a2d" /> | <img width="369" alt="image" src="https://github.com/user-attachments/assets/53f4cce9-f82a-4f30-8124-b1f7d36fb4f6" /> |


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
