### PR TITLE
fix(be): fix module resolution error in macos

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -96,7 +96,6 @@
     "@swc/cli": "^0.5.2",
     "@swc/core": "^1.10.4",
     "@types/archiver": "^6.0.3",
-    "@types/cache-manager": "^5.0.0",
     "@types/chai": "^4.3.20",
     "@types/chai-as-promised": "^7.1.8",
     "@types/express": "^5.0.0",

--- a/apps/backend/webpack.config.js
+++ b/apps/backend/webpack.config.js
@@ -3,6 +3,19 @@ const swcDefaultConfig =
     .swcOptions
 
 module.exports = {
+  // Somehow loading native binaries(*.node) in MacOS ARM64 is not working
+  // so let's use workaround to load them manually
+  externals: {
+    argon2: 'require("argon2")',
+    '@apollo/gateway': 'require("@apollo/gateway")',
+    '@apollo/subgraph': 'require("@apollo/subgraph")',
+    '@apollo/subgraph/package.json': 'require("@apollo/subgraph/package.json")',
+    '@apollo/subgraph/dist/directives':
+      'require("@apollo/subgraph/dist/directives")',
+    '@as-integrations/fastify': 'require("@as-integrations/fastify")',
+    '@css-inline/css-inline-darwin-arm64':
+      'require("@css-inline/css-inline-darwin-arm64")'
+  },
   module: {
     rules: [
       {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     cgroup: host
 
   local-storage:
-    profiles: ['devcontainer']
+    profiles: ['dev']
     container_name: codedang-local-storage
     image: minio/minio
     ports:
@@ -51,6 +51,7 @@ services:
       - codedang-storage:/data
 
   database:
+    profiles: ['dev', 'deploy']
     container_name: codedang-database
     image: postgres:16-alpine
     ports:
@@ -63,6 +64,7 @@ services:
       - codedang-database:/var/lib/postgresql/data
 
   test-database:
+    profiles: ['dev']
     container_name: codedang-test-database
     image: postgres:16-alpine
     ports:
@@ -75,12 +77,14 @@ services:
       - codedang-test-database:/var/lib/postgresql/data
 
   cache:
+    profiles: ['dev', 'deploy']
     container_name: codedang-cache
     image: redis:7-alpine
     ports:
       - 6380:6379
 
   rabbitmq:
+    profiles: ['dev', 'deploy']
     image: rabbitmq:4-management-alpine
     container_name: codedang-rabbitmq
     ports:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,9 +300,6 @@ importers:
       '@types/archiver':
         specifier: ^6.0.3
         version: 6.0.3
-      '@types/cache-manager':
-        specifier: ^5.0.0
-        version: 5.0.0
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
@@ -4951,10 +4948,6 @@ packages:
 
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
-
-  '@types/cache-manager@5.0.0':
-    resolution: {integrity: sha512-YaQBBhn2OIShxGMH7l1qzGgXCQJ2TRYTqMhFMXRBkDcXQIlqXv+XFkBGstwXSyv7q+JQm3HbpVhaVF8l5tr+Hg==}
-    deprecated: This is a stub types definition. cache-manager provides its own type definitions, so you do not need this installed.
 
   '@types/chai-as-promised@7.1.8':
     resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
@@ -16804,10 +16797,6 @@ snapshots:
   '@types/busboy@1.5.4':
     dependencies:
       '@types/node': 22.15.3
-
-  '@types/cache-manager@5.0.0':
-    dependencies:
-      cache-manager: 5.7.6
 
   '@types/chai-as-promised@7.1.8':
     dependencies:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+if [ -z "$DEVCONTAINER" ]
+then
+  docker compose --profile=dev up -d
+fi
+
 # Check requirements: npm
 if [ ! $(command -v npm) ]
 then


### PR DESCRIPTION
### Description

MacOS 환경에서 백엔드 서버 실행을 위해 `pnpm start`를 입력했을 때 아래처럼 출력됩니다
(devcontainer 안에서는 정상적으로 동작, 컨테이너 밖에서 실행했을 때만 에러 발생)

```
❯ pnpm start

> @codedang/backend@ start /Users/dotol/Workspace/codedang/apps/backend
> nest start

ERROR in ../../node_modules/@css-inline/css-inline-darwin-arm64/css-inline.darwin-arm64.node 1:0
Module parse failed: Unexpected character '�' (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)
 @ ../../node_modules/@css-inline/css-inline/index.js 141:28-74
 @ ../../node_modules/@nestjs-modules/mailer/dist/adapters/handlebars.adapter.js 7:21-54
 @ ./apps/client/src/email/mailerConfig.service.ts 11:27-93
 @ ./apps/client/src/app.module.ts 30:29-68
 @ ./apps/client/src/main.ts 10:19-42

ERROR in ../../node_modules/@nestjs/apollo/dist/drivers/apollo-base.driver.js 101:155-190
Module not found: Error: Can't resolve '@as-integrations/fastify' in '/Users/dotol/Workspace/codedang/node_modules/@nestjs/apollo/dist/drivers'
 @ ../../node_modules/@nestjs/apollo/dist/drivers/apollo-federation.driver.js 10:29-60
 @ ../../node_modules/@nestjs/apollo/dist/drivers/index.js 4:21-58
 @ ../../node_modules/@nestjs/apollo/dist/index.js 5:21-41
 @ ./libs/logger/src/apollo-plugin.logger.ts 11:16-41
 @ ./libs/logger/src/index.ts 6:13-46
 @ ./apps/client/src/app.module.ts 21:16-39
 @ ./apps/client/src/main.ts 10:19-42

...
```

정확한 원인은 찾지 못했지만 webpack의 module resolution이 올바르게 이뤄지지 않습니다.
webpack의 `externals` 옵션을 이용해 오류가 발생하는 특정 모듈들을 따로 resolution하도록 설정합니다.

> [!Note]
> 앞으로 devcontainer를 사용하지 않아도 `setup.sh` 실행 후 백엔드 서버 사용 가능합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
