### PR TITLE
feat(fe): remove inverting switch field for assignment and exercise

### DIFF
--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/page.tsx
@@ -152,12 +152,12 @@ export default function Information({ params }: InformationProps) {
               </div>
               <div className="flex items-center gap-4">
                 <span className="text-[16px] font-semibold">
-                  Disable Copy/Paste
+                  Enable Copy/Paste
                 </span>
                 <span
-                  className={`rounded-[12px] px-4 py-1 text-xs font-bold text-white ${!assignmentData?.enableCopyPaste ? 'bg-primary' : 'bg-gray-300'}`}
+                  className={`rounded-[12px] px-4 py-1 text-xs font-bold text-white ${assignmentData?.enableCopyPaste ? 'bg-primary' : 'bg-gray-300'}`}
                 >
-                  {!assignmentData?.enableCopyPaste ? 'ON' : 'OFF'}
+                  {assignmentData?.enableCopyPaste ? 'ON' : 'OFF'}
                 </span>
               </div>
             </div>

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/edit/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/edit/page.tsx
@@ -171,18 +171,16 @@ export default function Page({
               <div className="flex flex-col gap-1 rounded-md border bg-white p-[20px]">
                 <SwitchField
                   name="isJudgeResultVisible"
-                  title="Hide Hidden Testcase Result"
+                  title="Reveal Hidden Testcase Result"
                   description="When enabled, hidden testcase results will be hidden from students."
-                  invert={true}
-                  hasValue={methods.getValues('isJudgeResultVisible') || true}
+                  hasValue={methods.getValues('isJudgeResultVisible') || false}
                 />
 
                 <SwitchField
                   name="enableCopyPaste"
-                  title="Disable Copy/Paste"
                   description="When enabled, students will not be able to copy from or paste into the code editor."
-                  hasValue={methods.getValues('enableCopyPaste') || true}
-                  invert={true}
+                  title="Enable Participants Copy/Pasting"
+                  hasValue={methods.getValues('enableCopyPaste') || false}
                 />
               </div>
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/create/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/create/page.tsx
@@ -137,17 +137,17 @@ export default function Page({ params }: { params: { courseId: string } }) {
 
               <div className="flex flex-col gap-1 rounded-md border bg-white p-[20px]">
                 <SwitchField
+                  hasValue={true}
                   name="isJudgeResultVisible"
-                  title="Hide Hidden Testcase Result"
-                  description="When enabled, hidden testcase results will be hidden from students."
-                  invert={true}
+                  title="Reveal Hidden Testcase Result"
+                  description="When enabled, students will not be able to copy from or paste into the code editor."
                 />
 
                 <SwitchField
+                  hasValue={true}
                   name="enableCopyPaste"
-                  title="Disable Copy/Paste"
+                  title="Enable Participants Copy/Pasting"
                   description="When enabled, students will not be able to copy from or paste into the code editor."
-                  invert={true}
                 />
               </div>
 

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
@@ -146,12 +146,12 @@ export default function Information({ params }: InformationProps) {
             </div>
             <div className="flex items-center gap-4">
               <span className="text-[16px] font-semibold">
-                Disable Copy/Paste
+                Enable Copy/Paste
               </span>
               <span
-                className={`rounded-[12px] px-4 py-1 text-xs font-bold text-white ${!assignmentData?.enableCopyPaste ? 'bg-primary' : 'bg-gray-300'}`}
+                className={`rounded-[12px] px-4 py-1 text-xs font-bold text-white ${assignmentData?.enableCopyPaste ? 'bg-primary' : 'bg-gray-300'}`}
               >
-                {!assignmentData?.enableCopyPaste ? 'ON' : 'OFF'}
+                {assignmentData?.enableCopyPaste ? 'ON' : 'OFF'}
               </span>
             </div>
           </div>

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/edit/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/edit/page.tsx
@@ -171,17 +171,16 @@ export default function Page({
               <div className="flex flex-col gap-1 rounded-md border bg-white p-[20px]">
                 <SwitchField
                   name="isJudgeResultVisible"
-                  title="Hide Hidden Testcase Result"
+                  title="Reveal Hidden Testcase Result"
                   description="When enabled, hidden testcase results will be hidden from students."
-                  invert={true}
-                  hasValue={methods.getValues('isJudgeResultVisible') || true}
+                  hasValue={methods.getValues('isJudgeResultVisible') || false}
                 />
+
                 <SwitchField
                   name="enableCopyPaste"
-                  title="Disable Copy/Paste"
                   description="When enabled, students will not be able to copy from or paste into the code editor."
-                  hasValue={methods.getValues('enableCopyPaste') || true}
-                  invert={true}
+                  title="Enable Participants Copy/Pasting"
+                  hasValue={methods.getValues('enableCopyPaste') || false}
                 />
               </div>
 

--- a/apps/frontend/app/admin/course/[courseId]/exercise/create/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/create/page.tsx
@@ -138,17 +138,17 @@ export default function Page({ params }: { params: { courseId: string } }) {
 
               <div className="flex flex-col gap-1 rounded-md border bg-white p-[20px]">
                 <SwitchField
+                  hasValue={true}
                   name="isJudgeResultVisible"
-                  title="Hide Hidden Testcase Result"
-                  description="When enabled, hidden testcase results will be hidden from students."
-                  invert={true}
+                  title="Reveal Hidden Testcase Result"
+                  description="When enabled, students will not be able to copy from or paste into the code editor."
                 />
 
                 <SwitchField
+                  hasValue={true}
                   name="enableCopyPaste"
-                  title="Disable Copy/Paste"
+                  title="Enable Participants Copy/Pasting"
                   description="When enabled, students will not be able to copy from or paste into the code editor."
-                  invert={true}
                 />
               </div>
 


### PR DESCRIPTION
### Mangement - Assignment / Exercise의  Create / Edit / Detail 페이지
> [!Info]
> Assignment, Exercise 각각 새로 생성하고, 수정하는 화면 테스트 직접 해봤습니다 (민규)
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/495242bf-795f-4ca1-890a-4e41cb602849" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/0b7ff568-a747-439c-bcde-9e1a02cabd4a" />

---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1731
