### PR TITLE
fix(be): set register due time default

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.ts
@@ -188,10 +188,7 @@ export class ContestService {
         'The start time must be earlier than the end time'
       )
     }
-    if (
-      contest.registerDueTime &&
-      contest.registerDueTime >= contest.startTime
-    ) {
+    if (contest.registerDueTime >= contest.startTime) {
       throw new UnprocessableDataException(
         'The register due time must be earlier than the start time'
       )
@@ -317,19 +314,16 @@ export class ContestService {
       contest.endTime && contest.endTime !== contestFound.endTime
     contest.startTime = contest.startTime || contestFound.startTime
     contest.endTime = contest.endTime || contestFound.endTime
-    if (contest.registerDueTime != null) {
-      contest.registerDueTime =
-        contest.registerDueTime || contestFound.registerDueTime
-
-      if (contest.registerDueTime >= contest.startTime) {
-        throw new UnprocessableDataException(
-          'The register due time must be earlier than the start time'
-        )
-      }
-    }
+    contest.registerDueTime =
+      contest.registerDueTime || contestFound.registerDueTime
     if (contest.startTime >= contest.endTime) {
       throw new UnprocessableDataException(
         'The start time must be earlier than the end time'
+      )
+    }
+    if (contest.registerDueTime >= contest.startTime) {
+      throw new UnprocessableDataException(
+        'The register due time must be earlier than the start time'
       )
     }
     if (contest.summary) {

--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -276,7 +276,7 @@ export class ContestService {
       throw new ConflictFoundException('Already participated this contest')
     }
     const now = new Date()
-    if (contest.registerDueTime && now >= contest.registerDueTime) {
+    if (now >= contest.registerDueTime) {
       throw new ConflictFoundException(
         'Cannot participate in the contest after the registration deadline'
       )

--- a/apps/backend/prisma/migrations/20250712001015_add_register_due_date_to_contest/migration.sql
+++ b/apps/backend/prisma/migrations/20250712001015_add_register_due_date_to_contest/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `register_due_time` to the `contest` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "contest" ADD COLUMN     "register_due_time" TIMESTAMP(3) NOT NULL;

--- a/apps/backend/prisma/migrations/20250718141441_add_register_due_time/migration.sql
+++ b/apps/backend/prisma/migrations/20250718141441_add_register_due_time/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "contest" ADD COLUMN     "register_due_time" TIMESTAMP(3);

--- a/apps/backend/prisma/migrations/20250719052507_set_register_due_date_default/migration.sql
+++ b/apps/backend/prisma/migrations/20250719052507_set_register_due_date_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "contest" ALTER COLUMN "register_due_time" SET DEFAULT CURRENT_TIMESTAMP;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -294,23 +294,23 @@ enum Language {
 }
 
 model ProblemTestcase {
-  id              Int      @id @default(autoincrement())
-  problem         Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  problemId       Int      @map("problem_id")
-  order           Int?
+  id          Int      @id @default(autoincrement())
+  problem     Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  problemId   Int      @map("problem_id")
+  order       Int?
   // NOTE: Actual input/output value is going to be stored in S3.
   // These fields are only for backward compatibility.
   // All the new testcases are going to be stored in S3.
   // These fields are expected to be null for new testcases.
   // In future these fields will be removed after migration to S3.
-  input           String?
-  output          String?
-  scoreWeight     Int      @default(1) @map("score_weight")
-  isHidden        Boolean  @default(false) @map("is_hidden_testcase")
-  createTime      DateTime @default(now()) @map("create_time")
-  updateTime      DateTime @updatedAt @map("update_time")
-  acceptedCount   Int      @default(0) @map("accepted_count")
-  submissionCount Int      @default(0) @map("submission_count")
+  input       String?
+  output      String?
+  scoreWeight Int      @default(1) @map("score_weight")
+  isHidden    Boolean  @default(false) @map("is_hidden_testcase")
+  createTime  DateTime @default(now()) @map("create_time")
+  updateTime  DateTime @updatedAt @map("update_time")
+  acceptedCount	Int	@default(0)	@map("accepted_count")
+  submissionCount	Int	@default(0)	@map("submission_count")
 
   submissionResult SubmissionResult[]
 
@@ -453,7 +453,7 @@ model Contest {
   invitationCode             String?   @map("invitation_code")
   startTime                  DateTime  @map("start_time")
   endTime                    DateTime  @map("end_time")
-  registerDueTime            DateTime? @map("register_due_time")
+  registerDueTime            DateTime  @map("register_due_time")
   unfreeze                   Boolean   @default(false)
   freezeTime                 DateTime? @map("freeze_time")
   isJudgeResultVisible       Boolean   @default(true) @map("is_judge_result_visible") /// 이 Contest에 포함된 문제의 Judge Result를 사용자에게 보여줄지 말지 결정합니다.

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -294,23 +294,23 @@ enum Language {
 }
 
 model ProblemTestcase {
-  id          Int      @id @default(autoincrement())
-  problem     Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  problemId   Int      @map("problem_id")
-  order       Int?
+  id              Int      @id @default(autoincrement())
+  problem         Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  problemId       Int      @map("problem_id")
+  order           Int?
   // NOTE: Actual input/output value is going to be stored in S3.
   // These fields are only for backward compatibility.
   // All the new testcases are going to be stored in S3.
   // These fields are expected to be null for new testcases.
   // In future these fields will be removed after migration to S3.
-  input       String?
-  output      String?
-  scoreWeight Int      @default(1) @map("score_weight")
-  isHidden    Boolean  @default(false) @map("is_hidden_testcase")
-  createTime  DateTime @default(now()) @map("create_time")
-  updateTime  DateTime @updatedAt @map("update_time")
-  acceptedCount	Int	@default(0)	@map("accepted_count")
-  submissionCount	Int	@default(0)	@map("submission_count")
+  input           String?
+  output          String?
+  scoreWeight     Int      @default(1) @map("score_weight")
+  isHidden        Boolean  @default(false) @map("is_hidden_testcase")
+  createTime      DateTime @default(now()) @map("create_time")
+  updateTime      DateTime @updatedAt @map("update_time")
+  acceptedCount   Int      @default(0) @map("accepted_count")
+  submissionCount Int      @default(0) @map("submission_count")
 
   submissionResult SubmissionResult[]
 
@@ -453,7 +453,7 @@ model Contest {
   invitationCode             String?   @map("invitation_code")
   startTime                  DateTime  @map("start_time")
   endTime                    DateTime  @map("end_time")
-  registerDueTime            DateTime  @map("register_due_time")
+  registerDueTime            DateTime  @default(now()) @map("register_due_time")
   unfreeze                   Boolean   @default(false)
   freezeTime                 DateTime? @map("freeze_time")
   isJudgeResultVisible       Boolean   @default(true) @map("is_judge_result_visible") /// 이 Contest에 포함된 문제의 Judge Result를 사용자에게 보여줄지 말지 결정합니다.


### PR DESCRIPTION
### Description

prisma migration 에러에 대한 hotfix

### Additional context

- fix(be): modify registerduetime schema optional에 대한 commit revert
- registerDueTime의 default를 now()로 설정

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
