### PR TITLE
feat(fe): apply responsive feature to all elements

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/_components/ContestOverallTabs.tsx
@@ -53,7 +53,7 @@ export function ContestOverallTabs({ contestId }: { contestId: string }) {
   }, [])
 
   const leaderBoard =
-    realSize >= 768 ? (
+    realSize >= 1024 ? (
       <p>LEADERBOARD</p>
     ) : (
       <p className="text-xs">
@@ -64,7 +64,7 @@ export function ContestOverallTabs({ contestId }: { contestId: string }) {
     )
 
   const allSubmission =
-    realSize >= 768 ? (
+    realSize >= 1024 ? (
       <p>ALL SUBMISSION</p>
     ) : (
       <p className="text-xs">
@@ -77,7 +77,7 @@ export function ContestOverallTabs({ contestId }: { contestId: string }) {
     )
 
   const announcement =
-    realSize >= 768 ? (
+    realSize >= 1024 ? (
       <p>ANNOUNCEMENT</p>
     ) : (
       <p className="text-xs">
@@ -88,7 +88,7 @@ export function ContestOverallTabs({ contestId }: { contestId: string }) {
     )
 
   const statistics =
-    realSize >= 768 ? (
+    realSize >= 1024 ? (
       <p>STATISTICS</p>
     ) : (
       <p className="text-xs">
@@ -98,7 +98,7 @@ export function ContestOverallTabs({ contestId }: { contestId: string }) {
       </p>
     )
 
-  const qna = realSize >= 768 ? <p>Q&A</p> : <p className="text-xs">Q&A</p>
+  const qna = realSize >= 1024 ? <p>Q&A</p> : <p className="text-xs">Q&A</p>
 
   return (
     <div className="mb-16 flex h-[60px] w-full rounded-full border border-solid border-[#80808040] bg-white">


### PR DESCRIPTION
### Description

admin - management - contest - 특정 contest 항목에서 overallTabs에 화면 크기가 줄어들어도 Tab의 각 항목의 글자 크기가 줄어들지 않음을 확인

![스크린샷 2025-07-01 135621](https://github.com/user-attachments/assets/4958c5ba-f5c4-440b-8b2d-be8900ca120c)

화면 크기가 768px보다 작아지면 글자 크기가 줄어듦과 동시에 글자가 여러 줄로 나타나게끔 구현함.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
