### PR TITLE
feat(be): change editable items in ongoing contest

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.spec.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.spec.ts
@@ -200,11 +200,11 @@ const input = {
 } satisfies CreateContestInput
 
 const updateInput = {
-  title: 'test title10',
-  description: 'test description',
-  startTime: faker.date.past(),
   endTime: faker.date.future(),
-  enableCopyPaste: false
+  freezeTime: faker.date.between({
+    from: new Date(new Date().getTime()),
+    to: new Date(endTime.getTime())
+  })
 } satisfies UpdateContestInput
 
 const db = {

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -11,7 +11,7 @@ import {
 import { PrismaService } from '@libs/prisma'
 import type { ContestWithScores } from './model/contest-with-scores.model'
 import type { CreateContestInput } from './model/contest.input'
-import type { UpdateContestInput } from './model/contest.input'
+import { UpdateContestInput } from './model/contest.input'
 import type { ProblemScoreInput } from './model/problem-score.input'
 
 @Injectable()
@@ -301,6 +301,25 @@ export class ContestService {
       }
     })
 
+    const now = new Date()
+    const isOngoing =
+      now >= contestFound.startTime && now < contestFound.endTime
+
+    if (isOngoing) {
+      const allowedFields = UpdateContestInput.ongoingMutableFields
+      const modifiedFields = Object.keys(contest).filter(
+        (key) => contest[key] !== undefined
+      )
+      const disallowedFields = modifiedFields.filter(
+        (field) => !allowedFields.includes(field as keyof UpdateContestInput)
+      )
+      if (disallowedFields.length) {
+        throw new UnprocessableDataException(
+          `Only ${allowedFields.join(', ')} fields can be modified in ongoing contest`
+        )
+      }
+    }
+
     const isEndTimeChanged =
       contest.endTime && contest.endTime !== contestFound.endTime
     contest.startTime = contest.startTime || contestFound.startTime
