### PR TITLE
feat(fe): remove score setting when creating or updating exercise

### DIFF
--- a/apps/frontend/app/admin/course/[courseId]/_components/AssignmentProblemTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/_components/AssignmentProblemTable.tsx
@@ -14,7 +14,7 @@ export function AssignmentProblemTable({
   problems,
   setProblems,
   disableInput,
-  isExercise = true
+  isExercise = false
 }: AssignmentProblemTableProps) {
   const columns = useMemo(
     () => createColumns(setProblems, disableInput, isExercise),

--- a/apps/frontend/app/admin/course/[courseId]/_components/AssignmentProblemTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/_components/AssignmentProblemTable.tsx
@@ -7,16 +7,18 @@ interface AssignmentProblemTableProps {
   problems: AssignmentProblem[]
   setProblems: Dispatch<SetStateAction<AssignmentProblem[]>>
   disableInput: boolean
+  isExercise?: boolean
 }
 
 export function AssignmentProblemTable({
   problems,
   setProblems,
-  disableInput
+  disableInput,
+  isExercise = true
 }: AssignmentProblemTableProps) {
   const columns = useMemo(
-    () => createColumns(setProblems, disableInput),
-    [setProblems, disableInput]
+    () => createColumns(setProblems, disableInput, isExercise),
+    [setProblems, disableInput, isExercise]
   )
 
   return (

--- a/apps/frontend/app/admin/course/[courseId]/_components/AssignmentProblemTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/_components/AssignmentProblemTable.tsx
@@ -1,7 +1,8 @@
 import { DataTable, DataTableRoot } from '@/app/admin/_components/table'
 import { useMemo, type Dispatch, type SetStateAction } from 'react'
 import type { AssignmentProblem } from '../_libs/type'
-import { createColumns } from '../assignment/_components/AssignmentProblemColumns'
+import { createAssignmentColumns } from '../assignment/_components/AssignmentProblemColumns'
+import { createExerciseColumns } from '../exercise/_components/ExerciseProblemColumns'
 
 interface AssignmentProblemTableProps {
   problems: AssignmentProblem[]
@@ -17,7 +18,10 @@ export function AssignmentProblemTable({
   isExercise = false
 }: AssignmentProblemTableProps) {
   const columns = useMemo(
-    () => createColumns(setProblems, disableInput, isExercise),
+    () =>
+      isExercise
+        ? createExerciseColumns(setProblems, disableInput)
+        : createAssignmentColumns(setProblems, disableInput),
     [setProblems, disableInput, isExercise]
   )
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentProblemColumns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/_components/AssignmentProblemColumns.tsx
@@ -5,13 +5,18 @@ import { ContainedContests } from '@/app/admin/problem/_components/ContainedCont
 import { Badge } from '@/components/shadcn/badge'
 import { Input } from '@/components/shadcn/input'
 import type { Level } from '@/types/type'
-import type { ColumnDef } from '@tanstack/react-table'
+import type {
+  CellContext,
+  ColumnDef,
+  HeaderContext
+} from '@tanstack/react-table'
 import { toast } from 'sonner'
 import type { AssignmentProblem } from '../../_libs/type'
 
 export const createColumns = (
   setProblems: React.Dispatch<React.SetStateAction<AssignmentProblem[]>>,
-  disableInput: boolean
+  disableInput: boolean,
+  isExercise: boolean
 ): ColumnDef<AssignmentProblem>[] => [
   {
     accessorKey: 'title',
@@ -25,58 +30,66 @@ export const createColumns = (
     enableSorting: false,
     enableHiding: false
   },
-  {
-    accessorKey: 'score',
-    header: () => <p className="text-center text-sm">Score</p>,
-    cell: ({ row }) => (
-      <div
-        className="flex justify-center"
-        onClick={() => {
-          if (disableInput) {
-            toast.error('Problem scoring cannot be edited')
-          }
-        }}
-      >
-        <Input
-          disabled={disableInput}
-          defaultValue={row.getValue('score')}
-          className="hide-spin-button w-[70px] text-center focus-visible:ring-0 disabled:pointer-events-none"
-          type="number"
-          min={0}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              const target = e.target as HTMLInputElement
-              target.blur()
-            }
-          }}
-          onBlur={(event) => {
-            setProblems((prevProblems: AssignmentProblem[]) =>
-              prevProblems.map((problem) =>
-                problem.id === row.original.id
-                  ? { ...problem, score: Number(event.target.value) }
-                  : problem
-              )
-            )
-          }}
-        />
-      </div>
-    ),
-    footer: ({ table }) => (
-      <div className="flex justify-center">
-        <Input
-          disabled={true}
-          className="w-[70px] text-center focus-visible:ring-0"
-          value={table
-            .getCoreRowModel()
-            .rows.map((row) => row.original)
-            .reduce((total, problem) => total + problem.score, 0)}
-        />
-      </div>
-    ),
-    enableSorting: false,
-    enableHiding: false
-  },
+  ...(!isExercise
+    ? [
+        {
+          accessorKey: 'score',
+          header: () => <p className="text-center text-sm">Score</p>,
+          cell: ({ row }: CellContext<AssignmentProblem, unknown>) => (
+            <div
+              className="flex justify-center"
+              onClick={() => {
+                if (disableInput) {
+                  toast.error('Problem scoring cannot be edited')
+                }
+              }}
+            >
+              <Input
+                disabled={disableInput}
+                defaultValue={row.getValue('score')}
+                className="hide-spin-button w-[70px] text-center focus-visible:ring-0 disabled:pointer-events-none"
+                type="number"
+                min={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    const target = e.target as HTMLInputElement
+                    target.blur()
+                  }
+                }}
+                onBlur={(event) => {
+                  setProblems((prevProblems: AssignmentProblem[]) =>
+                    prevProblems.map((problem) =>
+                      problem.id === row.original.id
+                        ? { ...problem, score: Number(event.target.value) }
+                        : problem
+                    )
+                  )
+                }}
+              />
+            </div>
+          ),
+          footer: ({ table }: HeaderContext<AssignmentProblem, unknown>) => (
+            <div className="flex justify-center">
+              <Input
+                disabled={true}
+                className="w-[70px] text-center focus-visible:ring-0"
+                value={table
+                  .getCoreRowModel()
+                  .rows.map((row) => row.original)
+                  .reduce(
+                    (total: number, problem: AssignmentProblem) =>
+                      total + problem.score,
+                    0
+                  )}
+              />
+            </div>
+          ),
+          enableSorting: false,
+          enableHiding: false
+        }
+      ]
+    : []),
   {
     accessorKey: 'order',
     header: () => <p className="text-center text-sm">Order</p>,

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
@@ -78,10 +78,7 @@ export default function Information({ params }: InformationProps) {
                     <TableHead className="bg-gray-50 text-left text-sm font-normal text-gray-500">
                       Title
                     </TableHead>
-                    <TableHead className="w-20 bg-gray-50 text-center text-sm font-normal text-gray-500">
-                      Score
-                    </TableHead>
-                    <TableHead className="w-20 bg-gray-50 text-center text-sm font-normal text-gray-500">
+                    <TableHead className="w-40 bg-gray-50 text-center text-sm font-normal text-gray-500">
                       Solution
                     </TableHead>
                   </TableRow>
@@ -98,29 +95,11 @@ export default function Information({ params }: InformationProps) {
                       <TableCell className="text-left text-sm text-gray-900">
                         {problem.problem.title}
                       </TableCell>
-                      <TableCell className="text-center text-sm text-gray-900">
-                        {problem.score}
-                      </TableCell>
                       <TableCell className="text-center">
                         <FaEye className="inline text-gray-400" />
                       </TableCell>
                     </TableRow>
                   ))}
-                  <TableRow>
-                    <TableCell
-                      colSpan={2}
-                      className="rounded-bl-xl bg-gray-50 text-right text-sm font-semibold text-gray-700"
-                    >
-                      Total
-                    </TableCell>
-                    <TableCell className="text-primary bg-gray-50 text-center text-sm font-semibold">
-                      {problemsData.reduce(
-                        (acc, cur) => acc + (cur.score || 0),
-                        0
-                      )}
-                    </TableCell>
-                    <TableCell className="rounded-br-xl bg-gray-50" />
-                  </TableRow>
                 </TableBody>
               </Table>
             </div>

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/edit/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/edit/page.tsx
@@ -151,6 +151,7 @@ export default function Page({
                   problems={problems}
                   setProblems={setProblems}
                   disableInput={false}
+                  isExercise={true}
                 />
               </div>
 

--- a/apps/frontend/app/admin/course/[courseId]/exercise/_components/ExerciseProblemColumns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/_components/ExerciseProblemColumns.tsx
@@ -3,13 +3,12 @@
 import { OptionSelect } from '@/app/admin/_components/OptionSelect'
 import { ContainedContests } from '@/app/admin/problem/_components/ContainedContests'
 import { Badge } from '@/components/shadcn/badge'
-import { Input } from '@/components/shadcn/input'
 import type { Level } from '@/types/type'
 import type { ColumnDef } from '@tanstack/react-table'
 import { toast } from 'sonner'
 import type { AssignmentProblem } from '../../_libs/type'
 
-export const createAssignmentColumns = (
+export const createExerciseColumns = (
   setProblems: React.Dispatch<React.SetStateAction<AssignmentProblem[]>>,
   disableInput: boolean
 ): ColumnDef<AssignmentProblem>[] => [
@@ -22,58 +21,6 @@ export const createAssignmentColumns = (
       </p>
     ),
     footer: () => <p className="w-[350px] text-left text-sm">Score Sum</p>,
-    enableSorting: false,
-    enableHiding: false
-  },
-  {
-    accessorKey: 'score',
-    header: () => <p className="text-center text-sm">Score</p>,
-    cell: ({ row }) => (
-      <div
-        className="flex justify-center"
-        onClick={() => {
-          if (disableInput) {
-            toast.error('Problem scoring cannot be edited')
-          }
-        }}
-      >
-        <Input
-          disabled={disableInput}
-          defaultValue={row.getValue('score')}
-          className="hide-spin-button w-[70px] text-center focus-visible:ring-0 disabled:pointer-events-none"
-          type="number"
-          min={0}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              const target = e.target as HTMLInputElement
-              target.blur()
-            }
-          }}
-          onBlur={(event) => {
-            setProblems((prevProblems: AssignmentProblem[]) =>
-              prevProblems.map((problem) =>
-                problem.id === row.original.id
-                  ? { ...problem, score: Number(event.target.value) }
-                  : problem
-              )
-            )
-          }}
-        />
-      </div>
-    ),
-    footer: ({ table }) => (
-      <div className="flex justify-center">
-        <Input
-          disabled={true}
-          className="w-[70px] text-center focus-visible:ring-0"
-          value={table
-            .getCoreRowModel()
-            .rows.map((row) => row.original)
-            .reduce((total, problem) => total + problem.score, 0)}
-        />
-      </div>
-    ),
     enableSorting: false,
     enableHiding: false
   },

--- a/apps/frontend/app/admin/course/[courseId]/exercise/create/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/create/page.tsx
@@ -120,6 +120,7 @@ export default function Page({ params }: { params: { courseId: string } }) {
                   problems={problems}
                   setProblems={setProblems}
                   disableInput={false}
+                  isExercise={true}
                 />
               </div>
 

--- a/apps/frontend/graphql/problem/mutations.ts
+++ b/apps/frontend/graphql/problem/mutations.ts
@@ -15,10 +15,6 @@ const CREATE_PROBLEM = gql(`
       description
       inputDescription
       outputDescription
-      problemTestcase {
-        input
-        output
-      }
       timeLimit
       memoryLimit
       hint
@@ -46,10 +42,6 @@ const UPDATE_PROBLEM = gql(`
       description
       inputDescription
       outputDescription
-      problemTestcase {
-        input
-        output
-      }
       timeLimit
       memoryLimit
       hint


### PR DESCRIPTION
> [!Note]
> AssignmentProblemTable 컴포넌트에서 isExercise를 통해 로직을 분기했습니다. 
> isExercise에 따라 createExerciseColumns / createAssignmentColumns이 호출됩니다.

> [!IMPORTANT]  
> Create Exercise, Edit Exercise, Exercise Detail에 적용되는 변경사항입니다.

![image](https://github.com/user-attachments/assets/9cb51087-9b0e-4b38-af55-ded0aedb07fa)
![image](https://github.com/user-attachments/assets/2bbe72f2-1c86-47a7-aee3-c9e2ae1e68bf)



### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1771
