### PR TITLE
fix(fe): hide run button and tab on contest

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -538,21 +538,23 @@ export function EditorHeader({
         </AlertDialog>
 
         <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                variant="secondary"
-                className="h-8 shrink-0 gap-1 rounded-[4px] border-none bg-[#D7E5FE] px-2 font-normal text-[#484C4D] hover:bg-[#c6d3ea]"
-                onClick={run}
-              >
-                <IoPlayCircleOutline size={22} />
-                Run
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Ctrl/Cmd + Enter | Run your code in interactive terminal.</p>
-            </TooltipContent>
-          </Tooltip>
+          {contestId === undefined && (
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  variant="secondary"
+                  className="h-8 shrink-0 gap-1 rounded-[4px] border-none bg-[#D7E5FE] px-2 font-normal text-[#484C4D] hover:bg-[#c6d3ea]"
+                  onClick={run}
+                >
+                  <IoPlayCircleOutline size={22} />
+                  Run
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Ctrl/Cmd + Enter | Run your code in interactive terminal.</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
 
           <Tooltip>
             <TooltipTrigger>

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorResizablePanel.tsx
@@ -331,7 +331,7 @@ export function EditorMainResizablePanel({
                   defaultSize={40}
                   className={cn(isBottomPanelHidden && 'hidden')}
                 >
-                  <TestcasePanel isContest={Boolean(courseId)} />
+                  <TestcasePanel isContest={contestId !== undefined} />
                 </ResizablePanel>
               </ResizablePanelGroup>
             </TestPollingStoreProvider>

--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/TestcasePanel.tsx
@@ -59,6 +59,7 @@ export function TestcasePanel({ isContest }: TestcasePanelProps) {
     }
   }
 
+  // Hide 'run' feature in contest, because it is not stable yet
   // TODO: remove this after 'run' feature gets stable
   useEffect(() => {
     if (isContest) {


### PR DESCRIPTION
### Description

Continue from #2716
Contest에서 run 버튼과 탭을 모두 표시하지 않습니다. (기존 PR에서는 탭만 지웠네요...)

#### Contest일 때

<img width="743" alt="image" src="https://github.com/user-attachments/assets/28eaf171-3161-44db-b3be-76a270cdb5e2" />

#### Contest가 아닐 때

<img width="729" alt="image" src="https://github.com/user-attachments/assets/fceb6835-ffb1-4bb5-ab10-4ca27b2f48d8" />

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
