### PR TITLE
chore(infra): scale down ecs iris service to 0

### DIFF
--- a/apps/infra/production/codedang/codedang_service_iris.tf
+++ b/apps/infra/production/codedang/codedang_service_iris.tf
@@ -74,11 +74,11 @@ module "iris" {
   ecs_service = {
     name          = "Codedang-Iris-Service"
     cluster_arn   = module.codedang_iris.ecs_cluster.arn
-    desired_count = 2
+    desired_count = 0
   }
 
   appautoscaling_target = {
-    min_capacity = 2
+    min_capacity = 0
     max_capacity = 4
     resource_id = {
       cluster_name = module.codedang_iris.ecs_cluster.name


### PR DESCRIPTION
### Description

Iris를 on-prem 서버로 옮기면서 ECS의 Iris service를 down-scale합니다.
나중에 on-prem 서버에 문제가 생기면 수동으로 숫자 변경 후 terraform apply하면 될 것 같습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
