### PR TITLE
feat(fe): add PyPy3 documentation and change document modal design

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/ReferenceDialog.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/ReferenceDialog.tsx
@@ -6,8 +6,8 @@ import {
   DialogTrigger
 } from '@/components/shadcn/dialog'
 import compileIcon from '@/public/icons/compile-version.svg'
-import { FileText } from 'lucide-react'
 import Image from 'next/image'
+import { FaRegFile } from 'react-icons/fa6'
 
 export function ReferenceDialog() {
   return (
@@ -34,11 +34,13 @@ export function ReferenceDialog() {
             <table className="min-w-full bg-[#222939] text-left text-sm">
               <thead className="border-b border-slate-600 bg-slate-800 text-xs font-normal text-[#C4CACC]">
                 <tr>
-                  <th className="py-3 pl-4">Language</th>
-                  <th className="py-3 pl-4">Time Limit</th>
+                  <th className="py-3 pl-4 font-normal">Language</th>
+                  <th className="py-3 pl-4 font-normal">Time Limit</th>
 
-                  <th className="py-3 pl-4">Memory Limit</th>
-                  <th className="px-3 py-3">Compiler Version Document</th>
+                  <th className="py-3 pl-4 font-normal">Memory Limit</th>
+                  <th className="px-3 py-3 font-normal">
+                    Compiler Version Document
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -47,12 +49,12 @@ export function ReferenceDialog() {
                   <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
                   <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
                   <td className="px-3 py-3">
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center space-x-2 pb-2">
                       <a
                         href="https://cplusplus.com/reference/clibrary/"
                         target="_blank"
                       >
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>gcc 13.2.0</span>
                     </div>
@@ -61,7 +63,7 @@ export function ReferenceDialog() {
                         href="https://cplusplus.com/reference/clibrary/"
                         target="_blank"
                       >
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>c11</span>
                     </div>
@@ -72,12 +74,12 @@ export function ReferenceDialog() {
                   <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
                   <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
                   <td className="px-3 py-3">
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center space-x-2 pb-2">
                       <a
                         href="https://cplusplus.com/reference/"
                         target="_blank"
                       >
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>g++ 13.2.0</span>
                     </div>
@@ -86,7 +88,7 @@ export function ReferenceDialog() {
                         href="https://cplusplus.com/reference/"
                         target="_blank"
                       >
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>c++ 14</span>
                     </div>
@@ -102,7 +104,7 @@ export function ReferenceDialog() {
                         href="https://docs.oracle.com/en/java/javase/17/docs/api/index.html"
                         target="_blank"
                       >
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>openjdk 17.0.11</span>
                     </div>
@@ -118,7 +120,7 @@ export function ReferenceDialog() {
                         href="https://docs.python.org/3.12/library/index.html"
                         target="_blank"
                       >
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>python 3.12.3</span>
                     </div>
@@ -131,7 +133,7 @@ export function ReferenceDialog() {
                   <td className="px-3 py-3">
                     <div className="flex items-center space-x-2">
                       <a href="https://pypy.org/" target="_blank">
-                        <FileText size={18} />
+                        <FaRegFile size={16} />
                       </a>
                       <span>Python 3.1.0.14, PyPy 7.3.17</span>
                     </div>

--- a/apps/frontend/app/(client)/(code-editor)/_components/ReferenceDialog.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/ReferenceDialog.tsx
@@ -23,25 +23,30 @@ export function ReferenceDialog() {
         </DialogTrigger>
         <DialogContent
           showDarkOverlay={true}
-          className="rounded-xl border-none bg-slate-900 text-gray-300 sm:max-w-md"
+          className="h-[415px] w-[580px] max-w-none rounded-2xl border-none bg-slate-900 text-gray-300"
         >
           <DialogHeader>
-            <DialogTitle className="font-normal text-white">
+            <DialogTitle className="text-xl font-semibold text-white">
               Compiler Version Document
             </DialogTitle>
           </DialogHeader>
-          <div className="overflow-x-auto rounded border border-slate-600">
-            <table className="min-w-full bg-slate-900 text-left text-sm">
-              <thead className="border-b border-slate-600 bg-slate-800 text-xs">
+          <div className="overflow-x-auto rounded-[10px] border border-slate-600">
+            <table className="min-w-full bg-[#222939] text-left text-sm">
+              <thead className="border-b border-slate-600 bg-slate-800 text-xs font-normal text-[#C4CACC]">
                 <tr>
-                  <th className="px-6 py-3">Language</th>
-                  <th className="px-6 py-3">Compiler Version Document</th>
+                  <th className="py-3 pl-4">Language</th>
+                  <th className="py-3 pl-4">Time Limit</th>
+
+                  <th className="py-3 pl-4">Memory Limit</th>
+                  <th className="px-3 py-3">Compiler Version Document</th>
                 </tr>
               </thead>
               <tbody>
-                <tr className="border-b border-slate-600">
-                  <td className="flex px-6 py-4">C</td>
-                  <td className="px-6 py-4">
+                <tr className="border-b border-slate-600 bg-slate-900">
+                  <td className="py-3 pl-4">C</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
+                  <td className="px-3 py-3">
                     <div className="flex items-center space-x-2">
                       <a
                         href="https://cplusplus.com/reference/clibrary/"
@@ -62,9 +67,11 @@ export function ReferenceDialog() {
                     </div>
                   </td>
                 </tr>
-                <tr className="border-b border-slate-600">
-                  <td className="flex px-6 py-4">C++</td>
-                  <td className="px-6 py-4">
+                <tr className="border-b border-slate-600 bg-slate-900">
+                  <td className="py-3 pl-4">C++</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">-</td>
+                  <td className="px-3 py-3">
                     <div className="flex items-center space-x-2">
                       <a
                         href="https://cplusplus.com/reference/"
@@ -85,9 +92,11 @@ export function ReferenceDialog() {
                     </div>
                   </td>
                 </tr>
-                <tr className="border-b border-slate-600">
-                  <td className="flex px-6 py-4">Java</td>
-                  <td className="px-6 py-4">
+                <tr className="border-b border-slate-600 bg-slate-900">
+                  <td className="py-3 pl-4">Java</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">x2+1 sec</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">x2+16 MB</td>
+                  <td className="px-3 py-3">
                     <div className="flex items-center space-x-2">
                       <a
                         href="https://docs.oracle.com/en/java/javase/17/docs/api/index.html"
@@ -99,9 +108,11 @@ export function ReferenceDialog() {
                     </div>
                   </td>
                 </tr>
-                <tr>
-                  <td className="flex px-6 py-4">Python</td>
-                  <td className="px-6 py-4">
+                <tr className="border-b border-slate-600 bg-slate-900">
+                  <td className="py-3 pl-4">Python</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">x3+2 sec</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">x2+32 MB</td>
+                  <td className="px-3 py-3">
                     <div className="flex items-center space-x-2">
                       <a
                         href="https://docs.python.org/3.12/library/index.html"
@@ -110,6 +121,19 @@ export function ReferenceDialog() {
                         <FileText size={18} />
                       </a>
                       <span>python 3.12.3</span>
+                    </div>
+                  </td>
+                </tr>
+                <tr className="bg-slate-900">
+                  <td className="py-3 pl-4">PyPy3</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">x3+2 sec</td>
+                  <td className="py-3 pl-4 text-[#8A8A8A]">x2+128 MB</td>
+                  <td className="px-3 py-3">
+                    <div className="flex items-center space-x-2">
+                      <a href="https://pypy.org/" target="_blank">
+                        <FileText size={18} />
+                      </a>
+                      <span>Python 3.1.0.14, PyPy 7.3.17</span>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
### Description

1. PyPy3을 지원하게 되어 code editor의 documentation modal의 table에 PyPy3 row를 추가하였습니다. 
2. **time limit**과 **memory limit** 표시를 추가하였습니다. 
3. 디자인이 바뀌어서 css를 수정하였습니다.

***AS IS***
<img width="478" alt="스크린샷 2025-05-22 오후 8 27 14" src="https://github.com/user-attachments/assets/830b1ca2-65cd-4ef3-9f3e-04832bfb05ce" />


***TO BE***
<img width="612" alt="스크린샷 2025-05-22 오후 8 43 38" src="https://github.com/user-attachments/assets/097f4bfe-2300-4973-b98a-6b5ad88d5bff" />

> [!Tip]
> Preview에서 변경 사항을 확인하고 싶다면 코드에디터 들어가서 description tab에서 제일 밑으로 내리면  
> document 버튼을 찾으실 수 있어요 :)

ㄹㅇ 공컴이므로 BoxerCat을 리뷰어로 지목할게요!

closes TAS-1737

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
