### PR TITLE
feat(fe): allow contest admin and manager to see the client leaderboard before finish

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/_libs/apis/getContestLeaderboard.ts
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/_libs/apis/getContestLeaderboard.ts
@@ -1,4 +1,4 @@
-import { safeFetcher } from '@/libs/utils'
+import { safeFetcherWithAuth } from '@/libs/utils'
 
 interface GetContestLeaderboard {
   contestId: number
@@ -25,12 +25,15 @@ export interface LeaderboardUser {
 export interface ContestLeaderboard {
   maxScore: number
   leaderboard: LeaderboardUser[]
+  userRole: string
 }
 
 export const getContestLeaderboard = async ({
   contestId
 }: GetContestLeaderboard) => {
-  const response = await safeFetcher.get(`contest/${contestId}/leaderboard`)
+  const response = await safeFetcherWithAuth.get(
+    `contest/${contestId}/leaderboard`
+  )
 
   const data = await response.json<ContestLeaderboard>()
   return data

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
@@ -5,12 +5,12 @@ import searchIcon from '@/public/icons/search.svg'
 import { useQuery } from '@tanstack/react-query'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { LeaderboardModalDialog } from './_components/LeaderboardModalDialog'
 import { LeaderboardTable } from './_components/LeaderboardTable'
 import { getContest } from './_libs/apis/getContest'
-import { getContestLeaderboard } from './_libs/apis/getContestLeaderboard'
 import type { LeaderboardUser } from './_libs/apis/getContestLeaderboard'
+import { getContestLeaderboard } from './_libs/apis/getContestLeaderboard'
 
 const BaseLeaderboardUser = {
   username: '',
@@ -31,7 +31,8 @@ const BaseLeaderboardUser = {
 }
 const BaseContestLeaderboardData = {
   maxScore: 0,
-  leaderboard: [BaseLeaderboardUser]
+  leaderboard: [BaseLeaderboardUser],
+  userRole: null
 }
 
 const BaseFetchedContest = {
@@ -53,6 +54,7 @@ export default function ContestLeaderBoard() {
     queryFn: () => getContestLeaderboard({ contestId })
   })
   const contestLeaderboard = data ? data : BaseContestLeaderboardData
+  console.log('contest leaderboard role: ', contestLeaderboard.userRole)
   const [problemSize, setProblemSize] = useState(0)
   const [leaderboardUsers, setLeaderboardUsers] = useState([
     BaseLeaderboardUser
@@ -78,7 +80,12 @@ export default function ContestLeaderBoard() {
     if (!isLoading && !isError) {
       const contestEndTime = new Date(fetchedContest?.endTime)
       const contestStartTime = new Date(fetchedContest?.startTime)
-      if (contestEndTime > now && contestStartTime < now) {
+
+      const hasContestAuth =
+        contestLeaderboard.userRole === 'Admin' ||
+        contestLeaderboard.userRole === 'Manager'
+
+      if (!hasContestAuth && contestEndTime > now && contestStartTime < now) {
         throw new Error('Error(ongoing): The contest has not ended yet.')
       }
       if (contestStartTime > now) {

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
@@ -54,7 +54,6 @@ export default function ContestLeaderBoard() {
     queryFn: () => getContestLeaderboard({ contestId })
   })
   const contestLeaderboard = data ? data : BaseContestLeaderboardData
-  console.log('contest leaderboard role: ', contestLeaderboard.userRole)
   const [problemSize, setProblemSize] = useState(0)
   const [leaderboardUsers, setLeaderboardUsers] = useState([
     BaseLeaderboardUser


### PR DESCRIPTION
### Description

클라이언트 리더보드는 기존에 대회가 끝나기 전에는 볼 수 없도록 되어있었습니다.
그러나! NPC 측의 요청에 따라서 Contest Admin과 Contest Manager는 대회가 끝나기 전에도 리더보드를 볼 수 있도록 변경합니다.

- 아래 스크린 샷은 콘테스트 어드민이 진행중인 리더보드를 보는 장면입니다!
<img width="1512" alt="스크린샷 2025-05-27 오후 1 35 58" src="https://github.com/user-attachments/assets/2af5ae42-a8ac-4a6d-b7c3-afa8f4bfe4b2" />

> [!Tip]
> 정리하면 아래와 같음
>
> **대회 진행동안 client Contest Leaderboard 볼 수 있는 권한**
> Contest Admin 있음!
> Contest Manager 있음!
> Contest Participant 없음...
> 나머지 없음...

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
