### PR TITLE
fix(ci): bitnami minio container does not start properly

### DIFF
--- a/apps/backend/mocha-fixture.ts
+++ b/apps/backend/mocha-fixture.ts
@@ -1,4 +1,3 @@
-// random change to trigger test-backend
 import { use } from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 


### PR DESCRIPTION
### Description

며칠 전부터 `test-backend` CI가 제대로 동작하지 않는 이슈가 있습니다.
분석 결과 `test-backend` job에서 쓰이는 `bitnami/minio`가 다음과 같은 로그와 함께 제대로 동작하지 않았습니다.

```
/usr/bin/docker logs --details 01df0c29260fbcdbf7a5295d205901f1bcb204dac1ddd99887c0211ed97d8119
  08:16:45.45 INFO  ==> 
  08:16:45.45 INFO  ==> Welcome to the Bitnami minio container
  08:16:45.45 INFO  ==> Subscribe to project updates by watching https://github.com/bitnami/containers
  08:16:45.45 INFO  ==> Did you know there are enterprise versions of the Bitnami catalog? For enhanced secure software supply chain features, unlimited pulls from Docker, LTS support, or application customization, see Bitnami Premium or Tanzu Application Catalog. See https://www.arrow.com/globalecs/na/vendors/bitnami/ for more information.
  08:16:45.45 INFO  ==> 
  08:16:45.45 INFO  ==> ** Starting MinIO setup **
 minio 08:16:45.49 INFO  ==> Starting MinIO in background...
 minio 08:16:50.52 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:16:55.55 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:00.59 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:05.62 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:10.68 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:15.[72](https://github.com/skkuding/codedang/actions/runs/15361830002/job/43229926932?pr=2818#step:18:72) INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:20.75 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:25.78 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:30.81 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:35.84 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:40.87 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:45.90 INFO  ==> Adding local Minio host to 'mc' configuration...
 minio 08:17:50.97 INFO  ==> MinIO is already stopped...
 Failed to add temporary MinIO server
```

9일 전 push된 `bitnami/minio:latest` 이미지에서 발생되는 에러로 보이고, 해당 repo에도 이슈가 올라가있습니다.
https://github.com/bitnami/containers/issues/81869

일단 임시 해결방안으로 이전(2025.4.8)에 push된 이미지를 사용합니다.

### Additional context

`test-backend` CI 실행 후 pass 확인했습니다.
https://github.com/skkuding/codedang/actions/runs/15414022404/job/43372444546?pr=2829

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
