### PR TITLE
fix(be): modify registerduetime schema optional

### DIFF
--- a/apps/backend/prisma/migrations/20250712001015_add_register_due_date_to_contest/migration.sql
+++ b/apps/backend/prisma/migrations/20250712001015_add_register_due_date_to_contest/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - Added the required column `register_due_time` to the `contest` table without a default value. This is not possible if the table is not empty.
-
-*/
--- AlterTable
-ALTER TABLE "contest" ADD COLUMN     "register_due_time" TIMESTAMP(3) NOT NULL;

--- a/apps/backend/prisma/migrations/20250718141441_add_register_due_time/migration.sql
+++ b/apps/backend/prisma/migrations/20250718141441_add_register_due_time/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "contest" ADD COLUMN     "register_due_time" TIMESTAMP(3);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -294,23 +294,23 @@ enum Language {
 }
 
 model ProblemTestcase {
-  id          Int      @id @default(autoincrement())
-  problem     Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  problemId   Int      @map("problem_id")
-  order       Int?
+  id              Int      @id @default(autoincrement())
+  problem         Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  problemId       Int      @map("problem_id")
+  order           Int?
   // NOTE: Actual input/output value is going to be stored in S3.
   // These fields are only for backward compatibility.
   // All the new testcases are going to be stored in S3.
   // These fields are expected to be null for new testcases.
   // In future these fields will be removed after migration to S3.
-  input       String?
-  output      String?
-  scoreWeight Int      @default(1) @map("score_weight")
-  isHidden    Boolean  @default(false) @map("is_hidden_testcase")
-  createTime  DateTime @default(now()) @map("create_time")
-  updateTime  DateTime @updatedAt @map("update_time")
-  acceptedCount	Int	@default(0)	@map("accepted_count")
-  submissionCount	Int	@default(0)	@map("submission_count")
+  input           String?
+  output          String?
+  scoreWeight     Int      @default(1) @map("score_weight")
+  isHidden        Boolean  @default(false) @map("is_hidden_testcase")
+  createTime      DateTime @default(now()) @map("create_time")
+  updateTime      DateTime @updatedAt @map("update_time")
+  acceptedCount   Int      @default(0) @map("accepted_count")
+  submissionCount Int      @default(0) @map("submission_count")
 
   submissionResult SubmissionResult[]
 
@@ -453,7 +453,7 @@ model Contest {
   invitationCode             String?   @map("invitation_code")
   startTime                  DateTime  @map("start_time")
   endTime                    DateTime  @map("end_time")
-  registerDueTime            DateTime  @map("register_due_time")
+  registerDueTime            DateTime? @map("register_due_time")
   unfreeze                   Boolean   @default(false)
   freezeTime                 DateTime? @map("freeze_time")
   isJudgeResultVisible       Boolean   @default(true) @map("is_judge_result_visible") /// 이 Contest에 포함된 문제의 Judge Result를 사용자에게 보여줄지 말지 결정합니다.


### PR DESCRIPTION
### Description

contest 관련 registerDueTime 필드가 실제 db에 반영되지 않아 스키마를 수정

### Additional context



---

Closes TAS-1888

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
