### PR TITLE
feat(fe): make enableCopyPaste UI to disableCopyPaste UI in contest create/edit

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/edit/page.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/edit/page.tsx
@@ -20,7 +20,7 @@ import { AddManagerReviewerDialog } from '../../_components/AddManagerReviewerDi
 import { ContestManagerReviewerTable } from '../../_components/ContestManagerReviewerTable'
 import { ContestProblemTable } from '../../_components/ContestProblemTable'
 import { CreateEditContestLabel } from '../../_components/CreateEditContestLabel'
-import { EnableCopyPasteForm } from '../../_components/EnableCopyPasteForm'
+import { DisableCopyPasteForm } from '../../_components/DisableCopyPasteForm'
 import { FreezeForm } from '../../_components/FreezeForm'
 import { ImportDialog } from '../../_components/ImportDialog'
 import { PosterUploadForm } from '../../_components/PosterUploadForm'
@@ -151,9 +151,9 @@ export default function Page({ params }: { params: { contestId: string } }) {
                 hasValue={methods.getValues('invitationCode') !== null}
               />
               {methods.getValues('enableCopyPaste') !== undefined && (
-                <EnableCopyPasteForm
+                <DisableCopyPasteForm
                   name="enableCopyPaste"
-                  title="Enable Copy Paste"
+                  title="Disable Copy/Paste"
                   hasValue={methods.getValues('enableCopyPaste') !== false}
                 />
               )}

--- a/apps/frontend/app/admin/contest/_components/DisableCopyPasteForm.tsx
+++ b/apps/frontend/app/admin/contest/_components/DisableCopyPasteForm.tsx
@@ -6,17 +6,17 @@ import { Switch } from '@/components/shadcn/switch'
 import React from 'react'
 import { useController, useFormContext } from 'react-hook-form'
 
-interface EnableCopyPasteFormProps {
+interface DisableCopyPasteFormProps {
   name: string
   title: string
   hasValue?: boolean
 }
 
-export function EnableCopyPasteForm({
+export function DisableCopyPasteForm({
   name,
   title,
-  hasValue = true
-}: EnableCopyPasteFormProps) {
+  hasValue = false
+}: DisableCopyPasteFormProps) {
   const {
     control,
     formState: { errors }
@@ -27,13 +27,12 @@ export function EnableCopyPasteForm({
     control,
     defaultValue: hasValue
   })
-
   return (
     <div className="flex items-center gap-3">
       <Label required={false}>{title}</Label>
       <Switch
-        onCheckedChange={field.onChange}
-        checked={field.value}
+        onCheckedChange={(checked) => field.onChange(!checked)}
+        checked={!field.value}
         className="data-[state=checked]:bg-primary data-[state=unchecked]:bg-gray-300"
       />
       {field.value && errors[name] && (

--- a/apps/frontend/app/admin/contest/_components/DisableCopyPasteForm.tsx
+++ b/apps/frontend/app/admin/contest/_components/DisableCopyPasteForm.tsx
@@ -15,7 +15,7 @@ interface DisableCopyPasteFormProps {
 export function DisableCopyPasteForm({
   name,
   title,
-  hasValue = false
+  hasValue = true
 }: DisableCopyPasteFormProps) {
   const {
     control,

--- a/apps/frontend/app/admin/contest/create/page.tsx
+++ b/apps/frontend/app/admin/contest/create/page.tsx
@@ -17,7 +17,7 @@ import { AddManagerReviewerDialog } from '../_components/AddManagerReviewerDialo
 import { ContestManagerReviewerTable } from '../_components/ContestManagerReviewerTable'
 import { ContestProblemTable } from '../_components/ContestProblemTable'
 import { CreateEditContestLabel } from '../_components/CreateEditContestLabel'
-import { EnableCopyPasteForm } from '../_components/EnableCopyPasteForm'
+import { DisableCopyPasteForm } from '../_components/DisableCopyPasteForm'
 import { FreezeForm } from '../_components/FreezeForm'
 import { ImportDialog } from '../_components/ImportDialog'
 import { PosterUploadForm } from '../_components/PosterUploadForm'
@@ -91,9 +91,9 @@ export default function Page() {
                 formElement="input"
                 placeholder="Enter a invitation code"
               />
-              <EnableCopyPasteForm
+              <DisableCopyPasteForm
                 name="enableCopyPaste"
-                title="Enable Copy Paste"
+                title="Disable Copy/Paste"
               />
             </div>
 


### PR DESCRIPTION
### Description

기획 변경에 따라 admin page의 enable copy paste 문구를 disable copy paste로 변경하였습니다! 그리고 변경에 알맞게 switch의 true/false 여부를 설정하였습니다. 

Contest create/edit 각 페이지에서 변경된 화면을 확인할 수 있습니다.
<img width="941" alt="스크린샷 2025-05-14 오후 11 48 14" src="https://github.com/user-attachments/assets/5543839b-9b90-4e0f-9c7a-30b61c4a4371" />


>[!Note]
> enableCopyPaste 변수명을 변경하는 것은 큰 작업으로 예상되어... (백엔드 속성명도 enableCopyPaste니까!) 
> enableCopyPaste 변수명을 유지하면서 ui에서 반대로 값을 보여주는 형태로 구현하였습니다. 


closes TAS-1717

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
