### PR TITLE
feat(be): add feature to stop(cancel) judging once submission not accepted on a testcase

### DIFF
--- a/apps/backend/apps/client/src/submission/class/judge-request.ts
+++ b/apps/backend/apps/client/src/submission/class/judge-request.ts
@@ -9,17 +9,20 @@ export class JudgeRequest {
   timeLimit: number
   memoryLimit: number
   judgeMode: string
+  stopOnNotAccepted: boolean
 
   constructor(
     code: Snippet[],
     language: Language,
-    problem: { id: number; timeLimit: number; memoryLimit: number }
+    problem: { id: number; timeLimit: number; memoryLimit: number },
+    stopOnNotAccepted = false
   ) {
     this.code = code.map((snippet) => snippet.text).join('\n')
     this.language = language
     this.problemId = problem.id
     this.timeLimit = calculateTimeLimit(language, problem.timeLimit)
     this.memoryLimit = calculateMemoryLimit(language, problem.memoryLimit)
+    this.stopOnNotAccepted = stopOnNotAccepted
   }
 }
 
@@ -35,9 +38,10 @@ export class UserTestcaseJudgeRequest extends JudgeRequest {
     code: Snippet[],
     language: Language,
     problem: { id: number; timeLimit: number; memoryLimit: number },
-    userTestcases: { id: number; in: string; out: string }[]
+    userTestcases: { id: number; in: string; out: string }[],
+    stopOnNotAccepted = false
   ) {
-    super(code, language, problem)
+    super(code, language, problem, stopOnNotAccepted)
     this.userTestcases = userTestcases.map((tc) => {
       return { ...tc, hidden: false }
     })

--- a/apps/backend/apps/client/src/submission/class/judger-response.dto.ts
+++ b/apps/backend/apps/client/src/submission/class/judger-response.dto.ts
@@ -20,7 +20,7 @@ class JudgeResult {
 }
 
 export class JudgerResponse {
-  @Max(9)
+  @Max(10)
   @Min(0)
   @IsNotEmpty()
   resultCode: number

--- a/apps/backend/apps/client/src/submission/submission-pub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-pub.service.ts
@@ -34,24 +34,34 @@ export class SubmissionPublicationService {
    * 2. `isUserTest` 플래그에 따라 다음 중 하나의 채점 요청 객체를 생성
    *    - 사용자 테스트인 경우: `UserTestcaseJudgeRequest` 객체를 생성하며, 사용자 정의 테스트케이스를 포함
    *    - 아닌 경우: 일반 채점 요청인 `JudgeRequest` 객체를 생성
-   * 3. AMQP 프로토콜을 사용하여 지정된 EXCHANGE와 라우팅 키(SUBMISSION_KEY)를 통해
+   * 3. AMQP 프로토콜을 사용하여 지정된 EXCHANGE와 라우팅 키(SUBMISSION_KEY)를 통해 채점 요청 메시지를 발행
    *
-   * @param {Snippet[]} code - 제출한 코드 스니펫 배열
-   * @param {Submission} submission - 생성된 제출 기록
-   * @param {boolean} [isTest=false] - 공개 테스트 케이스 채점 여부 (기본값=false)
-   * @param {boolean} [isUserTest=false] - 사용자 정의 테스트 케이스 채점 여부 (기본값=false)
-   * @param {{ id: number; in: string; out: string }[]} [userTestcases] - 사용자 정의 테스트 케이스 배열
+   * @param {Object} params - 채점 요청 파라미터
+   * @param {Snippet[]} params.code - 제출한 코드 스니펫 배열
+   * @param {Submission | TestSubmission} params.submission - 생성된 제출 기록
+   * @param {boolean} [params.isTest=false] - 공개 테스트 케이스 채점 여부 (기본값=false)
+   * @param {boolean} [params.isUserTest=false] - 사용자 정의 테스트 케이스 채점 여부 (기본값=false)
+   * @param {{ id: number; in: string; out: string }[]} [params.userTestcases] - 사용자 정의 테스트 케이스 배열
+   * @param {boolean} [params.stopOnNotAccepted=false] - 테스트 케이스 실패 시 중단 여부 (기본값=false)
    * @returns {Promise<void>}
    * @throws {EntityNotExistException} 제출 기록에 해당하는 문제를 찾을 수 없는 경우
    */
   @Span()
-  async publishJudgeRequestMessage(
-    code: Snippet[],
-    submission: Submission | TestSubmission,
+  async publishJudgeRequestMessage({
+    code,
+    submission,
     isTest = false,
     isUserTest = false,
+    userTestcases,
+    stopOnNotAccepted = false
+  }: {
+    code: Snippet[]
+    submission: Submission | TestSubmission
+    isTest?: boolean
+    isUserTest?: boolean
     userTestcases?: { id: number; in: string; out: string }[]
-  ): Promise<void> {
+    stopOnNotAccepted?: boolean
+  }): Promise<void> {
     const problem = await this.prisma.problem.findUnique({
       where: { id: submission.problemId },
       select: {
@@ -70,9 +80,10 @@ export class SubmissionPublicationService {
           code,
           submission.language,
           problem,
-          userTestcases!
+          userTestcases!,
+          stopOnNotAccepted
         )
-      : new JudgeRequest(code, submission.language, problem)
+      : new JudgeRequest(code, submission.language, problem, stopOnNotAccepted)
 
     const span = this.traceService.startSpan(
       'publishJudgeRequestMessage.publish'

--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -348,7 +348,8 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       ? ResultStatus.Accepted
       : (submission.submissionResult.find(
           (submissionResult) =>
-            submissionResult.result !== ResultStatus.Accepted
+            submissionResult.result !== ResultStatus.Accepted &&
+            submissionResult.result !== ResultStatus.Canceled
         )?.result ?? ResultStatus.ServerError)
 
     await this.prisma.submission.update({

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -214,7 +214,8 @@ export class SubmissionService {
       userIp,
       idOptions: {
         contestId
-      }
+      },
+      stopOnNotAccepted: true
     })
 
     return submission
@@ -452,7 +453,8 @@ export class SubmissionService {
     problem,
     userId,
     userIp,
-    idOptions
+    idOptions,
+    stopOnNotAccepted = false
   }: {
     submissionDto: CreateSubmissionDto
     problem: Problem
@@ -463,6 +465,7 @@ export class SubmissionService {
       assignmentId?: number
       workbookId?: number
     }
+    stopOnNotAccepted?: boolean
   }) {
     if (!problem.languages.includes(submissionDto.language)) {
       throw new ConflictFoundException(
@@ -502,7 +505,11 @@ export class SubmissionService {
 
       await this.createSubmissionResults(submission)
 
-      await this.publish.publishJudgeRequestMessage(code, submission)
+      await this.publish.publishJudgeRequestMessage({
+        code,
+        submission,
+        stopOnNotAccepted
+      })
       return submission
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -722,7 +729,13 @@ export class SubmissionService {
     }
 
     await this.cacheManager.set(testcasesKey(testSubmission.id), testcaseIds)
-    await this.publish.publishJudgeRequestMessage(code, testSubmission, true)
+
+    await this.publish.publishJudgeRequestMessage({
+      code,
+      submission: testSubmission,
+      isTest: true,
+      stopOnNotAccepted: false
+    })
   }
 
   /**
@@ -746,27 +759,32 @@ export class SubmissionService {
     testSubmission: TestSubmission,
     userTestcases: { id: number; in: string; out: string }[]
   ): Promise<void> {
-    const testcaseIds: number[] = []
-    for (const testcase of userTestcases) {
-      await this.cacheManager.set(
-        userTestKey(testSubmission.id, testcase.id),
-        { id: testcase.id, result: 'Judging' },
-        TEST_SUBMISSION_EXPIRE_TIME
-      )
-      testcaseIds.push(testcase.id)
-    }
+    const testcaseIds = userTestcases.map((tc) => tc.id)
 
     await this.cacheManager.set(
       userTestcasesKey(testSubmission.id),
-      testcaseIds
+      testcaseIds,
+      TEST_SUBMISSION_EXPIRE_TIME
     )
-    await this.publish.publishJudgeRequestMessage(
+
+    for (const testcase of userTestcases) {
+      await this.cacheManager.set(
+        userTestKey(testSubmission.id, testcase.id),
+        {
+          id: testcase.id,
+          result: ResultStatus.Judging
+        },
+        TEST_SUBMISSION_EXPIRE_TIME
+      )
+    }
+
+    await this.publish.publishJudgeRequestMessage({
       code,
-      testSubmission,
-      false,
-      true,
-      userTestcases
-    )
+      submission: testSubmission,
+      isUserTest: true,
+      userTestcases,
+      stopOnNotAccepted: false
+    })
   }
 
   @Span()

--- a/apps/backend/apps/client/src/submission/test/submission-pub.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission-pub.service.spec.ts
@@ -86,7 +86,10 @@ describe('SubmissionPublicationService', () => {
       )
 
       await expect(
-        service.publishJudgeRequestMessage(submissions[0].code, submission)
+        service.publishJudgeRequestMessage({
+          code: submissions[0].code,
+          submission
+        })
       ).not.to.be.rejected
 
       expect(
@@ -128,11 +131,11 @@ describe('SubmissionPublicationService', () => {
       )
 
       await expect(
-        service.publishJudgeRequestMessage(
-          submissions[0].code,
+        service.publishJudgeRequestMessage({
+          code: submissions[0].code,
           submission,
-          true
-        )
+          isTest: true
+        })
       ).not.to.be.rejected
 
       expect(
@@ -162,7 +165,10 @@ describe('SubmissionPublicationService', () => {
       sandbox.stub(db.problem, 'findUnique').resolves(undefined)
 
       await expect(
-        service.publishJudgeRequestMessage(submissions[0].code, submission)
+        service.publishJudgeRequestMessage({
+          code: submissions[0].code,
+          submission
+        })
       ).to.be.rejectedWith(EntityNotExistException)
     })
   })

--- a/apps/backend/libs/constants/src/submission.constants.ts
+++ b/apps/backend/libs/constants/src/submission.constants.ts
@@ -41,6 +41,8 @@ export const Status = (code: number) => {
       return ResultStatus.ServerError
     case 8: // Segmentation Fault
       return ResultStatus.SegmentationFaultError
+    case 10: // Canceled
+      return ResultStatus.Canceled
     default:
       return ResultStatus.ServerError
   }

--- a/apps/backend/prisma/migrations/20250508115525_add_canceled_on_result_status_enum/migration.sql
+++ b/apps/backend/prisma/migrations/20250508115525_add_canceled_on_result_status_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ResultStatus" ADD VALUE 'Canceled';

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -668,6 +668,7 @@ enum ResultStatus {
   ServerError
   SegmentationFaultError
   Blind // isJudgeResultVisible == False로 설정된 Assignment/Contest의 채점 결과를 반환할 때 사용
+  Canceled // isStopOnNotAccepted == True일 때 앞선 테스트케이스가 Not Accepted인 경우 이후 테스트케이스 실행 취소
 }
 
 model TestSubmission {

--- a/apps/iris/src/handler/errors.go
+++ b/apps/iris/src/handler/errors.go
@@ -52,4 +52,5 @@ var (
 	ErrMemoryLimitExceed   = errors.New("memory limit exceeded")
 	ErrRuntime             = errors.New("runtime error")
 	ErrSegFault            = errors.New("segmentation fault")
+	ErrCanceled            = errors.New("execution canceled")
 )

--- a/apps/iris/src/handler/interface.go
+++ b/apps/iris/src/handler/interface.go
@@ -42,6 +42,8 @@ func resultCodeToError(code ResultCode) error {
 		return err.Wrap(ErrRuntime)
 	case SEGMENTATION_FAULT_ERROR:
 		return err.Wrap(ErrSegFault)
+	case CANCELED:
+		return err.Wrap(ErrCanceled)
 	}
 	return &HandlerError{caller: caller, err: ErrSandbox, level: logger.ERROR}
 }

--- a/apps/iris/src/handler/resultCode.go
+++ b/apps/iris/src/handler/resultCode.go
@@ -15,6 +15,7 @@ const (
 	TESTCASE_ERROR
 	SEGMENTATION_FAULT_ERROR
 	SERVER_ERROR
+	CANCELED
 )
 
 func SandboxStatusCodeToJudgeResultCode(status sandbox.StatusCode) ResultCode {

--- a/apps/iris/src/router/response.go
+++ b/apps/iris/src/router/response.go
@@ -85,5 +85,8 @@ func ErrorToResultCode(err error) handler.ResultCode {
 	if errors.Is(err, handler.ErrSegFault) {
 		return handler.SEGMENTATION_FAULT_ERROR
 	}
+	if errors.Is(err, handler.ErrCanceled) {
+		return handler.CANCELED
+	}
 	return handler.SERVER_ERROR
 }


### PR DESCRIPTION
### Description
현재 구현으로 사용자가 코드를 제출할 경우 채점 서버는 해당 제출에 대해 모든 테스트케이스를 채점을 하려고 시도합니다. 
강의에서는 중간에 틀린 TC가 있더라도 점수를 계산하기 위해서는 모든 TC를 계산하는 것이 맞았기 때문에 그렇게 진행했었습니다. 

하지만, 대회의 경우에는 다음 두 가지 특성으로 인해, 하나의 TC라도 틀리면 그 이후에는 채점을 안하는 것이 좋다고 판단됩니다.
- 테스트케이스가 굉장히 많고 제출도 많아 로드를 최대한 줄이는 것이 중요하다.
- 대회는 ICPC Rule을 따르기 때문에, 하나의 TC라도 틀리면 문제가 틀린 것이 되기 때문에 모든 테스트케이스를 돌려볼 필요가 없다.

이에 따라, 이 PR에서는,

1. IRIS (채점 서버)에 `StopOnNotAccepted` 기능을 구현합니다. `StopOnNotAccepted` 기능이 활성화된 채점 요청은, 테스트케이스 중 하나라도 `Accepted`가 아니면 나머지 테스트케이스는 실제로 실행하지 않고 `CANCELED` 상태로 처리합니다.

- 이전 테스트케이스가 실패한 경우 이후 테스트케이스를 취소하는 로직 구현
- 취소된 테스트케이스 처리 로직을 sendCancelResults 함수로 분리

2. 백엔드에서는 대회에서만 `StopOnNotAccepted = true` 옵션을 주어 채점 요청을 보내도록 하였고, 그 외의 요청은 default(StopOnNotAccepted = False`로 처리합니다. 

### Test Result
테스트 결과 Canceled가 잘 작동합니다.

테스트 과정:

1. TC 4개 가진 문제 생성 -> 대회 생성 후 문제 import 
- 문제 Capture: 
<img width="2217" alt="image" src="https://github.com/user-attachments/assets/9bf5c505-5b8b-4c31-9f9c-2a2ad1e7f1b3" />

2. 첫번째 TC는 AC / 두번째 TC는 WA가 되도록 코드 제출
- 제출 Capture:
<img width="2217" alt="image" src="https://github.com/user-attachments/assets/1c2c9808-2d7c-4ac1-bb60-00eae46ffa30" />

3. 로그 및 채점 결과 확인

- 채점 결과: 첫번째 TC - AC / 두번째 TC - WA / 세번째, 네번째 TC - Canceled
<img width="2217" alt="image" src="https://github.com/user-attachments/assets/b7dd8988-55df-4d4d-a737-212d9f111a9b" />

- iris log: 
```
2025-05-08T17:30:52.360Z        DEBUG   judger/runner.go:40     sandbox result: {
    "cpu_time": 1,
    "real_time": 27,
    "memory": 307200,
    "signal": 0,
    "exit_code": 0,
    "error": 0,
    "result": 0
}
2025-05-08T17:30:52.361Z        INFO    rabbitmq/connector.go:99        publishing 184B body
2025-05-08T17:30:52.361Z        INFO    rabbitmq/connector.go:99        {"submissionId":15,"resultCode":0,"judgeResult":{"testcaseId":61,"output":"5\n","cpuTime":1,"realTime":27,"memory":307200,"signal":0,"exitCode":0,"errorCode":0,"error":""},"error":""}

2025-05-08T17:30:52.361Z        DEBUG   rabbitmq/connector.go:99        published 184B OK
2025-05-08T17:30:52.361Z        DEBUG   runtime/asm_arm64.s:1223        result published: {"submissionId":15,"resultCode":0,"judgeResult":{"testcaseId":61,"output":"5\n","cpuTime":1,"realTime":27,"memory":307200,"signal":0,"exitCode":0,"errorCode":0,"error":""},"error":""}

2025-05-08T17:30:52.365Z        DEBUG   runtime/asm_arm64.s:1223        tag : 9
2025-05-08T17:30:52.365Z        DEBUG   runtime/asm_arm64.s:1223        confirmed delivery with delivery tag: 9
2025-05-08T17:30:52.366Z        DEBUG   judger/runner.go:40     sandbox result: {
    "cpu_time": 0,
    "real_time": 2,
    "memory": 307200,
    "signal": 0,
    "exit_code": 0,
    "error": 0,
    "result": 0
}
2025-05-08T17:30:52.366Z        INFO    router/router.go:53     parse error: wrong answer
2025-05-08T17:30:52.366Z        INFO    router/router.go:53     parse error: execution canceled
2025-05-08T17:30:52.366Z        INFO    rabbitmq/connector.go:99        publishing 183B body
2025-05-08T17:30:52.366Z        INFO    rabbitmq/connector.go:99        {"submissionId":15,"resultCode":1,"judgeResult":{"testcaseId":62,"output":"5\n","cpuTime":0,"realTime":2,"memory":307200,"signal":0,"exitCode":0,"errorCode":0,"error":""},"error":""}

2025-05-08T17:30:52.367Z        DEBUG   rabbitmq/connector.go:99        published 183B OK
2025-05-08T17:30:52.367Z        DEBUG   runtime/asm_arm64.s:1223        result published: {"submissionId":15,"resultCode":1,"judgeResult":{"testcaseId":62,"output":"5\n","cpuTime":0,"realTime":2,"memory":307200,"signal":0,"exitCode":0,"errorCode":0,"error":""},"error":""}

2025-05-08T17:30:52.367Z        INFO    rabbitmq/connector.go:99        publishing 229B body
2025-05-08T17:30:52.367Z        INFO    rabbitmq/connector.go:99        {"submissionId":15,"resultCode":10,"judgeResult":{"testcaseId":63,"output":"","cpuTime":0,"realTime":0,"memory":0,"signal":0,"exitCode":0,"errorCode":10,"error":"Execution canceled due to previous test case failure"},"error":""}

2025-05-08T17:30:52.367Z        DEBUG   rabbitmq/connector.go:99        published 229B OK
2025-05-08T17:30:52.367Z        DEBUG   runtime/asm_arm64.s:1223        result published: {"submissionId":15,"resultCode":10,"judgeResult":{"testcaseId":63,"output":"","cpuTime":0,"realTime":0,"memory":0,"signal":0,"exitCode":0,"errorCode":10,"error":"Execution canceled due to previous test case failure"},"error":""}

2025-05-08T17:30:52.367Z        INFO    router/router.go:53     parse error: execution canceled
2025-05-08T17:30:52.367Z        INFO    rabbitmq/connector.go:99        publishing 229B body
2025-05-08T17:30:52.367Z        INFO    rabbitmq/connector.go:99        {"submissionId":15,"resultCode":10,"judgeResult":{"testcaseId":64,"output":"","cpuTime":0,"realTime":0,"memory":0,"signal":0,"exitCode":0,"errorCode":10,"error":"Execution canceled due to previous test case failure"},"error":""}

2025-05-08T17:30:52.367Z        DEBUG   rabbitmq/connector.go:99        published 229B OK
2025-05-08T17:30:52.367Z        DEBUG   runtime/asm_arm64.s:1223        result published: {"submissionId":15,"resultCode":10,"judgeResult":{"testcaseId":64,"output":"","cpuTime":0,"realTime":0,"memory":0,"signal":0,"exitCode":0,"errorCode":10,"error":"Execution canceled due to previous test case failure"},"error":""}

2025-05-08T17:30:52.367Z        DEBUG   handler/judge-handler.go:262    task BzsfJxUAutaojiVO15 done: total time: 116.034542ms
2025-05-08T17:30:52.367Z        DEBUG   runtime/asm_arm64.s:1223        Router done...
2025-05-08T17:30:52.367Z        DEBUG   runtime/asm_arm64.s:1223        message ack
2025-05-08T17:30:52.368Z        DEBUG   runtime/asm_arm64.s:1223        tag : 10
2025-05-08T17:30:52.368Z        DEBUG   runtime/asm_arm64.s:1223        confirmed delivery with delivery tag: 10
2025-05-08T17:30:52.369Z        DEBUG   runtime/asm_arm64.s:1223        tag : 11
2025-05-08T17:30:52.369Z        DEBUG   runtime/asm_arm64.s:1223        confirmed delivery with delivery tag: 11
2025-05-08T17:30:52.369Z        DEBUG   runtime/asm_arm64.s:1223        tag : 12
2025-05-08T17:30:52.369Z        DEBUG   runtime/asm_arm64.s:1223        confirmed delivery with delivery tag: 12
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
