### PR TITLE
refactor(fe): improve header auth

### DIFF
--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -9,15 +9,15 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuTrigger,
   DropdownMenuItem,
-  DropdownMenuSeparator
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
 } from '@/components/shadcn/dropdown-menu'
-import { cn, fetcherWithAuth, safeFetcherWithAuth } from '@/libs/utils'
+import { cn, safeFetcherWithAuth } from '@/libs/utils'
 import { useAuthModalStore } from '@/stores/authModal'
 import type { Course } from '@/types/type'
 import { ContestRole, type UserContest } from '@generated/graphql'
-import { LogOut, UserRoundCog, ChevronDown } from 'lucide-react'
+import { ChevronDown, LogOut, UserRoundCog } from 'lucide-react'
 import type { Session } from 'next-auth'
 import { signOut } from 'next-auth/react'
 import Link from 'next/link'
@@ -33,6 +33,14 @@ interface HeaderAuthPanelProps {
   group?: 'default' | 'editor'
 }
 
+interface HeaderAuthUser {
+  role: string
+  studentId: string
+  major: string
+  canCreateCourse: boolean
+  canCreateContest: boolean
+}
+
 export function HeaderAuthPanel({
   session,
   group = 'default'
@@ -41,77 +49,74 @@ export function HeaderAuthPanel({
     (state) => state
   )
   const isUser = session?.user.role === 'User'
-  const [
-    hasCanCreateCourseOrContestPermission,
-    setHasCanCreateCourseOrContestPermission
-  ] = useState(false)
-  const [hasAnyGroupLeaderRole, setHasAnyGroupLeaderRole] = useState(false)
-  const [hasAnyPermissionOnContest, setHasAnyPermissionOnContest] =
-    useState(false)
+  const [hasCreatePermission, setHasCreatePermission] = useState(false)
+  const [isAnyGroupLeader, setIsAnyGroupLeader] = useState(false)
+  const [isAnyContestAdmin, setIsAnyContestAdmin] = useState(false)
   const isEditor = group === 'editor'
-  const [needsUpdate, setNeedsUpdate] = useState(false)
+  const [isUserInfoIncomplete, setIsUserInfoIncomplete] = useState(false)
   const pathname = usePathname()
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
 
   useEffect(() => {
-    const checkIfNeedsUpdate = async () => {
-      const userResponse = await fetcherWithAuth.get('user')
-      const user: {
-        role: string
-        studentId: string
-        major: string
-        canCreateCourse: boolean
-        canCreateContest: boolean
-      } = await userResponse.json()
-      const updateNeeded =
-        user.role === 'User' &&
-        (user.studentId === '0000000000' || user.major === 'none')
-
-      if (user.canCreateCourse || user.canCreateContest) {
-        setHasCanCreateCourseOrContestPermission(true)
-      }
-      setNeedsUpdate(updateNeeded)
-    }
-    if (session) {
-      checkIfNeedsUpdate()
+    if (!session) {
+      return
     }
 
-    async function fetchGroupLeaderRole() {
+    const fetchUserInfo = async () => {
       try {
-        const response: Course[] = await safeFetcherWithAuth
+        const user: HeaderAuthUser = await safeFetcherWithAuth
+          .get('user')
+          .json()
+
+        const isUserInfoIncomplete =
+          user.role === 'User' &&
+          (user.studentId === '0000000000' || user.major === 'none')
+
+        setIsUserInfoIncomplete(isUserInfoIncomplete)
+
+        setHasCreatePermission(user.canCreateCourse || user.canCreateContest)
+      } catch (error) {
+        console.error('Error fetching user info:', error)
+      }
+    }
+
+    const checkIsAnyGroupLeader = async () => {
+      try {
+        const courses: Course[] = await safeFetcherWithAuth
           .get('course/joined')
           .json()
 
-        const hasRole = response.some((course) => course.isGroupLeader)
-        setHasAnyGroupLeaderRole(hasRole)
+        const isAnyGroupLeader = courses.some((course) => course.isGroupLeader)
+        setIsAnyGroupLeader(isAnyGroupLeader)
       } catch (error) {
-        //TODO: error handling
         console.error('Error fetching group leader role:', error)
       }
     }
-    async function fetchContestRoles() {
+
+    const checkIsAnyContestAdmin = async () => {
       try {
         const response: UserContest[] = await safeFetcherWithAuth
           .get('contest/role')
           .json()
 
-        const hasPermission = response.some((userContest) => {
+        const isAnyContestAdmin = response.some((userContest) => {
           return (
             userContest.role !== ContestRole.Participant &&
             userContest.role !== ContestRole.Reviewer
           )
         })
-        setHasAnyPermissionOnContest(hasPermission)
+        setIsAnyContestAdmin(isAnyContestAdmin)
       } catch (error) {
         console.error('Error fetching contest roles:', error)
       }
     }
-    fetchGroupLeaderRole()
-    fetchContestRoles()
+    fetchUserInfo()
+    checkIsAnyGroupLeader()
+    checkIsAnyContestAdmin()
   }, [session, pathname])
 
-  const shouldShowDialog =
-    needsUpdate && pathname.split('/').pop() !== 'settings'
+  const shouldUpdateUserInfo =
+    isUserInfoIncomplete && pathname.split('/').pop() !== 'settings'
 
   return (
     <div className="ml-2 flex items-center gap-2">
@@ -146,9 +151,9 @@ export function HeaderAuthPanel({
                   'mr-5 rounded-sm border-none bg-[#4C5565] px-0 font-normal text-white'
               )}
             >
-              {(hasAnyGroupLeaderRole ||
-                hasAnyPermissionOnContest ||
-                hasCanCreateCourseOrContestPermission ||
+              {(isAnyGroupLeader ||
+                isAnyContestAdmin ||
+                hasCreatePermission ||
                 !isUser) && (
                 <Link href="/admin">
                   <DropdownMenuItem
@@ -190,7 +195,7 @@ export function HeaderAuthPanel({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Dialog open={shouldShowDialog}>
+          <Dialog open={shouldUpdateUserInfo}>
             <DialogContent
               className="min-h-[30rem] max-w-[20.5rem]"
               hideCloseButton={true}
@@ -277,9 +282,7 @@ export function HeaderAuthPanel({
               </DropdownMenuItem>
             </Link>
             <DropdownMenuSeparator className="bg-gray-300" />
-            {(hasAnyGroupLeaderRole ||
-              hasCanCreateCourseOrContestPermission ||
-              !isUser) && (
+            {(isAnyGroupLeader || hasCreatePermission || !isUser) && (
               <Link href="/admin">
                 <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
                   <UserRoundCog className="size-4" /> Management

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -49,13 +49,14 @@ export function HeaderAuthPanel({
     (state) => state
   )
   const isUser = session?.user.role === 'User'
-  const [hasCreatePermission, setHasCreatePermission] = useState(false)
-  const [isAnyGroupLeader, setIsAnyGroupLeader] = useState(false)
-  const [isAnyContestAdmin, setIsAnyContestAdmin] = useState(false)
+
   const isEditor = group === 'editor'
   const [isUserInfoIncomplete, setIsUserInfoIncomplete] = useState(false)
   const pathname = usePathname()
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [hasCreatePermission, setHasCreatePermission] = useState(false)
+  const [isAnyGroupLeader, setIsAnyGroupLeader] = useState(false)
+  const [isAnyContestAdmin, setIsAnyContestAdmin] = useState(false)
 
   useEffect(() => {
     if (!session) {
@@ -151,48 +152,16 @@ export function HeaderAuthPanel({
                   'mr-5 rounded-sm border-none bg-[#4C5565] px-0 font-normal text-white'
               )}
             >
-              {(isAnyGroupLeader ||
-                isAnyContestAdmin ||
-                hasCreatePermission ||
-                !isUser) && (
-                <Link href="/admin">
-                  <DropdownMenuItem
-                    className={cn(
-                      'flex cursor-pointer items-center gap-1',
-                      isEditor
-                        ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
-                        : 'font-semibold'
-                    )}
-                  >
-                    <UserRoundCog className="size-4" /> Management
-                  </DropdownMenuItem>
-                </Link>
-              )}
-              <Link href="/settings">
-                <DropdownMenuItem
-                  className={cn(
-                    'flex cursor-pointer items-center gap-1',
-                    isEditor
-                      ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
-                      : 'font-semibold'
-                  )}
-                >
-                  <UserRoundCog className="size-4" /> Settings
-                </DropdownMenuItem>
-              </Link>
-              <DropdownMenuItem
-                className={cn(
-                  'flex cursor-pointer items-center gap-1',
-                  isEditor
-                    ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
-                    : 'font-semibold'
-                )}
-                onClick={() => {
-                  signOut({ callbackUrl: '/', redirect: true })
-                }}
-              >
-                <LogOut className="size-4" /> LogOut
-              </DropdownMenuItem>
+              <AccountItems
+                session={session}
+                isAnyGroupLeader={isAnyGroupLeader}
+                isAnyContestAdmin={isAnyContestAdmin}
+                hasCreatePermission={hasCreatePermission}
+                isUser={isUser}
+                isEditor={isEditor}
+                showSignIn={showSignIn}
+                showSignUp={showSignUp}
+              />
             </DropdownMenuContent>
           </DropdownMenu>
           <Dialog open={shouldUpdateUserInfo}>
@@ -245,111 +214,146 @@ export function HeaderAuthPanel({
           </DialogContent>
         </Dialog>
       )}
-      {session ? (
-        <DropdownMenu>
-          <DropdownMenuTrigger className="flex gap-2 px-4 py-1 md:hidden">
-            <RxHamburgerMenu size="30" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="md:hidden">
-            <DropdownMenuItem className="text-primary pointer-events-none flex select-none items-center gap-1 font-semibold">
-              {session?.user.username}
-            </DropdownMenuItem>
-
-            <DropdownMenuSeparator className="bg-gray-300" />
-            <Link href="/notice">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Notice
-              </DropdownMenuItem>
-            </Link>
-            <Link href="/contest">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Contest
-              </DropdownMenuItem>
-            </Link>
-            <Link href="/problem">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Problem
-              </DropdownMenuItem>
-            </Link>
-            <Link href="/course">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Course
-              </DropdownMenuItem>
-            </Link>
-            <DropdownMenuSeparator className="bg-gray-300" />
-            {(isAnyGroupLeader || hasCreatePermission || !isUser) && (
-              <Link href="/admin">
-                <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                  <UserRoundCog className="size-4" /> Management
-                </DropdownMenuItem>
-              </Link>
-            )}
-            <Link href="/settings">
-              <DropdownMenuItem
-                className={cn(
-                  'flex cursor-pointer items-center gap-1',
-                  isEditor
-                    ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
-                    : 'font-semibold'
-                )}
-              >
-                <UserRoundCog className="size-4" /> Settings
-              </DropdownMenuItem>
-            </Link>
-            <DropdownMenuItem
-              className="flex cursor-pointer items-center gap-1 font-semibold"
-              onClick={() => {
-                signOut({ callbackUrl: '/', redirect: true })
-              }}
-            >
-              <LogOut className="size-4" /> Log Out
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger className="flex gap-2 px-4 py-1 md:hidden">
-            <RxHamburgerMenu size="30" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="md:hidden">
-            <Link href="/notice">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Notice
-              </DropdownMenuItem>
-            </Link>
-            <Link href="/contest">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Contest
-              </DropdownMenuItem>
-            </Link>
-            <Link href="/problem">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Problem
-              </DropdownMenuItem>
-            </Link>
-            <Link href="/course">
-              <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-                Course
-              </DropdownMenuItem>
-            </Link>
-            <DropdownMenuSeparator className="bg-gray-300" />
-            <DropdownMenuItem
-              className="flex cursor-pointer items-center gap-1 font-semibold"
-              onClick={() => showSignIn()}
-            >
-              Log In
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="flex cursor-pointer items-center gap-1 font-semibold"
-              onClick={() => {
-                showSignUp()
-              }}
-            >
-              Sign Up
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger className="flex gap-2 px-4 py-1 md:hidden">
+          <RxHamburgerMenu size="30" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="md:hidden">
+          <DropdownMenuItem className="text-primary pointer-events-none flex select-none items-center gap-1 font-semibold">
+            {session?.user.username}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className="bg-gray-300" />
+          <NavItems />
+          <DropdownMenuSeparator className="bg-gray-300" />
+          <AccountItems
+            session={session}
+            isAnyGroupLeader={isAnyGroupLeader}
+            isAnyContestAdmin={isAnyContestAdmin}
+            hasCreatePermission={hasCreatePermission}
+            isUser={isUser}
+            isEditor={isEditor}
+            showSignIn={showSignIn}
+            showSignUp={showSignUp}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
+  )
+}
+
+function NavItems() {
+  return (
+    <>
+      <Link href="/notice">
+        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+          Notice
+        </DropdownMenuItem>
+      </Link>
+      <Link href="/contest">
+        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+          Contest
+        </DropdownMenuItem>
+      </Link>
+      <Link href="/problem">
+        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+          Problem
+        </DropdownMenuItem>
+      </Link>
+      <Link href="/course">
+        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+          Course
+        </DropdownMenuItem>
+      </Link>
+    </>
+  )
+}
+
+interface AccountItemsProps {
+  session: Session | null
+  isAnyGroupLeader: boolean
+  isAnyContestAdmin: boolean
+  hasCreatePermission: boolean
+  isUser: boolean
+  isEditor: boolean
+  showSignIn: () => void
+  showSignUp: () => void
+}
+
+function AccountItems({
+  session,
+  isAnyGroupLeader,
+  isAnyContestAdmin,
+  hasCreatePermission,
+  isUser,
+  isEditor,
+  showSignIn,
+  showSignUp
+}: AccountItemsProps) {
+  if (session) {
+    return (
+      <>
+        {(isAnyGroupLeader ||
+          isAnyContestAdmin ||
+          hasCreatePermission ||
+          !isUser) && (
+          <Link href="/admin">
+            <DropdownMenuItem
+              className={cn(
+                'flex cursor-pointer items-center gap-1',
+                isEditor
+                  ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
+                  : 'font-semibold'
+              )}
+            >
+              <UserRoundCog className="size-4" /> Management
+            </DropdownMenuItem>
+          </Link>
+        )}
+        <Link href="/settings">
+          <DropdownMenuItem
+            className={cn(
+              'flex cursor-pointer items-center gap-1',
+              isEditor
+                ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
+                : 'font-semibold'
+            )}
+          >
+            <UserRoundCog className="size-4" /> Settings
+          </DropdownMenuItem>
+        </Link>
+        <DropdownMenuItem
+          className={cn(
+            'flex cursor-pointer items-center gap-1',
+            isEditor
+              ? 'rounded-none text-white focus:bg-[#222939] focus:text-white'
+              : 'font-semibold'
+          )}
+          onClick={() => {
+            signOut({ callbackUrl: '/', redirect: true })
+          }}
+        >
+          <LogOut className="size-4" /> LogOut
+        </DropdownMenuItem>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <DropdownMenuItem
+        className="flex cursor-pointer items-center gap-1 font-semibold"
+        onClick={() => showSignIn()}
+      >
+        Log In
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        className="flex cursor-pointer items-center gap-1 font-semibold"
+        onClick={() => {
+          showSignUp()
+        }}
+      >
+        Sign Up
+      </DropdownMenuItem>
+    </>
   )
 }

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -219,10 +219,14 @@ export function HeaderAuthPanel({
           <RxHamburgerMenu size="30" />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="md:hidden">
-          <DropdownMenuItem className="text-primary pointer-events-none flex select-none items-center gap-1 font-semibold">
-            {session?.user.username}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator className="bg-gray-300" />
+          {session && (
+            <>
+              <DropdownMenuItem className="text-primary pointer-events-none flex select-none items-center gap-1 font-semibold">
+                {session.user.username}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className="bg-gray-300" />
+            </>
+          )}
           <NavItems />
           <DropdownMenuSeparator className="bg-gray-300" />
           <AccountItems

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -251,12 +251,7 @@ export function HeaderAuthPanel({
             <RxHamburgerMenu size="30" />
           </DropdownMenuTrigger>
           <DropdownMenuContent className="md:hidden">
-            <DropdownMenuItem
-              className="text-primary flex cursor-pointer items-center gap-1 font-semibold"
-              onClick={() => {
-                signOut({ callbackUrl: '/', redirect: true })
-              }}
-            >
+            <DropdownMenuItem className="text-primary pointer-events-none flex select-none items-center gap-1 font-semibold">
               {session?.user.username}
             </DropdownMenuItem>
 

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -18,6 +18,7 @@ import { useAuthModalStore } from '@/stores/authModal'
 import type { Course } from '@/types/type'
 import { ContestRole, type UserContest } from '@generated/graphql'
 import { ChevronDown, LogOut, UserRoundCog } from 'lucide-react'
+import type { Route } from 'next'
 import type { Session } from 'next-auth'
 import { signOut } from 'next-auth/react'
 import Link from 'next/link'
@@ -246,30 +247,14 @@ export function HeaderAuthPanel({
 }
 
 function NavItems() {
-  return (
-    <>
-      <Link href="/notice">
-        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-          Notice
-        </DropdownMenuItem>
-      </Link>
-      <Link href="/contest">
-        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-          Contest
-        </DropdownMenuItem>
-      </Link>
-      <Link href="/problem">
-        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-          Problem
-        </DropdownMenuItem>
-      </Link>
-      <Link href="/course">
-        <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
-          Course
-        </DropdownMenuItem>
-      </Link>
-    </>
-  )
+  const navItems = ['notice', 'contest', 'problem', 'course']
+  return navItems.map((navItem) => (
+    <Link href={`/${navItem}` as Route} key={navItem}>
+      <DropdownMenuItem className="flex cursor-pointer items-center gap-1 font-semibold">
+        {navItem.charAt(0).toUpperCase() + navItem.slice(1)}
+      </DropdownMenuItem>
+    </Link>
+  ))
 }
 
 interface AccountItemsProps {


### PR DESCRIPTION
### Description
심심해서 Header의 Auth패널을 리팩토링해 보았습니다.
리팩토링하면서 보안상 문제 (햄부기메뉴에서 권한 확인이 한단계 부족했던점) 등을 개선할 수 있었습니다.
유자차의 권한도 한층 더 이해할 수 있었습니다. 추가로 더 가독성을 높이기 위해 변수명을 일부 수정하였습니다.

### Additional context
> [!WARNING]  
> 리팩토링 한다고 했는데, 6줄이나 더 늘어나서 심란함
---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1814