### PR TITLE
fix(fe): use duetime instead of endtime for deadline display

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
@@ -133,7 +133,7 @@ function AssignmentAccordionItem({
                 <p className="overflow-hidden whitespace-nowrap font-normal text-[#8A8A8A]">
                   {formatDateRange(
                     assignment.startTime,
-                    assignment.endTime,
+                    assignment.dueTime,
                     false
                   )}
                 </p>
@@ -248,7 +248,7 @@ export function AssignmentStatusTimeDiff({
 
   const updateAssignmentStatus = () => {
     const now = dayjs()
-    if (now.isAfter(assignment.endTime)) {
+    if (now.isAfter(assignment.dueTime)) {
       setAssignmentStatus('finished')
     } else if (now.isAfter(assignment.startTime)) {
       setAssignmentStatus('ongoing')
@@ -257,7 +257,7 @@ export function AssignmentStatusTimeDiff({
     }
 
     const timeRef =
-      assignmentStatus === 'ongoing' ? assignment.endTime : assignment.startTime
+      assignmentStatus === 'ongoing' ? assignment.dueTime : assignment.startTime
 
     const diff = dayjs.duration(Math.abs(dayjs(timeRef).diff(now)))
     const days = Math.floor(diff.asDays())
@@ -284,7 +284,7 @@ export function AssignmentStatusTimeDiff({
     updateAssignmentStatus()
   }, 1000)
 
-  if (dayjs(assignment.endTime).isSame(dayjs(UNLIMITED_DATE))) {
+  if (dayjs(assignment.dueTime).isSame(dayjs(UNLIMITED_DATE))) {
     return null
   }
 

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/assignment/[assignmentId]/page.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/assignment/[assignmentId]/page.tsx
@@ -79,7 +79,7 @@ export default function AssignmentDetail({ params }: AssignmentDetailProps) {
               <p className="text-sm font-medium text-[#333333e6]">
                 {formatDateRange(
                   assignment.startTime,
-                  assignment.endTime,
+                  assignment.dueTime,
                   false
                 )}
               </p>

--- a/apps/frontend/app/(client)/(main)/course/_components/AssignmentCard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/AssignmentCard.tsx
@@ -28,7 +28,7 @@ interface AssignmentCardProps {
 
 export function AssignmentCard({ assignment }: AssignmentCardProps) {
   const startTime = dateFormatter(assignment.startTime, 'YYYY-MM-DD')
-  const endTime = dateFormatter(assignment.endTime, 'YYYY-MM-DD')
+  const dueTime = dateFormatter(assignment.dueTime, 'YYYY-MM-DD')
 
   return (
     <div
@@ -53,7 +53,7 @@ export function AssignmentCard({ assignment }: AssignmentCardProps) {
           <div className="inline-flex items-center gap-2 whitespace-nowrap text-xs text-gray-800 opacity-80">
             <Image src={calendarIcon} alt="calendar" width={16} height={16} />
             <p className="overflow-hidden text-ellipsis whitespace-pre-wrap">
-              {startTime} ~ {endTime}
+              {startTime} ~ {dueTime}
             </p>
           </div>
           <AssignmentStatusTimeDiff

--- a/apps/frontend/components/AssignmentStatusTimeDiff.tsx
+++ b/apps/frontend/components/AssignmentStatusTimeDiff.tsx
@@ -41,7 +41,7 @@ export function AssignmentStatusTimeDiff({
 
   const updateAssignmentStatus = () => {
     const now = dayjs()
-    if (now.isAfter(assignment.endTime)) {
+    if (now.isAfter(assignment.dueTime)) {
       setAssignmentStatus('finished')
     } else if (now.isAfter(assignment.startTime)) {
       setAssignmentStatus('ongoing')
@@ -50,7 +50,7 @@ export function AssignmentStatusTimeDiff({
     }
 
     const timeRef =
-      assignmentStatus === 'ongoing' ? assignment.endTime : assignment.startTime
+      assignmentStatus === 'ongoing' ? assignment.dueTime : assignment.startTime
 
     const diff = dayjs.duration(Math.abs(dayjs(timeRef).diff(now)))
     const days = Math.floor(diff.asDays())
@@ -93,7 +93,7 @@ export function AssignmentStatusTimeDiff({
     )
   }
 
-  if (dayjs(assignment.endTime).isSame(dayjs(UNLIMITED_DATE))) {
+  if (dayjs(assignment.dueTime).isSame(dayjs(UNLIMITED_DATE))) {
     return null
   }
 

--- a/apps/frontend/types/type.ts
+++ b/apps/frontend/types/type.ts
@@ -355,6 +355,7 @@ export interface Assignment {
   title: string
   startTime: Date
   endTime: Date
+  dueTime: Date
   group: {
     id: string
     groupName: string


### PR DESCRIPTION
## 마감 기한 과제 열람 시간(endTime) 기준 -> 제출 마감 시간(dueTime) 기준으로 변경
1. main 페이지 -> course 탭 내 아코디언 회색 글자
<img width="1958" height="901" alt="image" src="https://github.com/user-attachments/assets/2003d772-1bdd-4e88-bf47-9d5a510b96ac" />

2. course 탭 -> assignment 디테일 페이지 마감 기한 표시
<img width="1719" height="326" alt="image" src="https://github.com/user-attachments/assets/5616d4c0-586f-41ee-a4d8-49e997e07f69" />

<img width="1763" height="283" alt="image" src="https://github.com/user-attachments/assets/c30464b0-48d2-4637-89df-20f7ab431d8d" />

3. admin 페이지 -> course -> assignment 디테일 페이지
<img width="1894" height="419" alt="image" src="https://github.com/user-attachments/assets/c29eb777-8c6c-4602-a03e-f4b3a280e7ce" />

4. 코드 제출 페이지
<img width="2879" height="188" alt="image" src="https://github.com/user-attachments/assets/5d68606d-a0ea-482e-8cf1-8a3f7e76b35b" />

---

> [!IMPORTANT]
> apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx 내의

    <div className="flex w-[10%] justify-center font-medium">
          {dayjs().isAfter(dayjs(assignment.endTime))
            ? (problem.problemRecord?.finalScore ?? '-')
            : '-'}{' '}
          / {problem.maxScore}
    </div>

부분은 채점 완료 시간 기준인 것 같아 일단 그대로 두었습니다..! 


### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-1873