### PR TITLE
fix(be): resolve migration failure for new field in contest table

### DIFF
--- a/apps/backend/prisma/migrations/20250712001015_add_register_due_date_to_contest/migration.sql
+++ b/apps/backend/prisma/migrations/20250712001015_add_register_due_date_to_contest/migration.sql
@@ -1,8 +1,2 @@
-/*
-  Warnings:
-
-  - Added the required column `register_due_time` to the `contest` table without a default value. This is not possible if the table is not empty.
-
-*/
 -- AlterTable
-ALTER TABLE "contest" ADD COLUMN     "register_due_time" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "contest" ADD COLUMN     "register_due_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/apps/backend/prisma/migrations/20250719052507_set_register_due_date_default/migration.sql
+++ b/apps/backend/prisma/migrations/20250719052507_set_register_due_date_default/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "contest" ALTER COLUMN "register_due_time" SET DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
### Description

Contest 테이블에 추가된 `register_due_time` field가 default 값 없이 `NOT NULL`로 설정되어 migration failure가 발생합니다.
Prisma 공식 가이드에 따라 해당 migration을 rollback하고 default 값이 추가된 migration을 적용합니다.
https://www.prisma.io/docs/orm/prisma-migrate/workflows/patching-and-hotfixing#failed-migration

참고: #2861, #2875, #2876

> [!Warning]
> 직접 스테이지 서버에서 rollback 작업이 필요합니다.
> `pnpm prisma migrate resolve --rolled-back "20250712001015_add_register_due_date_to_contest"`

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
