### PR TITLE
refactor(be): replace gql query names with model names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             frontend:
               - 'apps/frontend/**'
               - 'pnpm-lock.yaml'
+              - 'apps/backend/schema.gql'
 
       - uses: ./.github/actions/setup-pnpm
         if: steps.filter.outputs.frontend == 'true'

--- a/apps/backend/apps/admin/src/announcement/announcement.resolver.ts
+++ b/apps/backend/apps/admin/src/announcement/announcement.resolver.ts
@@ -20,17 +20,27 @@ export class AnnouncementResolver {
     return await this.announcementService.createAnnouncement(contestId, input)
   }
 
-  @Query(() => [AnnouncementWithProblemOrder], {
-    name: 'announcementByContestId'
-  })
-  async getAnnouncementsByContestId(
+  // TODO: Put this query under contest resolver as @ResolveField
+  // contest(id: number) {
+  //   announcements {
+  //     ...
+  //   }
+  // }
+  @Query(() => [AnnouncementWithProblemOrder])
+  async announcements(
     @Args('contestId', { type: () => Int }) contestId: number
   ) {
     return await this.announcementService.getAnnouncementsByContestId(contestId)
   }
 
-  @Query(() => Announcement, { name: 'announcement' })
-  async getAnnouncementById(
+  // TODO: Put this query under contest resolver as @ResolveField
+  // contest(id: number) {
+  //   announcement(id: number) {
+  //     ...
+  //   }
+  // }
+  @Query(() => Announcement)
+  async announcement(
     @Args('contestId', { type: () => Int }) contestId: number,
     @Args('id', { type: () => Int }) id: number
   ) {

--- a/apps/backend/apps/admin/src/assignment/assignment-problem.resolver.ts
+++ b/apps/backend/apps/admin/src/assignment/assignment-problem.resolver.ts
@@ -76,8 +76,8 @@ export class AssignmentProblemResolver {
     )
   }
 
-  @ResolveField('problem', () => ProblemWithIsVisible)
-  async getProblem(@Parent() assignmentProblem: AssignmentProblem) {
+  @ResolveField(() => ProblemWithIsVisible)
+  async problem(@Parent() assignmentProblem: AssignmentProblem) {
     return await this.problemService.getProblemById(assignmentProblem.problemId)
   }
 }

--- a/apps/backend/apps/admin/src/assignment/assignment.resolver.ts
+++ b/apps/backend/apps/admin/src/assignment/assignment.resolver.ts
@@ -32,8 +32,14 @@ import { UserAssignmentScoreSummaryWithUserInfo } from './model/score-summary'
 export class AssignmentResolver {
   constructor(private readonly assignmentService: AssignmentService) {}
 
+  // TODO: Put this query under group resolver as @ResolveField
+  // group(id: number) {
+  //   assignments {
+  //     ...
+  //   }
+  // }
   @Query(() => [AssignmentWithParticipants])
-  async getAssignments(
+  async assignments(
     @Args(
       'take',
       { type: () => Int, defaultValue: 10 },
@@ -58,8 +64,14 @@ export class AssignmentResolver {
     )
   }
 
+  // TODO: Put this query under group resolver as @ResolveField
+  // group(id: number) {
+  //   assignment(id: number) {
+  //     ...
+  //   }
+  // }
   @Query(() => AssignmentWithParticipants)
-  async getAssignment(
+  async assignment(
     @Args(
       'assignmentId',
       { type: () => Int },
@@ -136,6 +148,14 @@ export class AssignmentResolver {
    * Assignment Overall 페이지에서 특정 유저를 선택했을 때 사용
    * @see https://github.com/skkuding/codedang/pull/1894
    */
+  // TODO: Put this query under group resolver as @ResolveField
+  // group(id: number) {
+  //   user(id: number) {
+  //     assignment(id: number) {
+  //       ...
+  //     }
+  //   }
+  // }
   @Query(() => AssignmentSubmissionSummaryForUser)
   async getAssignmentSubmissionSummaryByUserId(
     @Args('assignmentId', { type: () => Int }, IDValidationPipe)
@@ -182,6 +202,14 @@ export class AssignmentResolver {
    * Assignment Overall 페이지의 Participants 탭의 정보
    * @see https://github.com/skkuding/codedang/pull/2029
    */
+  // TODO: Put this query under group resolver as @ResolveField
+  // group(id: number) {
+  //   assignment(id: number) {
+  //     scoreSummaries {
+  //       ...
+  //     }
+  //   }
+  // }
   @Query(() => [UserAssignmentScoreSummaryWithUserInfo])
   async getAssignmentScoreSummaries(
     @Args(
@@ -207,6 +235,12 @@ export class AssignmentResolver {
     )
   }
 
+  // TODO: Put this query under problem resolver as @ResolveField
+  // problem(id: number) {
+  //   assignments {
+  //     ...
+  //   }
+  // }
   @Query(() => AssignmentsGroupedByStatus)
   @UseDisableAdminGuard()
   async getAssignmentsByProblemId(
@@ -230,6 +264,18 @@ export class AssignmentResolver {
     )
   }
 
+  // TODO: Put this query under group resolver as @ResolveField
+  // group(id: number) {
+  //   user(id: number) {
+  //     assignment(id: number) {
+  //       problem(id: number) {
+  //         record(id: number) {
+  //           ...
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
   @Query(() => AssignmentProblemRecord)
   async getAssignmentProblemRecord(
     @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number,

--- a/apps/backend/apps/admin/src/contest/contest-problem.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest-problem.resolver.ts
@@ -25,6 +25,7 @@ export class ContestProblemResolver {
     private readonly problemService: ProblemService
   ) {}
 
+  // TODO: move to contest resolver as @ResolveField
   @Query(() => [ContestProblem], { name: 'getContestProblems' })
   async getContestProblems(
     @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
@@ -59,8 +60,8 @@ export class ContestProblemResolver {
     )
   }
 
-  @ResolveField('problem', () => ProblemWithIsVisible)
-  async getProblem(@Parent() contestProblem: ContestProblem) {
+  @ResolveField(() => ProblemWithIsVisible)
+  async problem(@Parent() contestProblem: ContestProblem) {
     return await this.problemService.getProblemById(contestProblem.problemId)
   }
 }

--- a/apps/backend/apps/admin/src/contest/contest.resolver.ts
+++ b/apps/backend/apps/admin/src/contest/contest.resolver.ts
@@ -42,7 +42,7 @@ export class ContestResolver {
 
   @Query(() => [ContestWithParticipants])
   @UseDisableContestRolesGuard()
-  async getContests(
+  async contests(
     @Args(
       'take',
       { type: () => Int, defaultValue: 10 },
@@ -57,8 +57,8 @@ export class ContestResolver {
   }
 
   @Query(() => ContestWithParticipants)
-  async getContest(
-    @Args('contestId', { type: () => Int }, new RequiredIntPipe('contestId'))
+  async contest(
+    @Args('id', { type: () => Int }, new RequiredIntPipe('id'))
     contestId: number
   ) {
     return await this.contestService.getContest(contestId)
@@ -148,6 +148,12 @@ export class ContestResolver {
    * Contest Overall 페이지의 Participants 탭의 정보
    * @see https://github.com/skkuding/codedang/pull/2029
    */
+  // TODO: Put this query under contest resolver as @ResolveField
+  // contest(id: number) {
+  //   participants {
+  //     ...
+  //   }
+  // }
   @Query(() => [UserContestScoreSummaryWithUserInfo])
   async getContestScoreSummaries(
     @Args('contestId', { type: () => Int, nullable: false }, IDValidationPipe)
@@ -167,6 +173,12 @@ export class ContestResolver {
     })
   }
 
+  // TODO: Put this query under problem resolver as @ResolveField
+  // problem(id: number) {
+  //   contests {
+  //     ...
+  //   }
+  // }
   @Query(() => ContestsGroupedByStatus)
   @UseDisableContestRolesGuard()
   async getContestsByProblemId(
@@ -175,6 +187,12 @@ export class ContestResolver {
     return await this.contestService.getContestsByProblemId(problemId)
   }
 
+  // TODO: Put this query under contest resolver as @ResolveField
+  // contest(id: number) {
+  //   leaderboard {
+  //     ...
+  //   }
+  // }
   @Query(() => ContestLeaderboard)
   async getContestLeaderboard(
     @Args('contestId', { type: () => Int }) contestId: number
@@ -182,6 +200,12 @@ export class ContestResolver {
     return this.contestService.getContestLeaderboard(contestId)
   }
 
+  // TODO: Put this query under contest resolver as @ResolveField
+  // contest(id: number) {
+  //   updateHistories {
+  //     ...
+  //   }
+  // }
   @Query(() => ContestUpdateHistories)
   async getContestUpdateHistories(
     @Args('contestId', { type: () => Int }) contestId: number
@@ -189,14 +213,20 @@ export class ContestResolver {
     return await this.contestService.getContestUpdateHistories(contestId)
   }
 
+  // TODO: Put this query under contest resolver as @ResolveField
+  // contest(id: number) {
+  //   roles {
+  //     ...
+  //   }
+  // }
   @Query(() => [UserContest])
   @UseDisableContestRolesGuard()
   async getContestRoles(@Context('req') req: AuthenticatedRequest) {
     return await this.contestService.getContestRoles(req.user.id)
   }
 
-  @ResolveField('createdBy', () => User, { nullable: true })
-  async getUser(@Parent() contest: Contest) {
+  @ResolveField(() => User, { nullable: true })
+  async createdBy(@Parent() contest: Contest) {
     const { createdById } = contest
     if (createdById == null) {
       return null

--- a/apps/backend/apps/admin/src/group/group.resolver.ts
+++ b/apps/backend/apps/admin/src/group/group.resolver.ts
@@ -64,7 +64,7 @@ export class GroupResolver {
   }
 
   @Query(() => [FindGroup])
-  async getCourses(
+  async courses(
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
     @Args('take', { defaultValue: 10, type: () => Int }) take: number
@@ -74,9 +74,7 @@ export class GroupResolver {
 
   @Query(() => FindGroup)
   @UseGroupLeaderGuard()
-  async getCourse(
-    @Args('groupId', { type: () => Int }, GroupIDPipe) id: number
-  ) {
+  async course(@Args('groupId', { type: () => Int }, GroupIDPipe) id: number) {
     return await this.groupService.getCourse(id)
   }
 }

--- a/apps/backend/apps/admin/src/notice/notice.resolver.ts
+++ b/apps/backend/apps/admin/src/notice/notice.resolver.ts
@@ -50,14 +50,14 @@ export class NoticeResolver {
   }
 
   @Query(() => Notice)
-  async getNotice(
+  async notice(
     @Args('noticeId', { type: () => Int }, IDValidationPipe) noticeId: number
   ) {
     return await this.noticeService.getNotice(noticeId)
   }
 
   @Query(() => [Notice], { nullable: 'items' })
-  async getNotices(
+  async notices(
     @Args('cursor', { type: () => Int, nullable: true }, CursorValidationPipe)
     cursor: number | null,
     @Args('take', { type: () => Int, defaultValue: 10 })
@@ -66,8 +66,8 @@ export class NoticeResolver {
     return await this.noticeService.getNotices(cursor, take)
   }
 
-  @ResolveField('createdBy', () => User, { nullable: true })
-  async getUser(@Parent() notice: Notice) {
+  @ResolveField(() => User, { nullable: true })
+  async createdBy(@Parent() notice: Notice) {
     const { createdById } = notice
     if (createdById == null) {
       return null

--- a/apps/backend/apps/admin/src/problem/resolvers/problem-tag.resolver.ts
+++ b/apps/backend/apps/admin/src/problem/resolvers/problem-tag.resolver.ts
@@ -16,8 +16,8 @@ export class ProblemTagResolver {
 
   constructor(private readonly tagService: TagService) {}
 
-  @ResolveField('tag', () => Tag)
-  async getTag(@Parent() problemTag: ProblemTag) {
+  @ResolveField(() => Tag)
+  async tag(@Parent() problemTag: ProblemTag) {
     try {
       return await this.tagService.getTag(problemTag.tagId)
     } catch (error) {
@@ -47,7 +47,7 @@ export class TagResolver {
   }
 
   @Query(() => [Tag])
-  async getTags() {
+  async tags() {
     return await this.tagService.getTags()
   }
 }

--- a/apps/backend/apps/admin/src/problem/resolvers/problem.resolver.ts
+++ b/apps/backend/apps/admin/src/problem/resolvers/problem.resolver.ts
@@ -60,7 +60,7 @@ export class ProblemResolver {
   }
 
   @Query(() => [ProblemWithIsVisible])
-  async getProblems(
+  async problems(
     @Context('req') req: AuthenticatedRequest,
     @Args('input') input: FilterProblemsInput,
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
@@ -81,30 +81,30 @@ export class ProblemResolver {
   }
 
   @Query(() => ProblemWithIsVisible)
-  async getProblem(
+  async problem(
     @Context('req') req: AuthenticatedRequest,
     @Args('id', { type: () => Int }, new RequiredIntPipe('id')) id: number
   ) {
     return await this.problemService.getProblem(id, req.user.role, req.user.id)
   }
 
-  @ResolveField('updateHistory', () => [UpdateHistory])
-  async getProblemUpdateHistory(@Parent() problem: ProblemWithIsVisible) {
+  @ResolveField(() => [UpdateHistory])
+  async updateHistory(@Parent() problem: ProblemWithIsVisible) {
     return await this.problemService.getProblemUpdateHistory(problem.id)
   }
 
-  @ResolveField('sharedGroups', () => [Group])
-  async getSharedGroups(@Parent() problem: ProblemWithIsVisible) {
+  @ResolveField(() => [Group])
+  async sharedGroups(@Parent() problem: ProblemWithIsVisible) {
     return await this.problemService.getSharedGroups(problem.id)
   }
 
-  @ResolveField('tag', () => [ProblemTag])
-  async getProblemTags(@Parent() problem: ProblemWithIsVisible) {
+  @ResolveField(() => [ProblemTag])
+  async tag(@Parent() problem: ProblemWithIsVisible) {
     return await this.tagService.getProblemTags(problem.id)
   }
 
-  @ResolveField('testcase', () => [ProblemTestcase])
-  async getProblemTestCases(@Parent() problem: ProblemWithIsVisible) {
+  @ResolveField(() => [ProblemTestcase])
+  async testcase(@Parent() problem: ProblemWithIsVisible) {
     return await this.testcaseService.getProblemTestcases(problem.id)
   }
 

--- a/apps/backend/apps/admin/src/submission/submission.resolver.ts
+++ b/apps/backend/apps/admin/src/submission/submission.resolver.ts
@@ -36,6 +36,12 @@ export class SubmissionResolver {
    * @param take 불러올 제출 내역의 수
    * @returns {SubmissionsWithTotal}
    */
+  // TODO: move to ProblemResolver @ResolveField
+  // problem(id: number) {
+  //   submissions {
+  //     ...
+  //   }
+  // }
   @Query(() => SubmissionsWithTotal)
   async getSubmissions(
     @Args('problemId', { type: () => Int }, new RequiredIntPipe('problemId'))
@@ -54,6 +60,12 @@ export class SubmissionResolver {
    * Contest Overall page의 'All submission' 탭에서 보여지는 정보를 불러오는 API
    * @see {@link https://github.com/skkuding/codedang/pull/1924}
    */
+  // TODO: move to ContestResolver @ResolveField
+  // contest(id: number) {
+  //   submissions {
+  //     ...
+  //   }
+  // }
   @Query(() => [ContestSubmission])
   @UseContestRolesGuard(ContestRole.Manager)
   async getContestSubmissions(
@@ -86,6 +98,16 @@ export class SubmissionResolver {
    * Assignment Overall page의 'All submission' 탭에서 보여지는 정보를 불러오는 API
    * https://github.com/skkuding/codedang/pull/1924
    */
+  // TODO: move to AssignmentResolver @ResolveField
+  // group(id: number) {
+  //   assignment(id: number) {
+  //     problem(id: number) {
+  //       submissions {
+  //         ...
+  //       }
+  //     }
+  //   }
+  // }
   @Query(() => [AssignmentSubmission])
   @UseGroupLeaderGuard()
   async getAssignmentSubmissions(
@@ -132,7 +154,7 @@ export class SubmissionResolver {
    */
   @Query(() => SubmissionDetail)
   @UseDisableAdminGuard()
-  async getSubmission(
+  async submission(
     @Args('id', { type: () => Int }) id: number,
     @Context('req') req: AuthenticatedRequest
   ): Promise<SubmissionDetail> {
@@ -146,6 +168,14 @@ export class SubmissionResolver {
    * @param problemId AssignmentProblemRecode을 조회할 problemID
    * @returns {string} 압축 파일을 다운로드 할 수 있는 URL
    */
+  // TODO: move to AssignmentResolver @ResolveField
+  // group(id: number) {
+  //   assignment(id: number) {
+  //     problem(id: number) {
+  //       submissionZipUrl
+  //     }
+  //   }
+  // }
   @Query(() => String, { nullable: true })
   @UseGroupLeaderGuard()
   async compressSourceCodes(

--- a/apps/backend/apps/admin/src/user/user.resolver.ts
+++ b/apps/backend/apps/admin/src/user/user.resolver.ts
@@ -47,7 +47,7 @@ export class UserResolver {
   }
 
   @Query(() => [User])
-  async getUsers(
+  async users(
     @Args('cursor', { nullable: true, type: () => Int }, CursorValidationPipe)
     cursor: number | null,
     @Args(
@@ -78,6 +78,12 @@ export class GroupMemberResolver {
    * @param {boolean} leaderOnly - 그룹의 리더만 필터링 해주는 플래그. 기본 값은 false
    * @returns {Promise<GroupMember[]>} - 그룹 멤버 리스트를 리턴함.
    */
+  // TODO: move to GroupResolver @ResolveField
+  // group(id: number) {
+  //   users {
+  //     ...
+  //   }
+  // }
   @Query(() => [GroupMember])
   async getGroupMembers(
     @Args('groupId', { type: () => Int }, GroupIDPipe)
@@ -107,6 +113,12 @@ export class GroupMemberResolver {
    * @param {number} userId - 조회할 사용자의 ID.
    * @returns {Promise<GroupMember>} 그룹 멤버 객체를 리턴함.
    */
+  // TODO: move to GroupResolver @ResolveField
+  // group(id: number) {
+  //   user(id: number) {
+  //     ...
+  //   }
+  // }
   @Query(() => GroupMember)
   async getGroupMember(
     @Args('groupId', { type: () => Int }, GroupIDPipe)
@@ -159,6 +171,12 @@ export class GroupMemberResolver {
    * @param {number} groupId - 특정 그룹의 id.
    * @returns {Promise<User[]>} 가입 요청한 유저 리스트를 리턴.
    */
+  // TODO: move to GroupResolver @ResolveField
+  // group(id: number) {
+  //   joinRequests {
+  //     ...
+  //   }
+  // }
   @Query(() => [User])
   async getJoinRequests(
     @Args('groupId', { type: () => Int }, GroupIDPipe) groupId: number

--- a/apps/backend/apps/admin/src/workbook/workbook-problem.resolver.ts
+++ b/apps/backend/apps/admin/src/workbook/workbook-problem.resolver.ts
@@ -23,6 +23,12 @@ export class WorkbookProblemResolver {
     private readonly problemService: ProblemService
   ) {}
 
+  // TODO: move to workbook resolver
+  // workbook(id: number) {
+  //   problems {
+  //     ...
+  //   }
+  // }
   @Query(() => [WorkbookProblem], { name: 'getWorkbookProblems' })
   async getWorkbookProblems(
     @Args('groupId', { type: () => Int }, GroupIDPipe)
@@ -50,8 +56,8 @@ export class WorkbookProblemResolver {
     )
   }
 
-  @ResolveField('problem', () => ProblemWithIsVisible)
-  async getProblem(@Parent() workbookProblem: WorkbookProblem) {
+  @ResolveField(() => ProblemWithIsVisible)
+  async problem(@Parent() workbookProblem: WorkbookProblem) {
     return await this.problemService.getProblemById(workbookProblem.problemId)
   }
 }

--- a/apps/backend/schema.gql
+++ b/apps/backend/schema.gql
@@ -1942,7 +1942,7 @@ type ProblemWithIsVisible {
   outputDescription: String!
   problemTag: [ProblemTag!]
   problemTestcase: [ProblemTestcase!]
-  sharedGroups: [Group!]!
+  sharedGroups: [Group!]
   solution: [JSON!]
   source: String!
   submission: [Submission!]
@@ -1965,7 +1965,7 @@ type ProblemWithIsVisible {
   testcase: [ProblemTestcase!]!
   timeLimit: Int!
   title: String!
-  updateHistory: [UpdateHistory!]!
+  updateHistory: [UpdateHistory!]
   updateTime: DateTime!
   workbookProblem: [WorkbookProblem!]
 }
@@ -1980,17 +1980,18 @@ enum Provider {
 type Query {
   announcement(contestId: Int!, id: Int!): Announcement!
   announcementByContestId(contestId: Int!): [AnnouncementWithProblemOrder!]!
+  assignment(assignmentId: Int!, groupId: Int!): AssignmentWithParticipants!
+  assignments(cursor: Int, groupId: Int!, isExercise: Boolean, take: Int! = 10): [AssignmentWithParticipants!]!
   compressSourceCodes(assignmentId: Int!, groupId: Int!, problemId: Int!): String
-  getAssignment(assignmentId: Int!, groupId: Int!): AssignmentWithParticipants!
+  contest(id: Int!): ContestWithParticipants!
+  contests(cursor: Int, take: Int! = 10): [ContestWithParticipants!]!
   getAssignmentLatestSubmission(assignmentId: Int!, groupId: Int!, problemId: Int!, userId: Int!): SubmissionDetail!
   getAssignmentProblemRecord(assignmentId: Int!, groupId: Int!, problemId: Int!, userId: Int!): AssignmentProblemRecord!
   getAssignmentProblems(assignmentId: Int!, groupId: Int!): [AssignmentProblem!]!
   getAssignmentScoreSummaries(assignmentId: Int!, cursor: Int, groupId: Int!, searchingName: String, take: Int! = 10): [UserAssignmentScoreSummaryWithUserInfo!]!
   getAssignmentSubmissionSummaryByUserId(assignmentId: Int!, cursor: Int, groupId: Int!, problemId: Int, take: Int! = 10, userId: Int!): AssignmentSubmissionSummaryForUser!
   getAssignmentSubmissions(cursor: Int, groupId: Int!, input: GetAssignmentSubmissionsInput!, order: String, take: Int = 10): [AssignmentSubmission!]!
-  getAssignments(cursor: Int, groupId: Int!, isExercise: Boolean, take: Int! = 10): [AssignmentWithParticipants!]!
   getAssignmentsByProblemId(problemId: Int!): AssignmentsGroupedByStatus!
-  getContest(contestId: Int!): ContestWithParticipants!
   getContestLeaderboard(contestId: Int!): ContestLeaderboard!
   getContestProblems(contestId: Int!): [ContestProblem!]!
   getContestRoles: [UserContest!]!
@@ -1998,7 +1999,6 @@ type Query {
   getContestSubmissionSummaryByUserId(contestId: Int!, cursor: Int, problemId: Int, take: Int! = 10, userId: Int!): ContestSubmissionSummaryForUser!
   getContestSubmissions(contestId: Int!, cursor: Int, input: GetContestSubmissionsInput!, order: String, take: Int = 10): [ContestSubmission!]!
   getContestUpdateHistories(contestId: Int!): ContestUpdateHistories!
-  getContests(cursor: Int, take: Int! = 10): [ContestWithParticipants!]!
   getContestsByProblemId(problemId: Int!): ContestsGroupedByStatus!
   getCourse(groupId: Int!): FindGroup!
   getCourses(cursor: Int, take: Int! = 10): [FindGroup!]!
@@ -2008,15 +2008,15 @@ type Query {
   getJoinRequests(groupId: Int!): [User!]!
   getNotice(noticeId: Int!): Notice!
   getNotices(cursor: Int, take: Int! = 10): [Notice]!
-  getProblem(id: Int!): ProblemWithIsVisible!
-  getProblems(contestId: Int, cursor: Int, input: FilterProblemsInput!, mode: String!, take: Int! = 10): [ProblemWithIsVisible!]!
   getSubmission(id: Int!): SubmissionDetail!
   getSubmissions(cursor: Int, problemId: Int!, take: Int = 10): SubmissionsWithTotal!
-  getTags: [Tag!]!
   getUserByEmailOrStudentId(email: String, groupId: Int!, studentId: String): [User!]!
   getUsers(cursor: Int, take: Int! = 10): [User!]!
   getWhitelist(groupId: Int!): [String!]!
   getWorkbookProblems(groupId: Int!, workbookId: Int!): [WorkbookProblem!]!
+  problem(id: Int!): ProblemWithIsVisible!
+  problems(contestId: Int, cursor: Int, input: FilterProblemsInput!, mode: String!, take: Int! = 10): [ProblemWithIsVisible!]!
+  tags: [Tag!]!
 }
 
 enum ResultStatus {

--- a/apps/frontend/app/admin/_components/AdminContestStatusTimeDiff.tsx
+++ b/apps/frontend/app/admin/_components/AdminContestStatusTimeDiff.tsx
@@ -15,7 +15,7 @@ import { toast } from 'sonner'
 dayjs.extend(duration)
 
 interface AdminTimeDiffProps {
-  contest: GetContestQuery['getContest'] | undefined
+  contest: GetContestQuery['contest'] | undefined
   textStyle: string
   inContestEditor: boolean
 }

--- a/apps/frontend/app/admin/_components/code-editor/EditorLayout.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/EditorLayout.tsx
@@ -33,7 +33,7 @@ export function EditorLayout({
       groupId: courseId,
       assignmentId
     }
-  }).data.getAssignment
+  }).data.assignment
 
   const { data } = useQuery(GET_ASSIGNMENT_LATEST_SUBMISSION, {
     variables: {

--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
@@ -44,12 +44,12 @@ export default function ContestLeaderBoard() {
 
   const [disableLeaderboard, setDisableLeaderboard] = useState<boolean>(true)
   const { data: fetchedContest } = useSuspenseQuery(GET_CONTEST, {
-    variables: { contestId }
+    variables: { id: contestId }
   })
 
   const now = new Date()
   useEffect(() => {
-    const endTime = new Date(fetchedContest.getContest.endTime)
+    const endTime = new Date(fetchedContest.contest.endTime)
     if (endTime > now) {
       setDisableLeaderboard(true)
     } else {
@@ -65,7 +65,7 @@ export default function ContestLeaderBoard() {
 
   useEffect(() => {
     if (contestLeaderboard.getContestLeaderboard.leaderboard[0] === undefined) {
-      const contestStartTime = new Date(fetchedContest.getContest.startTime)
+      const contestStartTime = new Date(fetchedContest.contest.startTime)
       if (contestStartTime > now) {
         throw new Error(
           'Error(before start): There is no data in leaderboard yet.'

--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/layout.tsx
@@ -23,9 +23,9 @@ export default function Layout({
 
   const contestData = useQuery(GET_CONTEST, {
     variables: {
-      contestId: Number(contestId)
+      id: Number(contestId)
     }
-  }).data?.getContest
+  }).data?.contest
 
   return (
     <main className="flex flex-col px-20 py-16">

--- a/apps/frontend/app/admin/contest/[contestId]/_components/SubmissionDetailAdmin.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/SubmissionDetailAdmin.tsx
@@ -43,7 +43,7 @@ export function SubmissionDetailAdmin({
     useLazyQuery(GET_PROBLEM_TESTCASE)
 
   const { correctTestcases, wrongTestcases } = (() => {
-    if (!testcaseData?.getProblem?.testcase || !submission?.testcaseResult) {
+    if (!testcaseData?.problem?.testcase || !submission?.testcaseResult) {
       return { correctTestcases: [], wrongTestcases: [] }
     }
 
@@ -53,7 +53,7 @@ export function SubmissionDetailAdmin({
     const correct: string[] = []
     const wrong: string[] = []
 
-    testcaseData.getProblem.testcase.forEach((testcase, index) => {
+    testcaseData.problem.testcase.forEach((testcase, index) => {
       const label = testcase.isHidden
         ? `Hidden #${hiddenIndex++}`
         : `Sample #${sampleIndex++}`
@@ -133,7 +133,7 @@ export function SubmissionDetailAdmin({
                     <td className="w-52 py-1">Correct Testcase:</td>
                     <td className="py-1 text-slate-500">
                       {correctTestcases.length}/
-                      {testcaseData?.getProblem?.testcase?.length || 0}
+                      {testcaseData?.problem?.testcase?.length || 0}
                     </td>
                   </tr>
                   {wrongTestcases.length > 0 && (
@@ -175,7 +175,7 @@ export function SubmissionDetailAdmin({
                     let sampleIndex = 1
                     let hiddenIndex = 1
 
-                    return testcaseData?.getProblem?.testcase?.map(
+                    return testcaseData?.problem?.testcase?.map(
                       (testcase, index) => {
                         const matchingResult = submission?.testcaseResult[index]
                         const label = testcase.isHidden

--- a/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/edit/_components/EditContestForm.tsx
@@ -58,13 +58,13 @@ export function EditContestForm({
   methods.setValue('userContest', formattedManagers)
 
   const { data: contestData } = useQuery(GET_CONTEST, {
-    variables: { contestId }
+    variables: { id: contestId }
   })
   // NOTE: 기존 useQuery의 onCompleted 대신 useEffect를 사용하여 managers와 problems를 업데이트.
   // useQuery는 내부적으로 비동기 처리이기 때문에, 컴포넌트가 렌더링되기도 전에 onCompleted 콜백이 실행될 수 있음(콘솔 경고 뜸).
   useEffect(() => {
     if (contestData) {
-      const data = contestData.getContest
+      const data = contestData.contest
       methods.reset({
         title: data.title,
         description: data.description,

--- a/apps/frontend/app/admin/contest/_components/ContestTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ContestTable.tsx
@@ -27,7 +27,7 @@ export function ContestTable() {
     }
   })
 
-  const contests = data.getContests.map((contest) => ({
+  const contests = data.contests.map((contest) => ({
     ...contest,
     id: Number(contest.id)
   }))

--- a/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/contest/_components/ImportProblemTable.tsx
@@ -49,7 +49,7 @@ export function ImportProblemTable({
     }
   })
 
-  const problems = data.getProblems.map((problem) => ({
+  const problems = data.problems.map((problem) => ({
     ...problem,
     id: Number(problem.id),
     isVisible: problem.isVisible !== undefined ? problem.isVisible : null,

--- a/apps/frontend/app/admin/course/[courseId]/_components/EditAssignmentForm.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/_components/EditAssignmentForm.tsx
@@ -59,7 +59,7 @@ export function EditAssignmentForm({
   useQuery(GET_ASSIGNMENT, {
     variables: { groupId: courseId, assignmentId },
     onCompleted: (assignmentData) => {
-      const data = assignmentData.getAssignment
+      const data = assignmentData.assignment
       methods.reset({
         id: assignmentId,
         title: data.title,

--- a/apps/frontend/app/admin/course/[courseId]/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/_components/ParticipantTable.tsx
@@ -125,7 +125,7 @@ export function ParticipantTable({ isExercise }: ParticipantTableProps) {
     }) || []
 
   // 5. 과제 제목 → 파일명 생성
-  const assignmentTitle = assignmentData?.getAssignments.find(
+  const assignmentTitle = assignmentData?.assignments.find(
     (assignment) => assignment.id === assignmentId.toString()
   )?.title
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/GradeAssignmentTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/GradeAssignmentTable.tsx
@@ -30,7 +30,7 @@ export function GradeAssignmentTable({ groupId }: AssignmentTableProps) {
     }
   })
 
-  const assignments = data.getAssignments.map((assignment) => ({
+  const assignments = data.assignments.map((assignment) => ({
     ...assignment,
     id: Number(assignment.id)
   }))

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
@@ -36,7 +36,7 @@ export function ParticipantTable({
       groupId,
       assignmentId
     }
-  }).data?.getAssignment
+  }).data?.assignment
 
   const [updateAssignment] = useMutation(UPDATE_ASSIGNMENT)
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/page.tsx
@@ -30,7 +30,7 @@ export default function Information({ params }: InformationProps) {
       groupId: Number(params.courseId),
       assignmentId: Number(params.assignmentId)
     }
-  }).data?.getAssignment
+  }).data?.assignment
 
   const problemsData =
     useSuspenseQuery(GET_ASSIGNMENT_PROBLEMS, {

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/layout.tsx
@@ -17,7 +17,7 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
       groupId: Number(courseId),
       assignmentId: Number(assignmentId)
     }
-  }).data?.getAssignment
+  }).data?.assignment
 
   return (
     <main className="flex flex-col gap-6 px-20 py-16">

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/_components/SubmissionDetailAdmin.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/_components/SubmissionDetailAdmin.tsx
@@ -41,7 +41,7 @@ export function SubmissionDetailAdmin({
     useLazyQuery(GET_PROBLEM_TESTCASE)
 
   const { correctTestcases, wrongTestcases } = (() => {
-    if (!testcaseData?.getProblem?.testcase || !submission?.testcaseResult) {
+    if (!testcaseData?.problem?.testcase || !submission?.testcaseResult) {
       return { correctTestcases: [], wrongTestcases: [] }
     }
 
@@ -51,7 +51,7 @@ export function SubmissionDetailAdmin({
     const correct: string[] = []
     const wrong: string[] = []
 
-    testcaseData.getProblem.testcase.forEach((testcase, index) => {
+    testcaseData.problem.testcase.forEach((testcase, index) => {
       const label = testcase.isHidden
         ? `Hidden #${hiddenIndex++}`
         : `Sample #${sampleIndex++}`
@@ -137,7 +137,7 @@ export function SubmissionDetailAdmin({
                     <td className="w-52 py-1">Correct Testcase:</td>
                     <td className="py-1 text-slate-500">
                       {correctTestcases.length}/
-                      {testcaseData?.getProblem?.testcase?.length || 0}
+                      {testcaseData?.problem?.testcase?.length || 0}
                     </td>
                   </tr>
                   {wrongTestcases.length > 0 && (
@@ -172,7 +172,7 @@ export function SubmissionDetailAdmin({
                     let sampleIndex = 1
                     let hiddenIndex = 1
 
-                    return testcaseData?.getProblem?.testcase?.map(
+                    return testcaseData?.problem?.testcase?.map(
                       (testcase, index) => {
                         const matchingResult = submission?.testcaseResult[index]
 

--- a/apps/frontend/app/admin/course/[courseId]/assignment/_components/ImportProblemTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/_components/ImportProblemTable.tsx
@@ -58,7 +58,7 @@ export function ImportProblemTable({
     }
   })
 
-  const combinedProblems = [...myData.getProblems, ...sharedData.getProblems]
+  const combinedProblems = [...myData.problems, ...sharedData.problems]
 
   const uniqueProblemsMap = new Map()
   combinedProblems.forEach((problem) => {

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
@@ -29,7 +29,7 @@ export default function Information({ params }: InformationProps) {
       groupId: Number(params.courseId),
       assignmentId: Number(params.exerciseId)
     }
-  }).data?.getAssignment
+  }).data?.assignment
 
   const problemsData =
     useSuspenseQuery(GET_ASSIGNMENT_PROBLEMS, {

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/layout.tsx
@@ -17,7 +17,7 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
       groupId: Number(courseId),
       assignmentId: Number(exerciseId)
     }
-  }).data?.getAssignment
+  }).data?.assignment
 
   return (
     <main className="flex flex-col gap-6 px-20 py-16">

--- a/apps/frontend/app/admin/course/_components/AssignmentTable.tsx
+++ b/apps/frontend/app/admin/course/_components/AssignmentTable.tsx
@@ -38,7 +38,7 @@ export function AssignmentTable({
     }
   })
 
-  const assignments = data.getAssignments.map((assignment) => ({
+  const assignments = data.assignments.map((assignment) => ({
     ...assignment,
     id: Number(assignment.id)
   }))

--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/EditProblemForm.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/EditProblemForm.tsx
@@ -48,7 +48,7 @@ export function EditProblemForm({
       id: Number(problemId)
     },
     onCompleted: (problemData) => {
-      const data = problemData.getProblem
+      const data = problemData.problem
 
       // HACK: This is a workaround for migrating testcase to separated query/mutation.
       // After migration, testcase input/output is not going to passed through 'getProblem' and 'updateProblem'

--- a/apps/frontend/app/admin/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/page.tsx
@@ -20,7 +20,7 @@ export default function Page({ params }: { params: { problemId: string } }) {
     variables: {
       id: Number(problemId)
     }
-  }).data?.getProblem
+  }).data?.problem
 
   const { items, paginator } = usePagination<SubmissionItem>(
     `submission?problemId=${problemId}`,

--- a/apps/frontend/app/admin/problem/[problemId]/preview/page.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/preview/page.tsx
@@ -28,9 +28,9 @@ export default function Page({ params }: PageProps) {
     ? null
     : ({
         id: 0,
-        ...data?.getProblem,
+        ...data?.problem,
         problemTestcase:
-          data?.getProblem?.testcase
+          data?.problem?.testcase
             ?.filter(({ isHidden }) => !isHidden)
             ?.map(({ id, ...rest }) => ({
               id: Number(id),

--- a/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
+++ b/apps/frontend/app/admin/problem/_components/ProblemTable.tsx
@@ -39,7 +39,7 @@ export function ProblemTable() {
     }
   })
 
-  const problems = data.getProblems.map((problem) => ({
+  const problems = data.problems.map((problem) => ({
     ...problem,
     id: Number(problem.id),
     isVisible: problem.isVisible !== undefined ? problem.isVisible : null,

--- a/apps/frontend/app/admin/problem/shared/_components/SharedProblemTable.tsx
+++ b/apps/frontend/app/admin/problem/shared/_components/SharedProblemTable.tsx
@@ -30,7 +30,7 @@ export function SharedProblemTable() {
     }
   })
 
-  const problems = data.getProblems.map((problem) => ({
+  const problems = data.problems.map((problem) => ({
     ...problem,
     id: Number(problem.id),
     languages: problem.languages ?? [],

--- a/apps/frontend/graphql/assignment/queries.ts
+++ b/apps/frontend/graphql/assignment/queries.ts
@@ -2,7 +2,7 @@ import { gql } from '@generated'
 
 const GET_ASSIGNMENT = gql(`
   query GetAssignment($groupId: Int!, $assignmentId: Int!) {
-    getAssignment(groupId: $groupId,assignmentId: $assignmentId) {
+    assignment(groupId: $groupId,assignmentId: $assignmentId) {
       id
       enableCopyPaste
       isJudgeResultVisible
@@ -20,7 +20,7 @@ const GET_ASSIGNMENT = gql(`
 
 const GET_ASSIGNMENTS = gql(`
   query GetAssignments($groupId: Int!, $cursor: Int, $take: Int!, $isExercise: Boolean) {
-    getAssignments(groupId: $groupId, cursor: $cursor, take: $take, isExercise: $isExercise) {
+    assignments(groupId: $groupId, cursor: $cursor, take: $take, isExercise: $isExercise) {
       id
       title
       startTime

--- a/apps/frontend/graphql/contest/queries.ts
+++ b/apps/frontend/graphql/contest/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@generated'
 
 const GET_CONTEST = gql(`
-  query GetContest($contestId: Int!) {
-    getContest(contestId: $contestId) {
+  query GetContest($id: Int!) {
+    contest(id: $id) {
       id
       isJudgeResultVisible
       invitationCode
@@ -43,7 +43,7 @@ const GET_CONTEST = gql(`
 
 const GET_CONTESTS = gql(`
   query GetContests($cursor: Int, $take: Int!) {
-    getContests(cursor: $cursor, take: $take) {
+    contests(cursor: $cursor, take: $take) {
       id
       title
       startTime

--- a/apps/frontend/graphql/problem/queries.ts
+++ b/apps/frontend/graphql/problem/queries.ts
@@ -2,7 +2,7 @@ import { gql } from '@generated'
 
 const GET_PROBLEM = gql(`
   query GetProblem($id: Int!) {
-    getProblem(id: $id) {
+    problem(id: $id) {
       title
       isVisible
       difficulty
@@ -36,7 +36,7 @@ const GET_PROBLEM = gql(`
 
 const GET_PROBLEMS = gql(`
   query GetProblems($cursor: Int, $take: Int!, $input: FilterProblemsInput!, $mode: String!, $contestId: Int) {
-    getProblems(cursor: $cursor, take: $take, input: $input, mode: $mode, contestId: $contestId) {
+    problems(cursor: $cursor, take: $take, input: $input, mode: $mode, contestId: $contestId) {
       id
       title
       updateTime
@@ -62,7 +62,7 @@ const GET_PROBLEMS = gql(`
 
 const GET_PROBLEM_DETAIL = gql(`
   query GetProblemDetail($id: Int!) {
-    getProblem(id: $id) {
+    problem(id: $id) {
       title
       description
     }
@@ -116,7 +116,7 @@ const GET_CONTEST_PROBLEMS = gql(`
 
 const GET_TAGS = gql(`
   query GetTags {
-    getTags {
+    tags {
       id
       name
     }
@@ -125,7 +125,7 @@ const GET_TAGS = gql(`
 
 const GET_PROBLEM_TESTCASE = gql(`
   query GetProblemTestcase($id: Int!) {
-    getProblem(id: $id) {
+    problem(id: $id) {
       testcase {
         id
         input


### PR DESCRIPTION
### Description

GraphQL best practices를 따르도록 query 이름을 `get~` 형태에서 모델 이름으로 변경합니다.
(예: `getNotices` => `notices`)
https://www.apollographql.com/docs/react/data/operation-best-practices

Best practices에 따라 추후 query들도 nested로 바꿀 에정입니다.

예)

#### 기존

```gql
getAssignmentScoreSummaries(groupId: number, assignmentId: number) {
  ...
}
```

#### 변경

```gql
group(id: number) {
  assignment(id: number) {
    scoreSummaries {
      ...
    }
  }
}
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
