### PR TITLE
fix(fe): set dueTime to be equal to endTime temporarily

### DIFF
--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/edit/_components/EditAssignmentForm.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/edit/_components/EditAssignmentForm.tsx
@@ -181,12 +181,19 @@ export function EditAssignmentForm({
 
   const proceedSubmit = async () => {
     const input = methods.getValues()
+
+    // NOTE: 임시로 dueTime을 endTime과 동일하게 설정
+    const finalInput = {
+      ...input,
+      dueTime: input.endTime
+    }
+
     setIsLoading(true)
 
     await updateAssignment({
       variables: {
         groupId: courseId,
-        input
+        input: finalInput
       }
     })
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/_libs/schemas.ts
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/_libs/schemas.ts
@@ -12,6 +12,7 @@ export const createSchema = v.object({
   description: v.string(),
   startTime: v.optional(v.date()),
   endTime: v.optional(v.date()),
+  dueTime: v.optional(v.date()),
   week: v.number(),
   enableCopyPaste: v.boolean(),
   isJudgeResultVisible: v.boolean(),

--- a/apps/frontend/app/admin/course/[courseId]/assignment/create/_components/CreateAssignmentForm.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/create/_components/CreateAssignmentForm.tsx
@@ -73,10 +73,12 @@ export function CreateAssignmentForm({
     const input = methods.getValues()
     setIsCreating(true)
 
+    // NOTE: 임시로 dueTime을 endTime과 동일하게 설정
     const finalInput = {
       ...input,
       startTime: input.startTime ?? new Date(0),
-      endTime: input.endTime ?? new Date('2999-12-31T23:59:59')
+      endTime: input.endTime ?? new Date('2999-12-31T23:59:59'),
+      dueTime: input.endTime ?? new Date('2999-12-31T23:59:59')
     }
 
     const { data } = await createAssignment({


### PR DESCRIPTION
### Description
gql 스키마 충돌을 피하기 위해 
`createAssignment` 와 `updateAssignment` 2개의 mutation에서
`dueTime` 을 임시로 `endTime` 과 동일하게 설정했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Closes TAS-1703

### Additional context
> [!NOTE]
> 향후에는 dueTime을 인풋으로 받아 별도로 처리하도록 수정할 예정입니다.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
