### PR TITLE
feat(fe): remove string cheeze

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/leaderboard/page.tsx
@@ -5,12 +5,12 @@ import searchIcon from '@/public/icons/search.svg'
 import { useQuery } from '@tanstack/react-query'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { LeaderboardModalDialog } from './_components/LeaderboardModalDialog'
 import { LeaderboardTable } from './_components/LeaderboardTable'
 import { getContest } from './_libs/apis/getContest'
-import { getContestLeaderboard } from './_libs/apis/getContestLeaderboard'
 import type { LeaderboardUser } from './_libs/apis/getContestLeaderboard'
+import { getContestLeaderboard } from './_libs/apis/getContestLeaderboard'
 
 const BaseLeaderboardUser = {
   username: '',
@@ -147,11 +147,13 @@ export default function ContestLeaderBoard() {
         />
       </div>
       <div>
-        <LeaderboardTable
-          problemSize={problemSize}
-          leaderboardUsers={leaderboardUsers}
-          matchedIndices={matchedIndices}
-        />
+        {!isLoading && (
+          <LeaderboardTable
+            problemSize={problemSize}
+            leaderboardUsers={leaderboardUsers}
+            matchedIndices={matchedIndices}
+          />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
### Description

***AS IS***
client leaderboard가 refresh 될 때, 리더보드 데이터가 fetch되기 전에 
리더보드에 dummy 값이 들어가는데 이후 데이터가 fetch 되면 리더보드가 주욱 길어지는 모션이 나왔습니다.

>> 콘테스트 진행 동안 클라이언트 리더보드는 대회장 앞에 띄워져 있을 것이고 수시로 새로고침됩니다. 이 때 주욱 길어지는 모션이 
지속적으로 나온다면 대회를 하면서 신경 쓰일 수 있을 것 같아서 모션이 나오지 않도록 수정하였습니다. 

***TO BE***
client leaderboard를 refresh 할 때, 데이터가 fetching 되기 전까지 아예 리더보드를 렌더링하지 않습니다.

> [!Tip]
> 단순합니다! loading 일 때 리더보드 테이블을 렌더링하지 않습니다! 그 부분을 확인해주시면 감사하겠습니다.

closes TAS-1746

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
