### PR TITLE
feat(infra): setup argocd for iris and basic k8s setup

### DIFF
--- a/apps/k8s/argocd/argocd.yaml
+++ b/apps/k8s/argocd/argocd.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  source:
+    path: apps/k8s/argocd
+    repoURL: https://github.com/skkuding/codedang
+    targetRevision: main
+    directory:
+      recurse: true
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/apps/k8s/argocd/internal.yaml
+++ b/apps/k8s/argocd/internal.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-internal
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: apps/k8s/internal
+    repoURL: https://github.com/skkuding/codedang
+    targetRevision: main
+    directory:
+      recurse: true
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/apps/k8s/argocd/iris.yaml
+++ b/apps/k8s/argocd/iris.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: iris
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: iris
+    server: https://kubernetes.default.svc
+  source:
+    path: apps/k8s/iris
+    repoURL: https://github.com/skkuding/codedang
+    targetRevision: main
+    directory:
+      recurse: true
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground


### PR DESCRIPTION
### Description

Argo CD 파이프라인을 세팅합니다. target 브랜치는 임시로 main 브랜치로 설정했고, 앞으로 `apps/k8s` 폴더에 있는 yaml 파일들을 자동으로 읽어 배포합니다.

- 더 쉬운 유지보수와 가시성을 위해, Argo CD UI로 설정하는 대신 yaml 파일로 declarative하게 구성하였습니다.
- 지금은 argocd / iris / internal 폴더 각각에 대한 Application 리소스를 생성하였습니다. 
- 추후 release 브랜치가 구성되면 main 브랜치 대신 release 브랜치에서 yaml을 읽도록 설정하면 될 듯 합니다.

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/eb08486f-ec92-4f65-a5d2-ae610cd369a2" />


---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
