### PR TITLE
fix(be): extend contest problem visible authority

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -1166,6 +1166,9 @@ export class ContestService {
         id: true,
         order: true,
         problemId: true
+      },
+      orderBy: {
+        order: 'asc'
       }
     })
 

--- a/apps/backend/apps/admin/src/problem/services/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/problem.service.ts
@@ -438,7 +438,7 @@ export class ProblemService {
       ...data
     } = input
 
-    // SuperAdmin/Admin은 항상 visible 설정 가능
+    // Admin 이상 권한이 있으면 항상 visible 설정 가능
     if (
       userRole !== Role.SuperAdmin &&
       userRole !== Role.Admin &&

--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -476,6 +476,9 @@ export class ContestService {
         id: true,
         order: true,
         problemId: true
+      },
+      orderBy: {
+        order: 'asc'
       }
     }) // 모든 문제 목록이 포함된 배열
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

대회 종료 후 문제 공개가 가능하도록, Contest Admin/Manager에게 Visible 설정 권한을 추가 부여합니다.

![image](https://github.com/user-attachments/assets/2e77e463-1558-4538-b230-e4af34bd7d87)

> [!NOTE]
> 현재 Admin 이상의 권한이 없으면 문제의 Visible 설정이 불가능합니다.
> (Super, Admin 계정만 설정 가능)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
