### PR TITLE
fix(fe): improve assignment display issues

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -37,15 +37,15 @@ import { fetcherWithAuth } from '@/libs/utils'
 import submitIcon from '@/public/icons/submit.svg'
 import { useAuthModalStore } from '@/stores/authModal'
 import {
-  useLanguageStore,
-  useCodeStore,
+  getCodeFromLocalStorage,
   getStorageKey,
-  getCodeFromLocalStorage
+  useCodeStore,
+  useLanguageStore
 } from '@/stores/editor'
 import {
-  useTestcaseTabStore,
+  RUN_CODE_TAB,
   useSidePanelTabStore,
-  RUN_CODE_TAB
+  useTestcaseTabStore
 } from '@/stores/editorTabs'
 import type {
   Language,
@@ -332,6 +332,8 @@ export function EditorHeader({
       if (res.status === 401) {
         showSignIn()
         toast.error('Log in first to submit your code')
+      } else if (res.status === 404) {
+        toast.error('The assignment submission period has ended.')
       } else {
         toast.error('Please try again later.')
       }

--- a/apps/frontend/app/admin/course/[courseId]/_components/WeekComboBox.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/_components/WeekComboBox.tsx
@@ -1,10 +1,10 @@
 import { ErrorMessage } from '@/app/admin/_components/ErrorMessage'
 import { Button } from '@/components/shadcn/button'
-import { Command, CommandList, CommandItem } from '@/components/shadcn/command'
+import { Command, CommandItem, CommandList } from '@/components/shadcn/command'
 import {
   Popover,
-  PopoverTrigger,
-  PopoverContent
+  PopoverContent,
+  PopoverTrigger
 } from '@/components/shadcn/popover'
 import { GET_COURSE } from '@/graphql/course/queries'
 import { cn } from '@/libs/utils'
@@ -47,7 +47,7 @@ export function WeekComboBox({ name, courseId }: WeekComboBoxProps) {
         <PopoverTrigger asChild>
           <Button
             variant="outline"
-            className="flex h-[36px] w-[220px] justify-between font-normal"
+            className="flex h-[36px] w-[255px] justify-between font-normal"
           >
             <p className={cn(!selectedWeek && 'text-[#C4C4C4]')}>
               {selectedWeek ? `Week ${selectedWeek}` : 'Select an option'}

--- a/apps/frontend/components/shadcn/date-time-picker-demo.tsx
+++ b/apps/frontend/components/shadcn/date-time-picker-demo.tsx
@@ -49,7 +49,7 @@ export const DateTimePickerDemo = ({
           variant={'outline'}
           className={cn(
             'h-[36px] justify-start text-left font-normal',
-            isContest ? 'w-[492px]' : 'w-[218px]',
+            isContest ? 'w-[492px]' : 'w-[255px]',
             !date && 'text-muted-foreground'
           )}
         >


### PR DESCRIPTION
### Description
두 가지 변경사항이 있습니다.

1. assignment / exercise를 생성 또는 수정할 때, DateTime를 선택할 때 'November'처럼 긴 텍스트의 날짜가 선택되면 Form을 벗어나는 현상이 있었습니다. November에 맞도록 Form의 너비를 넓혔습니다. 하단 사진 before > after 순서입니다.
![image.png](attachment:9d34ccdb-2f27-40ee-bf34-2f15797d2881:image.png)
![image.png](attachment:b0fb5081-8887-4d49-abd6-33c1fe20899d:image.png)

2. 학생이 과제 제출마감 기간 이후에 제출을 시도할 때 적절하지 않은 멘트가 나오고 있던 걸 적절하게 수정하였습니다. 하단 사진 before > after 순서입니다.
![image.png](attachment:b18faa83-01ea-4a49-b3c3-872d4bec48fb:image.png)
![image.png](attachment:7dbd6fa9-ff2d-418f-a144-8c3b97cf840f:image.png)

### Additional context
> [!IMPORTANT]  
> 현재 Preview에서 로그인이 되지 않는 상황입니다. 따라서 로컬에서 로그인하여 변경사항을 확인하실 수 있습니다.

http://localhost:5525/admin/course/2/assignment/80/edit (instuctor계정 사용)
http://localhost:5525/course/2/assignment/80/problem/12 (user01계정 사용)

---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1870
