### PR TITLE
fix(fe): delete header width limit

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/Header.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/Header.tsx
@@ -8,7 +8,7 @@ import { NavLink } from './NavLink'
 export async function Header() {
   const session = await auth()
   return (
-    <header className="fixed left-0 z-40 grid h-[60px] w-full max-w-[1920px] place-items-center bg-white/80 px-[30px] backdrop-blur-sm">
+    <header className="fixed left-0 z-40 grid h-[60px] w-full place-items-center bg-white/80 px-[30px] backdrop-blur-sm">
       <div className="flex w-full max-w-[1440px] items-center justify-between gap-5 px-[116px]">
         {/* FIXME: If you uncomment a group tab, you have to remove a pr-20 tailwind class */}
         <div className="flex min-w-fit items-center justify-between gap-8 text-[16px]">


### PR DESCRIPTION
### Description
<img width="2640" height="1433" alt="image" src="https://github.com/user-attachments/assets/099c307c-9184-4153-90cc-c7fd3ed1e912" />
기존 헤더 컴포넌트가 1920px 이상의 화면에서 깨지는 현상이 발생했습니다.

- max-width때문에 발생했는데 수정해줬습니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
`max-w-[1920px]`이 들어가있어서 깨지는거였어서 아예 속성을 삭제해줬습니다.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
closes TAS-1908
### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
