### PR TITLE
chore(be): return user role to contest leaderboard

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.controller.ts
+++ b/apps/backend/apps/client/src/contest/contest.controller.ts
@@ -71,11 +71,16 @@ export class ContestController {
   }
 
   @Get(':id/leaderboard')
-  @AuthNotNeededIfPublic()
+  @UserNullWhenAuthFailedIfPublic()
   async getLeaderboard(
+    @Req() req: AuthenticatedRequest,
     @Param('id', IDValidationPipe) contestId: number,
     @Query('search') search: string
   ) {
-    return await this.contestService.getContestLeaderboard(contestId, search)
+    return await this.contestService.getContestLeaderboard(
+      contestId,
+      req.user?.id,
+      search
+    )
   }
 }

--- a/apps/backend/apps/client/src/contest/contest.service.spec.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.spec.ts
@@ -368,7 +368,10 @@ describe('ContestService', () => {
 
   describe('getContestLeaderboard', () => {
     it('should return leaderboard of the contest', async () => {
-      const leaderboard = await service.getContestLeaderboard(contestId)
+      const leaderboard = await service.getContestLeaderboard(
+        contestId,
+        contestAdminId
+      )
       expect(leaderboard).to.be.ok
     })
   })

--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -334,17 +334,29 @@ export class ContestService {
     })
   }
 
-  async getContestLeaderboard(contestId: number, search?: string) {
+  async getContestLeaderboard(
+    contestId: number,
+    userId: number,
+    search?: string
+  ) {
     const contest = await this.prisma.contest.findUniqueOrThrow({
       where: {
         id: contestId
       },
       select: {
         freezeTime: true,
-        unfreeze: true
+        unfreeze: true,
+        userContest: {
+          where: {
+            userId
+          },
+          select: {
+            role: true
+          }
+        }
       }
     })
-
+    const userRole = contest.userContest[0]?.role ?? null
     const now = new Date()
     const isFrozen = Boolean(
       contest.freezeTime && now >= contest.freezeTime && !contest.unfreeze
@@ -569,6 +581,7 @@ export class ContestService {
       : leaderboard
 
     return {
+      userRole,
       maxScore,
       leaderboard: filteredLeaderboard
     }

--- a/collection/client/Contest/Get Leaderboard/succeed.bru
+++ b/collection/client/Contest/Get Leaderboard/succeed.bru
@@ -32,7 +32,7 @@ docs {
 
   ```json
   {
-    "userRole": "Manager"
+    "userRole": "Manager",
     "maxScore": 60,
     "leaderboard": [
       {

--- a/collection/client/Contest/Get Leaderboard/succeed.bru
+++ b/collection/client/Contest/Get Leaderboard/succeed.bru
@@ -21,15 +21,15 @@ params:path {
 docs {
   # Get Leaderboard
   contest의 리더보드를 return합니다.
-  
+
   ## Query
   | 이름 | 타입 | 설명 |
   |-----|-----|-----|
   |search|string|검색하고자하는 string을 넣으면 해당 문자열이 포함된 유저명들만을 return합니다|
-  
+
   ## Return
   ## 🔹 Response Format
-  
+
   ```json
   {
     "maxScore": 60,
@@ -56,11 +56,12 @@ docs {
     ]
   }
   ```
-  
+
   ## 🔹 Response Fields
-  
+
   | 이름 | 타입 | 설명 |
   |------------|--------|----------------------------|
+  | `userRole` | `string` | 사용자의 대회 role (Admin, Manager, Reviewer, Participant, null) |
   | `maxScore` | `number` | 대회에서 획득 가능한 최대 점수 |
   | `leaderboard` | `array` | 대회의 리더보드 |
   | `leaderboard[].user` | `object` | 참가자 정보 |

--- a/collection/client/Contest/Get Leaderboard/succeed.bru
+++ b/collection/client/Contest/Get Leaderboard/succeed.bru
@@ -32,6 +32,7 @@ docs {
 
   ```json
   {
+    "userRole": "Manager"
     "maxScore": 60,
     "leaderboard": [
       {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

대회 leaderboard를 열람할 때 대회 역할에 따른 열람 권한 구분을 위해 userRole 정보를 함께 반환합니다


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