@@ -323,13 +342,30 @@ export class ContestService {
     const isFreezeTimeChanged =
       contest.freezeTime && contest.freezeTime !== contestFound.freezeTime
     if (isFreezeTimeChanged) {
-      const now = new Date()
       if (contest.freezeTime && contest.freezeTime < now) {
         throw new UnprocessableDataException(
           'The freeze time must be later than the current time'
         )
       }
-      if (contestFound.freezeTime && contestFound.freezeTime < now) {
+      if (contest.freezeTime && contest.freezeTime > contest.endTime) {
+        throw new UnprocessableDataException(
+          'The freeze time must be earlier than the end time'
+        )
+      }
+      if (
+        contestFound.freezeTime &&
+        contest.freezeTime &&
+        contest.freezeTime <= contestFound.freezeTime
+      ) {
+        throw new UnprocessableDataException(
+          'The freeze time must be later than the previous freeze time'
+        )
+      }
+      if (
+        isOngoing &&
+        contestFound.freezeTime &&
+        contestFound.freezeTime < now
+      ) {
         throw new UnprocessableDataException(
           'Cannot change freeze time after the freeze time has passed already'
         )

--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -342,12 +342,12 @@ export class ContestService {
     const isFreezeTimeChanged =
       contest.freezeTime && contest.freezeTime !== contestFound.freezeTime
     if (isFreezeTimeChanged) {
-      if (contest.freezeTime && contest.freezeTime < now) {
+      if (contest.freezeTime && contest.freezeTime <= now) {
         throw new UnprocessableDataException(
           'The freeze time must be later than the current time'
         )
       }
-      if (contest.freezeTime && contest.freezeTime > contest.endTime) {
+      if (contest.freezeTime && contest.freezeTime >= contest.endTime) {
         throw new UnprocessableDataException(
           'The freeze time must be earlier than the end time'
         )
@@ -364,7 +364,7 @@ export class ContestService {
       if (
         isOngoing &&
         contestFound.freezeTime &&
-        contestFound.freezeTime < now
+        contestFound.freezeTime <= now
       ) {
         throw new UnprocessableDataException(
           'Cannot change freeze time after the freeze time has passed already'

--- a/apps/backend/apps/admin/src/contest/model/contest.input.ts
+++ b/apps/backend/apps/admin/src/contest/model/contest.input.ts
@@ -115,6 +115,12 @@ export class UpdateContestInput {
 
   @Field(() => GraphQLJSON, { nullable: true })
   summary?: Record<string, string>
+
+  // ongoing contest에서 수정 가능한 필드
+  static readonly ongoingMutableFields: (keyof UpdateContestInput)[] = [
+    'endTime',
+    'freezeTime'
+  ]
 }
 
 @InputType()

--- a/collection/admin/Contest/Update Contest/Succeed.bru
+++ b/collection/admin/Contest/Update Contest/Succeed.bru
@@ -60,7 +60,7 @@ body:graphql:vars {
       "penalty": 20,
       "lastPenalty": false,
       "posterUrl": null,
-      "freezeTime": "2030-01-01T00:00:00.000Z",
+      "freezeTime": "2028-01-01T00:00:00.000Z",
       "unfreeze": false,
       "evaluateWithSampleTestcase": false
     }

--- a/collection/admin/Contest/Update Contest/Succeed.bru
+++ b/collection/admin/Contest/Update Contest/Succeed.bru
@@ -37,7 +37,7 @@ body:graphql {
 
 body:graphql:vars {
   {
-    "contestId": 20,
+    "contestId": 19,
     "input": {
       "title": "Updated Contest 2",
       "description": "thisisupdatedcontest",
@@ -73,10 +73,10 @@ assert {
 
 docs {
   # Update Contest
-
+  
   ## Description
   기존 콘테스트 정보를 업데이트합니다. 콘테스트 관리 권한이 있는 사용자만 사용할 수 있으며, 유효한 입력값이 필요합니다.
-
+  
   ## 요청 필드
   | 필드명 | 타입 | 필수 여부 | 설명 |
   |--------|------|----------|------|
@@ -96,7 +96,7 @@ docs {
   | evaluateWithSampleTestcase | Boolean | ❌ | 샘플 테스트케이스로 평가 여부 |
   | userContest | [UserContestRoleInput] | ❌ | Manager, Reviewer 역할 부여 및 수정 |
   | summary | GraphQLJSON | ❌ | 다국어 요약 정보 |
-
+  
   ## 응답 필드
   | 필드명 | 타입 | 설명 |
   |--------|------|------|
@@ -113,7 +113,7 @@ docs {
   | summary | GraphQLJSON | 다국어 요약 정보 |
   | userContest | [UserContestRole] | Manager, Reviewer 역할 목록 |
   | createdById | Int | 콘테스트 생성자 ID |
-
+  
   ## 권한
   - `Contest Manager`, `Contest Admin` 권한이 있는 사용자만 사용할 수 있습니다.
   - 권한이 없는 경우 `UnauthorizedException` 오류가 반환됩니다.

--- a/collection/admin/Contest/Update Contest/[ERR] Limited Modifiable Fields in Ongoing Contest.bru
+++ b/collection/admin/Contest/Update Contest/[ERR] Limited Modifiable Fields in Ongoing Contest.bru
@@ -1,7 +1,7 @@
 meta {
-  name: [422] End Time Earlier than Start Time
+  name: [ERR] Limited Modifiable Fields in Ongoing Contest
   type: graphql
-  seq: 2
+  seq: 4
 }
 
 post {
@@ -31,22 +31,16 @@ body:graphql {
 
 body:graphql:vars {
   {
-    "contestId": 15,
+    "contestId": 20,
     "input": {
       "title": "Updated Contest 2",
       "description": "thisisupdatedcontest",
-      "startTime": "2030-01-01",
-      "endTime": "2020-01-01",
+      "startTime": "2024-01-01",
+      "endTime": "2030-01-01",
       "enableCopyPaste": true,
       "isJudgeResultVisible": true,
       "invitationCode": "123456",
-      "summary": {
-        "참여대상": "updatedparticipationTarget",
-        "진행방식": "updatedcompetitionMethod",
-        "순위산정": "updatedrankingMethod",
-        "문제형태": "updatedproblemFormat",
-        "참여혜택": "updatedbenefits"
-      }
+      "freezeTime": "2029-01-01"
     }
   }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Contest가 진행중일 때(Ongoing) 수정 가능한 필드를 제한합니다.

 - Ongoing 상태에서는 End Time, Freeze Time만 수정 가능하도록 제한
 - 단, Freeze Time의 경우 현재 시각이 Freeze Time 이전이어야 하고, 변경된 Freeze Time은 기존 Freeze Time 이후여야 함


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
