### PR TITLE
fix(be): handle redis connection error with cache manager

### DIFF
--- a/apps/backend/apps/admin/src/contest/contest.service.spec.ts
+++ b/apps/backend/apps/admin/src/contest/contest.service.spec.ts
@@ -206,8 +206,8 @@ const input = {
 } satisfies CreateContestInput
 
 const updateInput = {
-  startTime: faker.date.recent(),
-  endTime: faker.date.future(),
+  startTime,
+  endTime,
   registerDueTime: faker.date.past(),
   freezeTime: faker.date.between({
     from: startTime,

--- a/apps/backend/libs/cache/src/cache-config.service.spec.ts
+++ b/apps/backend/libs/cache/src/cache-config.service.spec.ts
@@ -1,0 +1,131 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { CacheModule } from '@nestjs/cache-manager'
+import { ConfigModule, ConfigService } from '@nestjs/config'
+import { Test, type TestingModule } from '@nestjs/testing'
+import type { Cache } from 'cache-manager'
+import { expect } from 'chai'
+import { CacheConfigService } from './cache-config.service'
+
+describe('CacheConfigService', () => {
+  let cacheManager: Cache
+  let cacheConfigService: CacheConfigService
+
+  let module: TestingModule
+
+  before(async () => {
+    const mockConfigService = {
+      get: (key: string) => {
+        if (key === 'REDIS_HOST') return 'localhost'
+        if (key === 'REDIS_PORT') return '6380'
+        return undefined
+      }
+    }
+
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule,
+        CacheModule.registerAsync({
+          useClass: CacheConfigService,
+          imports: [ConfigModule]
+        })
+      ],
+      providers: [
+        CacheConfigService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService
+        }
+      ]
+    }).compile()
+
+    cacheManager = module.get<Cache>(CACHE_MANAGER)
+    cacheConfigService = module.get<CacheConfigService>(CacheConfigService)
+  })
+
+  after(async () => {
+    if (module) {
+      module.close()
+    }
+  })
+
+  describe('Redis Connection Test', () => {
+    it('should persist data across multiple operations', async () => {
+      const keys = ['key1', 'key2', 'key3']
+      const values = ['value1', 'value2', 'value3']
+
+      for (let i = 0; i < keys.length; i++) {
+        await cacheManager.set(keys[i], values[i], 5000)
+      }
+
+      for (let i = 0; i < keys.length; i++) {
+        const result = await cacheManager.get(keys[i])
+        expect(result).to.equal(values[i])
+      }
+    })
+
+    it('should handle TTL correctly', async () => {
+      const testKey = 'ttl-test-key'
+      const testValue = 'ttl-test-value'
+
+      await cacheManager.set(testKey, testValue, 1000)
+
+      let result = await cacheManager.get(testKey)
+      expect(result).to.equal(testValue)
+
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+      result = await cacheManager.get(testKey)
+      expect(result).to.be.undefined
+    })
+
+    it('should verify store type is Redis-based', async () => {
+      const options = await cacheConfigService.createCacheOptions()
+
+      expect(options.stores).to.be.an('array')
+      expect(options.stores).to.have.length(1)
+
+      const store = options.stores![0].store
+      expect(store).to.have.property('constructor')
+      expect(store.constructor.name).to.equal('KeyvRedis')
+
+      await store.disconnect()
+    })
+  })
+
+  describe('Configuration Error Handling', async () => {
+    it('should throw error when Redis host is missing', () => {
+      const mockConfigService = {
+        get: (key: string) => {
+          if (key === 'REDIS_HOST') return undefined
+          if (key === 'REDIS_PORT') return '6379'
+          return undefined
+        }
+      }
+
+      const cacheConfigService = new CacheConfigService(
+        mockConfigService as ConfigService
+      )
+
+      expect(cacheConfigService.createCacheOptions()).to.be.rejectedWith(
+        'Redis host and port must be configured'
+      )
+    })
+
+    it('should throw error when Redis port is missing', () => {
+      const mockConfigService = {
+        get: (key: string) => {
+          if (key === 'REDIS_HOST') return 'localhost'
+          if (key === 'REDIS_PORT') return undefined
+          return undefined
+        }
+      }
+
+      const cacheConfigService = new CacheConfigService(
+        mockConfigService as ConfigService
+      )
+
+      expect(cacheConfigService.createCacheOptions()).to.be.rejectedWith(
+        'Redis host and port must be configured'
+      )
+    })
+  })
+})

--- a/apps/backend/libs/cache/src/cache-config.service.ts
+++ b/apps/backend/libs/cache/src/cache-config.service.ts
@@ -4,13 +4,14 @@ import type {
 } from '@nestjs/cache-manager'
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import keyvRedis from '@keyv/redis'
+import { createKeyv } from '@keyv/redis'
+import type Keyv from 'keyv'
 
 @Injectable()
 export class CacheConfigService implements CacheOptionsFactory {
   constructor(private readonly config: ConfigService) {}
 
-  createCacheOptions(): CacheModuleOptions {
+  async createCacheOptions(): Promise<CacheModuleOptions> {
     const host = this.config.get<string>('REDIS_HOST')
     const port = this.config.get<string>('REDIS_PORT')
 
@@ -18,13 +19,29 @@ export class CacheConfigService implements CacheOptionsFactory {
       throw new Error('Redis host and port must be configured')
     }
 
+    const store = createKeyv(`redis://${host}:${port}`, {
+      throwOnErrors: true,
+      throwOnConnectError: true
+    })
+
+    await this.testConnection(store)
+
     return {
-      store: new keyvRedis({
-        socket: {
-          host,
-          port: parseInt(port)
-        }
-      })
+      stores: [store]
+    }
+  }
+
+  async testConnection(store: Keyv) {
+    try {
+      await store.set('test', 'connection')
+      const value = await store.get('test')
+      if (value === 'connection') {
+        await store.delete('test')
+      } else {
+        throw new Error('unexpected value')
+      }
+    } catch (error) {
+      throw new Error(`Redis connection failed: ${error.message}`)
     }
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,6 +76,7 @@
     "graphql-type-json": "^0.3.2",
     "graphql-upload": "^17.0.0",
     "handlebars": "^4.7.8",
+    "keyv": "^5.4.0",
     "nestjs-otel": "^6.2.0",
     "nestjs-pino": "^4.4.0",
     "nodemailer": "^6.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
+      keyv:
+        specifier: ^5.4.0
+        version: 5.4.0
       nestjs-otel:
         specifier: ^6.2.0
         version: 6.2.0(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.19)


### PR DESCRIPTION
### Description

#2881 에서 `cache-manager-redis-yet` -> `keyv` 마이그레이션 후 cacheManager가 redis에 접근하지 못하는 이슈를 해결합니다.
`keyv`에서 모종의 이유로(...) `socket` 옵션이 동작하지 않아 `redis://${host}:${port}` 형태로 uri를 전달하도록 수정했습니다.
또한 앞으로 같은 이슈를 방지하도록 (1) 유닛 테스트를 추가하였고 (2) 서버 시작마다 매번 redis connection을 확인하도록 구현하였습니다.

### Additional context

Admin contest service에서 flaky한 테스트를 고쳤습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
