### PR TITLE
refactor(fe): modify ment of finished exercise

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/FinishedNoticePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/FinishedNoticePanel.tsx
@@ -1,0 +1,108 @@
+import { Button } from '@/components/shadcn/button'
+import { fetcher } from '@/libs/utils'
+import exitIcon from '@/public/icons/exit2.svg'
+import visitIcon from '@/public/icons/visit.svg'
+import Image from 'next/image'
+import Link from 'next/link'
+
+interface FinishedNoticePanelProps {
+  target: 'assignment' | 'exercise' | 'contest'
+  problemId: string
+  assignmentId?: string
+  courseId?: string
+  contestId?: string
+}
+
+export async function FinishedNoticePanel({
+  target,
+  problemId,
+  assignmentId,
+  courseId,
+  contestId
+}: FinishedNoticePanelProps) {
+  const isProblemPubliclyAvailable =
+    (await fetcher.head(`problem/${problemId}`)).status === 200
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-opacity-10 text-center backdrop-blur-md">
+      <p className="h-[58px] text-4xl font-bold text-white">
+        The {target} has finished!
+      </p>
+      <p className="h-[56px] text-xl font-normal text-[#B0B0B0]">
+        {isProblemPubliclyAvailable
+          ? 'You can solve the public problem regardless of scoring.'
+          : `This problem is no longer available since the ${target} has finished.`}
+        <br />
+        Click the button below to{' '}
+        {contestId === undefined ? 'exit the page.' : 'go to the leaderboard.'}
+      </p>
+      <div className="mt-[64px] flex gap-[24px]">
+        {isProblemPubliclyAvailable && (
+          <VisitProblemButton problemId={problemId} />
+        )}
+        {courseId && assignmentId && (
+          <ExitButton
+            courseId={courseId}
+            assignmentId={assignmentId}
+            target={target}
+          />
+        )}
+        {contestId && (
+          <ExitButton
+            courseId={courseId}
+            contestId={contestId}
+            target={target}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface VisitProblemButtonProps {
+  problemId: string
+}
+
+function VisitProblemButton({ problemId }: VisitProblemButtonProps) {
+  return (
+    <Link href={`/problem/${problemId}`}>
+      <Button
+        type="button"
+        className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
+      >
+        <Image src={visitIcon} alt="exit" width={20} height={20} />
+        Visit Public Problem
+      </Button>
+    </Link>
+  )
+}
+
+interface ExitButtonProps {
+  target: 'assignment' | 'exercise' | 'contest'
+  courseId?: string
+  assignmentId?: string
+  contestId?: string
+}
+
+function ExitButton({
+  target,
+  courseId,
+  assignmentId,
+  contestId
+}: ExitButtonProps) {
+  const hrefMap = {
+    assignment: `/course/${courseId}/assignment/${assignmentId}`,
+    exercise: `/course/${courseId}/exercise/${assignmentId}`,
+    contest: `/contest/${contestId}/leaderboard`
+  } as const
+  return (
+    <Link href={hrefMap[target]}>
+      <Button
+        type="button"
+        className="ml-4 h-10 shrink-0 gap-[5px] bg-blue-500 font-sans hover:bg-blue-700"
+      >
+        <Image src={exitIcon} alt="exit" width={20} height={20} />
+        {target === 'contest' ? 'View Leaderboard' : 'Exit'}
+      </Button>
+    </Link>
+  )
+}

--- a/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/finished/problem/[problemId]/page.tsx
@@ -1,70 +1,23 @@
 import { EditorSkeleton } from '@/app/(client)/(code-editor)/_components/EditorSkeleton'
-import { Button } from '@/components/shadcn/button'
-import { fetcher } from '@/libs/utils'
-import exitIcon from '@/public/icons/exit2.svg'
-import visitIcon from '@/public/icons/visit.svg'
-import Image from 'next/image'
-import Link from 'next/link'
+import { FinishedNoticePanel } from '@/app/(client)/(code-editor)/_components/FinishedNoticePanel'
 
-export default async function ContestFinishedPage({
-  params
-}: {
+interface ContestFinishedPageProps {
   params: { problemId: string; contestId: string }
-}) {
+}
+
+export default function ContestFinishedPage({
+  params
+}: ContestFinishedPageProps) {
   const { problemId, contestId } = params
 
-  const isProblemPubliclyAvailable =
-    (await fetcher.head(`problem/${problemId}`)).status === 200
   return (
     <>
       <EditorSkeleton />
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-opacity-10 text-white backdrop-blur-md">
-        <div className="text-center">
-          <h1 className="mb-[19px] text-4xl font-bold">
-            The contest has finished!
-          </h1>
-          {isProblemPubliclyAvailable ? (
-            <>
-              <p className="mb-2 font-sans font-light">
-                You can solve the public problem regardless of scoring,
-              </p>
-              <p className="mb-10 font-sans font-light">
-                or click the exit button below to exit the page.
-              </p>
-            </>
-          ) : (
-            <div className="text-[#B0B0B0]">
-              <p className="mb-2 text-xl font-light">
-                These problems are no longer available since the contest has
-                finished.
-              </p>
-              <p className="mb-16 text-xl font-light">
-                Click the button below to go to the leaderboard.
-              </p>
-            </div>
-          )}
-          {isProblemPubliclyAvailable && (
-            <Link href={`/problem/${problemId}`}>
-              <Button
-                size="icon"
-                className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
-              >
-                <Image src={visitIcon} alt="exit" width={20} height={20} />
-                Visit Public Problem
-              </Button>
-            </Link>
-          )}
-          <Link href={`/contest/${contestId}/leaderboard`}>
-            <Button
-              size="icon"
-              className="ml-4 h-[46px] w-[209px] shrink-0 gap-[6px] rounded-full bg-blue-500 text-base hover:bg-blue-700"
-            >
-              <Image src={exitIcon} alt="exit" width={20} height={20} />
-              View Leaderboard
-            </Button>
-          </Link>
-        </div>
-      </div>
+      <FinishedNoticePanel
+        target={'contest'}
+        problemId={problemId}
+        contestId={contestId}
+      />
     </>
   )
 }

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/finished/problem/[problemId]/page.tsx
@@ -1,93 +1,24 @@
 import { EditorSkeleton } from '@/app/(client)/(code-editor)/_components/EditorSkeleton'
-import { Button } from '@/components/shadcn/button'
-import { fetcher } from '@/libs/utils'
-import exitIcon from '@/public/icons/exit.svg'
-import visitIcon from '@/public/icons/visit.svg'
-import Image from 'next/image'
-import Link from 'next/link'
+import { FinishedNoticePanel } from '@/app/(client)/(code-editor)/_components/FinishedNoticePanel'
 
 interface AssignmentFinishedPageProps {
   params: { problemId: string; assignmentId: string; courseId: string }
 }
 
-export default async function AssignmentFinishedPage({
+export default function AssignmentFinishedPage({
   params
 }: AssignmentFinishedPageProps) {
   const { problemId, assignmentId, courseId } = params
 
-  const isProblemPubliclyAvailable =
-    (await fetcher.head(`problem/${problemId}`)).status === 200
   return (
     <>
       <EditorSkeleton />
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-opacity-10 text-[#B0B0B0] backdrop-blur-md">
-        <div className="text-center">
-          <h1 className="mb-8 text-4xl text-white">
-            The assignment has finished!
-          </h1>
-          {isProblemPubliclyAvailable ? (
-            <>
-              <p className="mb-2 font-sans font-light">
-                You can solve the public problem regardless of scoring,
-              </p>
-              <p className="mb-10 font-sans font-light">
-                or click the exit button below to exit the page.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="mb-2 font-sans font-light">
-                These problems are no longer available since the assignment has
-                finished.
-              </p>
-              <p className="mb-10 font-sans font-light">
-                Click the button below to exit the page.
-              </p>
-            </>
-          )}
-          {isProblemPubliclyAvailable && (
-            <VisitProblemButton problemId={problemId} />
-          )}
-          <ExitButton courseId={courseId} assignmentId={assignmentId} />
-        </div>
-      </div>
+      <FinishedNoticePanel
+        target={'assignment'}
+        problemId={problemId}
+        assignmentId={assignmentId}
+        courseId={courseId}
+      />
     </>
-  )
-}
-
-interface VisitProblemButtonProps {
-  problemId: string
-}
-
-function VisitProblemButton({ problemId }: VisitProblemButtonProps) {
-  return (
-    <Link href={`/problem/${problemId}`}>
-      <Button
-        type="button"
-        className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
-      >
-        <Image src={visitIcon} alt="exit" width={20} height={20} />
-        Visit Public Problem
-      </Button>
-    </Link>
-  )
-}
-
-interface ExitButtonProps {
-  courseId: string
-  assignmentId: string
-}
-
-function ExitButton({ courseId, assignmentId }: ExitButtonProps) {
-  return (
-    <Link href={`/course/${courseId}/assignment/${assignmentId}`}>
-      <Button
-        type="button"
-        className="ml-4 h-10 w-24 shrink-0 gap-[5px] rounded-[4px] bg-blue-500 font-sans hover:bg-blue-700"
-      >
-        <Image src={exitIcon} alt="exit" width={20} height={20} />
-        Exit
-      </Button>
-    </Link>
   )
 }

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/finished/problem/[problemId]/page.tsx
@@ -3,15 +3,16 @@ import { Button } from '@/components/shadcn/button'
 import { fetcher } from '@/libs/utils'
 import exitIcon from '@/public/icons/exit.svg'
 import visitIcon from '@/public/icons/visit.svg'
-import type { Route } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 
+interface AssignmentFinishedPageProps {
+  params: { problemId: string; assignmentId: string; courseId: string }
+}
+
 export default async function AssignmentFinishedPage({
   params
-}: {
-  params: { problemId: string; assignmentId: string; courseId: string }
-}) {
+}: AssignmentFinishedPageProps) {
   const { problemId, assignmentId, courseId } = params
 
   const isProblemPubliclyAvailable =
@@ -45,29 +46,48 @@ export default async function AssignmentFinishedPage({
             </>
           )}
           {isProblemPubliclyAvailable && (
-            <Link href={`/problem/${problemId}`}>
-              <Button
-                size="icon"
-                className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
-              >
-                <Image src={visitIcon} alt="exit" width={20} height={20} />
-                Visit Public Problem
-              </Button>
-            </Link>
+            <VisitProblemButton problemId={problemId} />
           )}
-          <Link
-            href={`/course/${courseId}/assignment/${assignmentId}` as Route}
-          >
-            <Button
-              size="icon"
-              className="ml-4 h-10 w-24 shrink-0 gap-[5px] rounded-[4px] bg-blue-500 font-sans hover:bg-blue-700"
-            >
-              <Image src={exitIcon} alt="exit" width={20} height={20} />
-              Exit
-            </Button>
-          </Link>
+          <ExitButton courseId={courseId} assignmentId={assignmentId} />
         </div>
       </div>
     </>
+  )
+}
+
+interface VisitProblemButtonProps {
+  problemId: string
+}
+
+function VisitProblemButton({ problemId }: VisitProblemButtonProps) {
+  return (
+    <Link href={`/problem/${problemId}`}>
+      <Button
+        type="button"
+        className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
+      >
+        <Image src={visitIcon} alt="exit" width={20} height={20} />
+        Visit Public Problem
+      </Button>
+    </Link>
+  )
+}
+
+interface ExitButtonProps {
+  courseId: string
+  assignmentId: string
+}
+
+function ExitButton({ courseId, assignmentId }: ExitButtonProps) {
+  return (
+    <Link href={`/course/${courseId}/assignment/${assignmentId}`}>
+      <Button
+        type="button"
+        className="ml-4 h-10 w-24 shrink-0 gap-[5px] rounded-[4px] bg-blue-500 font-sans hover:bg-blue-700"
+      >
+        <Image src={exitIcon} alt="exit" width={20} height={20} />
+        Exit
+      </Button>
+    </Link>
   )
 }

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/exercise/[exerciseId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/exercise/[exerciseId]/finished/problem/[problemId]/page.tsx
@@ -1,75 +1,24 @@
 import { EditorSkeleton } from '@/app/(client)/(code-editor)/_components/EditorSkeleton'
-import { Button } from '@/components/shadcn/button'
-import { fetcher } from '@/libs/utils'
-import exitIcon from '@/public/icons/exit.svg'
-import visitIcon from '@/public/icons/visit.svg'
-import type { Route } from 'next'
-import Image from 'next/image'
-import Link from 'next/link'
+import { FinishedNoticePanel } from '@/app/(client)/(code-editor)/_components/FinishedNoticePanel'
 
-interface AssignmentFinishedPageProps {
-  params: { problemId: string; assignmentId: string; courseId: string }
+interface ExerciseFinishedPageProps {
+  params: { problemId: string; exerciseId: string; courseId: string }
 }
 
-export default async function AssignmentFinishedPage({
+export default function ExerciseFinishedPage({
   params
-}: AssignmentFinishedPageProps) {
-  const { problemId, assignmentId, courseId } = params
+}: ExerciseFinishedPageProps) {
+  const { problemId, exerciseId, courseId } = params
 
-  const isProblemPubliclyAvailable =
-    (await fetcher.head(`problem/${problemId}`)).status === 200
   return (
     <>
       <EditorSkeleton />
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-opacity-10 text-[#B0B0B0] backdrop-blur-md">
-        <div className="text-center">
-          <h1 className="mb-8 text-4xl text-white">
-            The assignment has finished!
-          </h1>
-          {isProblemPubliclyAvailable ? (
-            <>
-              <p className="mb-2 font-sans font-light">
-                You can solve the public problem regardless of scoring,
-              </p>
-              <p className="mb-10 font-sans font-light">
-                or click the exit button below to exit the page.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="mb-2 font-sans font-light">
-                These problems are no longer available since the assignment has
-                finished.
-              </p>
-              <p className="mb-10 font-sans font-light">
-                Click the button below to exit the page.
-              </p>
-            </>
-          )}
-          {isProblemPubliclyAvailable && (
-            <Link href={`/problem/${problemId}`}>
-              <Button
-                size="icon"
-                className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
-              >
-                <Image src={visitIcon} alt="exit" width={20} height={20} />
-                Visit Public Problem
-              </Button>
-            </Link>
-          )}
-          <Link
-            href={`/course/${courseId}/assignment/${assignmentId}` as Route}
-          >
-            <Button
-              type="button"
-              className="ml-4 h-10 w-24 shrink-0 gap-[5px] bg-blue-500 font-sans hover:bg-blue-700"
-            >
-              <Image src={exitIcon} alt="exit" width={20} height={20} />
-              Exit
-            </Button>
-          </Link>
-        </div>
-      </div>
+      <FinishedNoticePanel
+        target={'exercise'}
+        problemId={problemId}
+        assignmentId={exerciseId}
+        courseId={courseId}
+      />
     </>
   )
 }

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/exercise/[exerciseId]/finished/problem/[problemId]/page.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/exercise/[exerciseId]/finished/problem/[problemId]/page.tsx
@@ -7,11 +7,13 @@ import type { Route } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 
+interface AssignmentFinishedPageProps {
+  params: { problemId: string; assignmentId: string; courseId: string }
+}
+
 export default async function AssignmentFinishedPage({
   params
-}: {
-  params: { problemId: string; assignmentId: string; courseId: string }
-}) {
+}: AssignmentFinishedPageProps) {
   const { problemId, assignmentId, courseId } = params
 
   const isProblemPubliclyAvailable =
@@ -59,8 +61,8 @@ export default async function AssignmentFinishedPage({
             href={`/course/${courseId}/assignment/${assignmentId}` as Route}
           >
             <Button
-              size="icon"
-              className="ml-4 h-10 w-24 shrink-0 gap-[5px] rounded-[4px] bg-blue-500 font-sans hover:bg-blue-700"
+              type="button"
+              className="ml-4 h-10 w-24 shrink-0 gap-[5px] bg-blue-500 font-sans hover:bg-blue-700"
             >
               <Image src={exitIcon} alt="exit" width={20} height={20} />
               Exit


### PR DESCRIPTION
### Description
단순히 exercise가 종료됐을때 멘트만 수정하려고 했지만,
contest, assignment, course가 종료됐을 때 페이지를 모두 통합하는 것이 낫다고 생각해서
새로운 컴포넌트 FinishedNoticePanel에 통합해버렸습니다.

### Additional context
> [!TIP]
> 다음 첨부된 링크에서 contest, assignment, course별로 적용된 화면을 확인할 수 있습니다. (user01 계정)
contest/6/finished/problem/4
course/2/assignment/53/finished/problem/13
course/2/exercise/52/finished/problem/12
---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1845
