### PR TITLE
feat(be): add createdBy in contest resolver

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.module.ts
+++ b/apps/backend/apps/admin/src/contest/contest.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common'
 import { RolesModule } from '@libs/auth'
 import { ProblemModule } from '@admin/problem/problem.module'
+import { UserModule } from '@admin/user/user.module'
 import { ContestResolver } from './contest.resolver'
 import { ContestService } from './contest.service'
 
 @Module({
-  imports: [RolesModule, ProblemModule],
+  imports: [RolesModule, ProblemModule, UserModule],
   providers: [ContestService, ContestResolver]
 })
 export class ContestModule {}

--- a/apps/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest.resolver.ts
@@ -1,5 +1,14 @@
-import { Args, Context, Int, Mutation, Query, Resolver } from '@nestjs/graphql'
-import { Contest, ContestProblem, UserContest } from '@generated'
+import {
+  Args,
+  Context,
+  Int,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver
+} from '@nestjs/graphql'
+import { Contest, ContestProblem, User, UserContest } from '@generated'
 import { ContestRole } from '@prisma/client'
 import {
   AuthenticatedRequest,
@@ -11,6 +20,7 @@ import {
   IDValidationPipe,
   RequiredIntPipe
 } from '@libs/pipe'
+import { UserService } from '@admin/user/user.service'
 import { ContestService } from './contest.service'
 import { ContestLeaderboard } from './model/contest-leaderboard.model'
 import { ContestSubmissionSummaryForUser } from './model/contest-submission-summary-for-user.model'
@@ -22,10 +32,13 @@ import { ContestsGroupedByStatus } from './model/contests-grouped-by-status.outp
 import { ProblemScoreInput } from './model/problem-score.input'
 import { UserContestScoreSummaryWithUserInfo } from './model/score-summary'
 
-@Resolver(() => Contest)
+@Resolver(() => ContestWithParticipants)
 @UseContestRolesGuard(ContestRole.Manager)
 export class ContestResolver {
-  constructor(private readonly contestService: ContestService) {}
+  constructor(
+    private readonly contestService: ContestService,
+    private readonly userService: UserService
+  ) {}
 
   @Query(() => [ContestWithParticipants])
   @UseDisableContestRolesGuard()
@@ -179,5 +192,14 @@ export class ContestResolver {
   @UseDisableContestRolesGuard()
   async getContestRoles(@Context('req') req: AuthenticatedRequest) {
     return await this.contestService.getContestRoles(req.user.id)
+  }
+
+  @ResolveField('createdBy', () => User, { nullable: true })
+  async getUser(@Parent() contest: Contest) {
+    const { createdById } = contest
+    if (createdById == null) {
+      return null
+    }
+    return await this.userService.getUser(createdById)
   }
 }

--- a/collection/admin/Contest/Get Contests/Succeed.bru
+++ b/collection/admin/Contest/Get Contests/Succeed.bru
@@ -22,6 +22,9 @@ body:graphql {
       startTime
       endTime
       participants
+      createdBy {
+        username
+      }
     }
   }
 }

--- a/collection/admin/Notice/Get Notices/Succeed.bru
+++ b/collection/admin/Notice/Get Notices/Succeed.bru
@@ -17,6 +17,10 @@ body:graphql {
       content
       title
       createTime
+      createdBy {
+        id
+        username
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

Admin Get contest 시 생성자에 대한 정보(createdBy)가 return되지 않고 있습니다.
resolve field를 사용하여 이를 해결합니다.

### Additional context

- n+1 문제가 발생합니다.
다음의 PR에서 해결 완료 후 머지될 때 같이 반영하겠습니다
https://github.com/skkuding/codedang/pull/2682

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
