### PR TITLE
fix(fe): fix switch toggle

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -259,7 +259,7 @@ export function EditorHeader({
       toast.success('Successfully submitted the code')
       storeCodeToLocalStorage(code)
       const submission: Submission = await res.json()
-      console.log('submission: ', submission)
+
       setSubmissionId(submission.id)
       if (contestId) {
         queryClient.invalidateQueries({

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -259,6 +259,7 @@ export function EditorHeader({
       toast.success('Successfully submitted the code')
       storeCodeToLocalStorage(code)
       const submission: Submission = await res.json()
+      console.log('submission: ', submission)
       setSubmissionId(submission.id)
       if (contestId) {
         queryClient.invalidateQueries({

--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/_components/LeaderboardUnfreezeSwitchDialog.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/_components/LeaderboardUnfreezeSwitchDialog.tsx
@@ -48,7 +48,7 @@ export function LeaderboardUnfreezeSwitchDialog({
       <DialogTrigger asChild>
         <Switch
           disabled={isUnfrozen}
-          checked={isUnfrozen}
+          checked={activated ? isUnfrozen : false}
           className={`h-[24px] w-[46px] aria-checked:bg-[#3581FA] ${!activated ? 'aria-[checked=false]:bg-[#C4C4C4]' : 'aria-[checked=false]:bg-[#80808014]'} `}
           thumbClassName="w-[18px] h-[18px] data-[state=checked]:translate-x-[22px] data-[state=unchecked]:translate-x-[2px]"
         />

--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/_components/LeaderboardUnfreezeSwitchDialog.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/_components/LeaderboardUnfreezeSwitchDialog.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Button } from '@/components/shadcn/button'
 import {
   Dialog,

--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
@@ -56,7 +56,7 @@ export default function ContestLeaderBoard() {
       setDisableLeaderboard(false)
     }
   }, [fetchedContest])
-
+  console.log('contest leaderboard: ', contestLeaderboard.getContestLeaderboard)
   const isUnfrozen = !contestLeaderboard.getContestLeaderboard.isFrozen
 
   const [problemSize, setProblemSize] = useState(0)

--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
@@ -56,7 +56,6 @@ export default function ContestLeaderBoard() {
       setDisableLeaderboard(false)
     }
   }, [fetchedContest])
-  console.log('contest leaderboard: ', contestLeaderboard.getContestLeaderboard)
   const isUnfrozen = !contestLeaderboard.getContestLeaderboard.isFrozen
 
   const [problemSize, setProblemSize] = useState(0)


### PR DESCRIPTION
### Description

- Situation
admin의 leaderboard 페이지에서 unfreeze leaderboard 스위치 토글이 비활성화( 콘테스트가 끝나기 전에는 unfreeze 기능을 사용할 필요가 없으므로 비활성화돼있음!!! ) 돼있을 때, 체크 쪽으로 되어 있었는데 그 모습은 자연스럽지 않아보였습니다. 그 이유로 unfreeze가 비활성화돼있는 동안 스위치가 켜지지 않는 쪽으로 수정하였습니다. 

- lmplementation

토글이 deactivated 상태에서 switch 기본값을 false로 주었습니다.

바꾸기 전

![스크린샷 2025-04-30 오후 10 26 02](https://github.com/user-attachments/assets/8176bb94-a98d-436f-8948-706636dc8fcd)

바꾼 후

![스크린샷 2025-04-30 오후 10 25 31](https://github.com/user-attachments/assets/819b5b95-06b9-449c-93f6-b8e5a33a0fc1)


closes TAS-1619

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
