### PR TITLE
chore(be): get participation info to admin get contest

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -140,7 +140,13 @@ export class ContestService {
         },
         contestRecord: {
           select: {
-            userId: true
+            userId: true,
+            user: {
+              select: {
+                username: true,
+                email: true
+              }
+            }
           }
         }
       }

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -137,6 +137,11 @@ export class ContestService {
               }
             }
           }
+        },
+        contestRecord: {
+          select: {
+            userId: true
+          }
         }
       }
     })

--- a/collection/admin/Contest/Get Contest/Succeed.bru
+++ b/collection/admin/Contest/Get Contest/Succeed.bru
@@ -23,6 +23,10 @@ body:graphql {
       endTime
       contestRecord {
         userId
+        user {
+          username
+          email
+        }
       }
       userContest {
         userId

--- a/collection/admin/Contest/Get Contest/Succeed.bru
+++ b/collection/admin/Contest/Get Contest/Succeed.bru
@@ -21,6 +21,9 @@ body:graphql {
       freezeTime
       startTime
       endTime
+      contestRecord {
+        userId
+      }
       userContest {
         userId
         role
@@ -38,7 +41,7 @@ body:graphql {
 
 body:graphql:vars {
   {
-    "contestId": 20
+    "contestId": 1
   }
 }
 
@@ -49,7 +52,7 @@ assert {
 docs {
   ## Get Problem
   참가자수 정보를 포함한 Problem 정보를 가져옵니다.
-
+  
   ### Error Cases
   #### NOT_FOUND
   존재하는 contestId를 전달해야 합니다.


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
admin의 getContest api에 contest 참여자 정보 중 userId를 추가로 불러오도록 수정합니다.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
