### PR TITLE
feat(cd): add automatic year.number image tagging

### DIFF
--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -75,7 +75,43 @@ jobs:
   build-admin-api:
     name: Build admin-api image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Determine next image tag
+        id: tag
+        env:
+          OWNER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          year=$(date +%Y)
+
+          PKG="codedang-admin-api"
+
+          url="https://api.github.com/orgs/$OWNER/packages/container/$PKG/versions"
+
+          tags=$(curl -fsSL -H "Authorization: Bearer $TOKEN" "$url" \
+            |  jq -r '.[].metadata.container.tags[]' \
+            |  grep "^${year}\.[0-9]\+$" || true)
+
+          if [[-z "$tags"]]; then
+            next = "${year}.1"
+
+          else
+            max=$(echo "$tags" \
+              | sed -E "s/^${year}\.([0-9]+)$/\1/" \
+              | sort -n \
+              | tail -n 1)
+            next="${year}.$((max + 1))"
+          fi
+          echo "IMAGE_TAG=$next" >> "$GITHUB_ENV"
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -94,12 +130,48 @@ jobs:
           build-args: |
             target=admin
             app_env=stage
-          tags: ghcr.io/${{ github.repository_owner }}/codedang-admin-api:latest
+          tags: ghcr.io/${{ github.repository_owner }}/codedang-admin-api:${{env.IMAGE_TAG}}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
 
   build-iris:
     name: Build Iris docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Determine next image tag
+        id: tag
+        env:
+          OWNER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          year=$(date +%Y)
+
+          PKG="codedang-iris"
+
+          url="https://api.github.com/orgs/$OWNER/packages/container/$PKG/versions"
+
+          tags=$(curl -fsSL -H "Authorization: Bearer $TOKEN" "$url" \
+            |  jq -r '.[].metadata.container.tags[]' \
+            |  grep "^${year}\.[0-9]\+$" || true)
+
+          if [[-z "$tags"]]; then
+            next = "${year}.1"
+
+          else
+            max=$(echo "$tags" \
+              | sed -E "s/^${year}\.([0-9]+)$/\1/" \
+              | sort -n \
+              | tail -n 1)
+            next="${year}.$((max + 1))"
+          fi
+          echo "IMAGE_TAG=$next" >> "$GITHUB_ENV"
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -117,7 +189,9 @@ jobs:
           context: '{{defaultContext}}:apps/iris'
           build-args: |
             app_env=stage
-          tags: ghcr.io/${{ github.repository_owner }}/codedang-iris:latest
+          tags: ghcr.io/${{ github.repository_owner }}/codedang-iris:${{env.IMAGE_TAG}}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
 
   run-server:
     name: Run stage server

--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -13,7 +13,43 @@ jobs:
   build-client-api:
     name: Build client-api image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Determine next image tag
+        id: tag
+        env:
+          OWNER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          year = $(date +%Y)
+
+          PKG = "codedang-client-api"
+
+          url ="https://api.github.com/orgs/$OWNER/packages/container/$PKG/versions"
+
+          tags=$(curl -fsSL -H "Authorization: Bearer $TOKEN" "$url" \
+            |  jq -r '.[].metadata.container.tags[]' \
+            |  grep "^${year}\.[0-9]\+$" || true)
+
+          if [[-z "$tags"]]; then
+            next = "${year}.1"
+
+          else
+            max=$(echo "$tags" \
+              | sed -E "s/^${year}\.([0-9]+)$/\1/" \
+              | sort -n \
+              | tail -n 1)
+            next = "${year}.$((max + 1))"
+          fi
+          echo "IMAGE_TAG=$next" >> "$GITHUB_ENV"
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -32,7 +68,9 @@ jobs:
           build-args: |
             target=client
             app_env=stage
-          tags: ghcr.io/${{ github.repository_owner }}/codedang-client-api:latest
+          tags: ghcr.io/${{ github.repository_owner }}/codedang-client-api:${{env.IMAGE_TAG}}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
 
   build-admin-api:
     name: Build admin-api image

--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -28,11 +28,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          year = $(date +%Y)
+          year=$(date +%Y)
 
-          PKG = "codedang-client-api"
+          PKG="codedang-client-api"
 
-          url ="https://api.github.com/orgs/$OWNER/packages/container/$PKG/versions"
+          url="https://api.github.com/orgs/$OWNER/packages/container/$PKG/versions"
 
           tags=$(curl -fsSL -H "Authorization: Bearer $TOKEN" "$url" \
             |  jq -r '.[].metadata.container.tags[]' \
@@ -46,7 +46,7 @@ jobs:
               | sed -E "s/^${year}\.([0-9]+)$/\1/" \
               | sort -n \
               | tail -n 1)
-            next = "${year}.$((max + 1))"
+            next="${year}.$((max + 1))"
           fi
           echo "IMAGE_TAG=$next" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
### Description

이 PR은 Github Actions CD 파이프라인을('cd - stage.yml')을 다음과 같이 개선합니다. 

1. 자동 버저닝
    - 현재 연도(`date + %Y`) 기반으로 이미 등록된 동일 연도 태그 목록에서 최대 숫자 +1을 계산해 `IMAGE_TAG 환경 변수에 저장
    
2. Git 커밋 해시 라벨 추가
     - docker/build-push-action 실행 시 `labels: org.opencontainers.image.revision=${{ github.sha }}`를 통해 해당 이미지가 어떤 커밋에서 빌드됐는지 추적 가능하도록 설정.

 

### Additional context

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
