### PR TITLE
chore(fe): change default sort algorithm

### DIFF
--- a/apps/frontend/app/admin/contest/_components/ContestTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestTable.tsx
@@ -54,7 +54,7 @@ export function ContestTable() {
     <DataTableRoot
       data={contestsWithStatus}
       columns={columns}
-      defaultSortState={[{ id: 'startTime', desc: true }]}
+      defaultSortState={[{ id: 'status', desc: true }]}
     >
       <div className="mb-6 flex justify-between">
         <DataTableSearchBar columndId="title" />

--- a/apps/frontend/app/admin/contest/_components/ContestTableColumns.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestTableColumns.tsx
@@ -81,7 +81,7 @@ export const columns: ColumnDef<DataTableContest>[] = [
     ),
     cell: ({ row }) => (
       <p className="overflow-hidden whitespace-nowrap text-center font-normal text-neutral-500">
-        {`${dateFormatter(row.original.startTime, 'YY-MM-DD HH:mm')} ~ ${dateFormatter(row.original.endTime, 'YY-MM-DD HH:mm')}`}
+        {`${dateFormatter(row.original.startTime, 'YY-MM-DD HH:mm:ss')} ~ ${dateFormatter(row.original.endTime, 'YY-MM-DD HH:mm:ss')}`}
       </p>
     ),
     size: 250


### PR DESCRIPTION
### Description

admin contest list가 올바르게 sorting된 상태로 나타나지 않는 문제가 있었기에 이를 해결했습니다. 

As is
![image](https://github.com/user-attachments/assets/7423b92a-c5f6-4ed0-8ec9-c9802e6b6052)


To be
<img width="1226" alt="스크린샷 2025-05-22 오후 5 50 54" src="https://github.com/user-attachments/assets/7045e798-a5c7-4c0b-a084-61e71584a9f7" />


closes TAS-1654

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
