### PR TITLE
feat(fe): change code editor header buttons position

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -469,6 +469,33 @@ export function EditorHeader({
   return (
     <div className="flex shrink-0 items-center justify-between border-b border-b-slate-700 bg-[#222939] px-6">
       <div>
+        <Select
+          onValueChange={(language: Language) => {
+            setLanguage(language)
+          }}
+          value={language}
+        >
+          <SelectTrigger className="h-8 min-w-[86px] max-w-fit shrink-0 rounded-[4px] border-none bg-slate-600 px-2 font-mono hover:bg-slate-700 focus:outline-none focus:ring-0 focus:ring-offset-0">
+            <p className="px-1">
+              <SelectValue />
+            </p>
+          </SelectTrigger>
+          <SelectContent className="mt-3 min-w-[100px] max-w-fit border-none bg-[#4C5565] p-0 font-mono">
+            <SelectGroup className="text-white">
+              {problem.languages.map((language) => (
+                <SelectItem
+                  key={language}
+                  value={language}
+                  className="cursor-pointer hover:bg-[#222939]"
+                >
+                  {language}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center gap-3">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
@@ -501,25 +528,8 @@ export function EditorHeader({
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
-      </div>
-      <div className="flex items-center gap-3">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                size="icon"
-                className="size-7 h-8 w-[77px] shrink-0 gap-[5px] rounded-[4px] bg-[#fafafa] font-medium text-[#484C4D] hover:bg-[#e1e1e1]"
-                onClick={saveCode}
-              >
-                <Save className="stroke-[1.3]" size={22} />
-                Save
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Ctrl/Cmd + S | Save your code in your browser.</p>
-            </TooltipContent>
-          </Tooltip>
 
+        <TooltipProvider>
           <Tooltip>
             <TooltipTrigger>
               <Button
@@ -536,6 +546,22 @@ export function EditorHeader({
             </TooltipContent>
           </Tooltip>
 
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                size="icon"
+                className="size-7 h-8 w-[77px] shrink-0 gap-[5px] rounded-[4px] bg-[#fafafa] font-medium text-[#484C4D] hover:bg-[#e1e1e1]"
+                onClick={saveCode}
+              >
+                <Save className="stroke-[1.3]" size={22} />
+                Save
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Ctrl/Cmd + S | Save your code in your browser.</p>
+            </TooltipContent>
+          </Tooltip>
+
           <RunTestButton
             problemId={problem.id}
             language={language}
@@ -543,6 +569,7 @@ export function EditorHeader({
             saveCode={storeCodeToLocalStorage}
             className="test-button"
           />
+
           <Tooltip>
             <TooltipTrigger>
               <Button
@@ -564,31 +591,6 @@ export function EditorHeader({
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        <Select
-          onValueChange={(language: Language) => {
-            setLanguage(language)
-          }}
-          value={language}
-        >
-          <SelectTrigger className="h-8 min-w-[86px] max-w-fit shrink-0 rounded-[4px] border-none bg-slate-600 px-2 font-mono hover:bg-slate-700 focus:outline-none focus:ring-0 focus:ring-offset-0">
-            <p className="px-1">
-              <SelectValue />
-            </p>
-          </SelectTrigger>
-          <SelectContent className="mt-3 min-w-[100px] max-w-fit border-none bg-[#4C5565] p-0 font-mono">
-            <SelectGroup className="text-white">
-              {problem.languages.map((language) => (
-                <SelectItem
-                  key={language}
-                  value={language}
-                  className="cursor-pointer hover:bg-[#222939]"
-                >
-                  {language}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
       </div>
       <BackCautionDialog
         confrim={isModalConfrimed}


### PR DESCRIPTION
### Description

기획 변경에 따라 코드에디터의 버튼 위치를 다음과 같이 수정합니다. 
<img width="979" alt="스크린샷 2025-05-15 오전 12 17 39" src="https://github.com/user-attachments/assets/714d08af-760e-4053-90d8-ed9b53c892b2" />


콘테스트를 포함한 모든 에디터를 사용하는 화면에 적용됩니다.
problem, assignment, contest의 code editor 모두에서 위와 같은 모습으로 보이는 것입니다.

공통 컴포넌트이므로 BOXERCAT 님을 리뷰어로 지정합니다!

> [!TIP]
> 리뷰어들에게 꿀팁! 이 코드는 그냥 컴포넌트의 위치만 복붙으로 바꿔준 것입니다! css나 문법 같은거를 꼼꼼히 봐주지 않아도
> 문제 없을 거에요! 여러분 화면에서도 위와 같이 보이는 지, 버튼은 잘 동작하는 지와 같은 것들을 위주로 봐주시면 좋을 것 같아요!

closes TAS-1719

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
