### PR TITLE
feat(infra): add health check api in iris server

### DIFF
--- a/apps/infra/stage/server2/Caddyfile
+++ b/apps/infra/stage/server2/Caddyfile
@@ -90,6 +90,12 @@ stage.codedang.com {
 		import cors *.vercel.app
 	}
 
+	handle /health{
+		reverse_porxy 127.0.0,1:3404
+
+		import cors *.codedang.com
+	}
+
 	handle {
 		reverse_proxy https://coolify.codedang.com {
 			header_up Host coolify.codedang.com


### PR DESCRIPTION
### Description
현재 stage의 iris 서버의 health check를 status.codedang.com에서 확인할 수 없습니다.
go routine으로 api를 만들어 iris 서버에 http 요청을 통해 health check를 진행하려 합니다.

### Additional context
지난 PR에서 9999번 포트 사용이 중복되어 포트 번호를 변경하기로 했습니다.
또한 Caddy에서 handle 부분을 추가해 보았습니다.

---

### Before submitting the PR, please make sure you do the following

- [V] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [V] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [V] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [V] Ideally, include relevant tests that fail without this PR but pass with it.
