### PR TITLE
fix(cd): prevent stage env being overridden

### DIFF
--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -100,7 +100,6 @@ jobs:
       - name: Load dotenv from secret
         run: |
           echo "${{ secrets.ENV_DEVELOPMENT }}" > .env
-          echo "${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT_URL }}" > .env
 
       - name: Check if containers are running
         id: check-container


### PR DESCRIPTION
### Description

#2705 에서 cd-stage.yml에서 .env를 생성할 때 redirection이 잘못 되어 기존 .env 값이 지워지는 이슈를 해결합니다.

```sh
echo "${{ secrets.ENV_DEVELOPMENT }}" > .env
echo "${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT_URL }}" > .env  # overriding .env
```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
