### PR TITLE
feat(fe): add copy button to submission code

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/LoadButton.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/LoadButton.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useCodeStore } from '@/stores/editor'
+
+export function LoadButton({ code }: { code: string }) {
+  const setCode = useCodeStore((s) => s.setCode)
+
+  return (
+    <button
+      className="size-7 h-8 w-[77px] shrink-0 gap-[5px] rounded-[4px] bg-slate-600 font-normal text-white hover:bg-slate-700"
+      onClick={() => setCode(code)}
+    >
+      Load
+    </button>
+  )
+}

--- a/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/submission/_components/SubmissionDetail.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/contest/[contestId]/problem/[problemId]/submission/_components/SubmissionDetail.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { LoadButton } from '@/app/(client)/(code-editor)/_components/LoadButton'
 import { dataIfError } from '@/app/(client)/(code-editor)/_libs/dataIfError'
 import { CodeEditor } from '@/components/CodeEditor'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
@@ -75,14 +76,18 @@ export async function SubmissionDetail({
       </ScrollArea>
       <div className="-ml-16 mt-[10px] h-2 min-w-[100%] bg-[#121728]" />
       <div className="my-3 px-6">
-        <h2 className="mb-[18px] text-base font-bold">Source Code</h2>
+        <div className="mb-[18px] flex items-center justify-between">
+          <h2 className="text-base font-bold">Source Code</h2>
+          <LoadButton code={submission.code} />
+        </div>
         <CodeEditor
           value={submission.code}
           language={submission.language}
           readOnly
-          className="max-h-[1010px] min-h-[10px] w-full rounded-lg"
+          className="max-h-96 min-h-16 w-full rounded-lg"
         />
       </div>
+      <div className="-ml-16 h-2 min-w-[100%] bg-[#121728]" />
 
       {res.ok ? null : (
         <div className="absolute left-0 top-0 z-10 flex h-full w-full flex-col items-center justify-center gap-1 backdrop-blur">

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/[submissionId]/_components/SubmissionDetail.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/assignment/[assignmentId]/problem/[problemId]/submission/[submissionId]/_components/SubmissionDetail.tsx
@@ -1,3 +1,4 @@
+import { LoadButton } from '@/app/(client)/(code-editor)/_components/LoadButton'
 import { dataIfError } from '@/app/(client)/(code-editor)/_libs/dataIfError'
 import { CodeEditor } from '@/components/CodeEditor'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
@@ -73,7 +74,10 @@ export async function SubmissionDetail({
       </ScrollArea>
       <div className="-ml-16 mt-[10px] h-2 min-w-[100%] bg-[#121728]" />
       <div className="my-3 px-6">
-        <h2 className="mb-[18px] text-base font-bold">Source Code</h2>
+        <div className="mb-[18px] flex items-center justify-between">
+          <h2 className="text-base font-bold">Source Code</h2>
+          <LoadButton code={submission.code} />
+        </div>
         <CodeEditor
           value={submission.code}
           language={submission.language}

--- a/apps/frontend/app/(client)/(code-editor)/course/[courseId]/exercise/[exerciseId]/problem/[problemId]/submission/[submissionId]/_components/SubmissionDetail.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/course/[courseId]/exercise/[exerciseId]/problem/[problemId]/submission/[submissionId]/_components/SubmissionDetail.tsx
@@ -1,3 +1,4 @@
+import { LoadButton } from '@/app/(client)/(code-editor)/_components/LoadButton'
 import { dataIfError } from '@/app/(client)/(code-editor)/_libs/dataIfError'
 import { CodeEditor } from '@/components/CodeEditor'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
@@ -73,7 +74,10 @@ export async function SubmissionDetail({
       </ScrollArea>
       <div className="-ml-16 mt-[10px] h-2 min-w-[100%] bg-[#121728]" />
       <div className="my-3 px-6">
-        <h2 className="mb-[18px] text-base font-bold">Source Code</h2>
+        <div className="mb-[18px] flex items-center justify-between">
+          <h2 className="text-base font-bold">Source Code</h2>
+          <LoadButton code={submission.code} />
+        </div>
         <CodeEditor
           value={submission.code}
           language={submission.language}

--- a/apps/frontend/app/(client)/(code-editor)/problem/[problemId]/submission/_components/SubmissionDetail.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/problem/[problemId]/submission/_components/SubmissionDetail.tsx
@@ -1,3 +1,4 @@
+import { LoadButton } from '@/app/(client)/(code-editor)/_components/LoadButton'
 import { dataIfError } from '@/app/(client)/(code-editor)/_libs/dataIfError'
 import { CodeEditor } from '@/components/CodeEditor'
 import { ScrollArea, ScrollBar } from '@/components/shadcn/scroll-area'
@@ -58,7 +59,10 @@ export async function SubmissionDetail({ problemId, submissionId }: Props) {
         <ScrollBar orientation="horizontal" />
       </ScrollArea>
       <div>
-        <h2 className="mb-3 text-lg font-bold">Source Code</h2>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-bold">Source Code</h2>
+          <LoadButton code={submission.code} />
+        </div>
         <CodeEditor
           value={submission.code}
           language={submission.language}


### PR DESCRIPTION
**Description**
- code-editor에 붙여넣기가 방지되어 있는 경우, 유저가 제출했던 Source Code를 다시 붙여넣기할 수 없다는 문제점이 있어, Source Code 옆에 Load Button을 추가해서 code-editor에 제출했던 코드가 바로 들어가는 기능을 구현하였습니다.

<img width="919" height="504" alt="KakaoTalk_20250722_105952609" src="https://github.com/user-attachments/assets/a9e515b7-267f-4396-9cb7-8bb043952682" />

- 버튼 디자인이 따로 지정되어있지 않아서 기존에 있던 Reset 버튼과 동일한 디자인으로 제작하였습니다.