### PR TITLE
feat(fe): add refresh button on submission tab

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -34,6 +34,7 @@ import { EditorHeader } from './EditorHeader/EditorHeader'
 import { LeaderboardModalDialog } from './LeaderboardModalDialog'
 import { TestcasePanel } from './TestcasePanel/TestcasePanel'
 import { useLeaderboardSync } from './context/ReFetchingLeaderboardStoreProvider'
+import { useSubmissionSync } from './context/ReFetchingSubmissionStoreProvider'
 import { TestPollingStoreProvider } from './context/TestPollingStoreProvider'
 import { TestcaseStoreProvider } from './context/TestcaseStoreProvider'
 
@@ -93,6 +94,9 @@ export function EditorMainResizablePanel({
     setIsBottomPanelHidden((prev) => !prev)
   }
   const triggerRefresh = useLeaderboardSync((state) => state.triggerRefresh)
+  const triggerSubmissionRefresh = useSubmissionSync(
+    (state) => state.triggerRefresh
+  )
   const {
     isSidePanelHidden,
     toggleSidePanelVisibility
@@ -188,7 +192,7 @@ export function EditorMainResizablePanel({
                 )}
               </TabsList>
             </Tabs>
-            {tabValue === 'Leaderboard' ? (
+            {tabValue === 'Leaderboard' && (
               <div className="flex gap-x-4">
                 <LeaderboardModalDialog />
                 <TooltipProvider>
@@ -221,7 +225,19 @@ export function EditorMainResizablePanel({
                   </Tooltip>
                 </TooltipProvider>
               </div>
-            ) : null}
+            )}
+            {tabValue === 'Submission' && contestId && (
+              <div className="flex gap-x-4">
+                <Image
+                  src={syncIcon}
+                  alt="Sync"
+                  className={'cursor-pointer'}
+                  onClick={() => {
+                    triggerSubmissionRefresh()
+                  }}
+                />
+              </div>
+            )}
           </div>
           <ScrollArea className="[&>div>div]:!block">
             <Suspense fallback={<Loading />}>{children}</Suspense>

--- a/apps/frontend/app/(client)/(code-editor)/_components/context/ReFetchingSubmissionStoreProvider.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/context/ReFetchingSubmissionStoreProvider.tsx
@@ -1,0 +1,12 @@
+import { create } from 'zustand'
+
+interface SubmissionSync {
+  refreshTrigger: number
+  triggerRefresh: () => void
+}
+
+export const useSubmissionSync = create<SubmissionSync>((set) => ({
+  refreshTrigger: 0,
+  triggerRefresh: () =>
+    set((state) => ({ refreshTrigger: state.refreshTrigger + 1 }))
+}))

--- a/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/submission/_components/SubmissionPaginatedTable.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/submission/_components/SubmissionPaginatedTable.tsx
@@ -4,6 +4,7 @@ import {
   SubmissionTable,
   SubmissionTableFallback
 } from '@/app/(client)/(code-editor)/_components/SubmissionTable'
+import { useSubmissionSync } from '@/app/(client)/(code-editor)/_components/context/ReFetchingSubmissionStoreProvider'
 import { getContestProblemList } from '@/app/(client)/_libs/apis/contestProblem'
 import { contestSubmissionQueries } from '@/app/(client)/_libs/queries/contestSubmission'
 import {
@@ -26,12 +27,12 @@ export function SubmissionPaginatedTable({
   problemId: number
   contestId: number
 }) {
+  const refreshTrigger = useSubmissionSync((state) => state.refreshTrigger)
   const [queryParams, updateQueryParams] = useState({
     take: getTakeQueryParam({ itemsPerPage })
   })
-
   const problemIdList = useSuspenseQuery({
-    queryKey: ['Contest Problem', contestId],
+    queryKey: ['Contest Problem', contestId, refreshTrigger],
     queryFn: async () => {
       const response = await getContestProblemList({
         contestId,


### PR DESCRIPTION
### Description

>[!Note]
> contest의 submission tab에 새로고침 버튼을 추가했습니다!

**왜?**

>[!Warning]
> submission이 leaderboard가 새로고침하는 것을 보고 부러움을 느꼈기 때문 ㅠㅠ

진짜 이유: Contest Submission에서 테스트케이스별로 채점 결과가 나오는데, 2초 간격으로 10번까지 결과를 가져온 이후에는 결과 업데이트가 안되어서, 하드 리프레쉬(Ctrl + R)를 해야만 결과가 다시 가져와 집니다.

그래서 Soft refresh가 가능하도록 하기 위해서 submission refresh 버튼을 추가!

---------------
구현은 leaderboard refresh와 마찬가지로 zustand를 이용해서 refreshTrigger 변수를 handling 하는 방식으로 했습니다. 

화면으로 보면 다음과 같습니다. 

<img width="516" alt="스크린샷 2025-05-09 오후 12 09 51" src="https://github.com/user-attachments/assets/ef741a8c-a54a-4dd6-a9d4-4b037fbd8649" />


closes TAS-1671

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
