### PR TITLE
feat(be): implement notification filtering and unread count api

### DIFF
--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -79,9 +79,14 @@ describe('GroupService', () => {
 
       expect(res).to.deep.equal({
         id: 3,
-        groupName: 'Example Private Group 2',
+        groupName: '자료구조',
         groupType: 'Course',
-        courseInfo: null,
+        courseInfo: {
+          courseNum: 'SWE2017',
+          classNum: 2,
+          professor: '박영희',
+          semester: '2025 Spring'
+        },
         isJoined: false
       })
     })
@@ -179,14 +184,16 @@ describe('GroupService', () => {
           },
           {
             id: 3,
-            groupName: 'Example Private Group 2',
-            description: 'This is an example private group just for testing.',
+            groupName: '자료구조',
+            description:
+              '배열, 링크드리스트, 스택, 큐, 트리, 그래프 등 기본적인 자료구조와 알고리즘을 학습합니다.',
             memberNum: 1
           },
           {
             id: 4,
-            groupName: 'Example Private Group 3',
-            description: 'This is an example private group just for testing.',
+            groupName: '알고리즘',
+            description:
+              '정렬, 탐색, 동적계획법, 그리디 알고리즘 등 다양한 알고리즘 설계 기법을 학습합니다.',
             memberNum: 2
           }
         ],

--- a/apps/backend/apps/client/src/notification/notification.controller.ts
+++ b/apps/backend/apps/client/src/notification/notification.controller.ts
@@ -5,9 +5,9 @@ import {
   Delete,
   Param,
   Query,
-  ParseIntPipe,
   Req,
-  DefaultValuePipe
+  DefaultValuePipe,
+  ParseBoolPipe
 } from '@nestjs/common'
 import { AuthenticatedRequest } from '@libs/auth'
 import { CursorValidationPipe, RequiredIntPipe } from '@libs/pipe'
@@ -25,9 +25,24 @@ export class NotificationController {
     @Req() req: AuthenticatedRequest,
     @Query('cursor', CursorValidationPipe) cursor: number | null,
     @Query('take', new DefaultValuePipe(8), new RequiredIntPipe('take'))
-    take: number
+    take: number,
+    @Query('isRead', new ParseBoolPipe({ optional: true }))
+    isRead: boolean | null
   ) {
-    return this.notificationService.getNotifications(req.user.id, cursor, take)
+    return await this.notificationService.getNotifications(
+      req.user.id,
+      cursor,
+      take,
+      isRead
+    )
+  }
+
+  /**
+   * 사용자의 읽지 않은 알림 개수를 조회합니다.
+   */
+  @Get('unread-count')
+  async getUnreadCount(@Req() req: AuthenticatedRequest) {
+    return await this.notificationService.getUnreadCount(req.user.id)
   }
 
   /**
@@ -36,9 +51,10 @@ export class NotificationController {
   @Patch(':id/read')
   async markAsRead(
     @Req() req: AuthenticatedRequest,
-    @Param('id', ParseIntPipe) notificationRecordId: number
+    @Param('id', new RequiredIntPipe('notificationRecordId'))
+    notificationRecordId: number
   ) {
-    return this.notificationService.markAsRead(
+    return await this.notificationService.markAsRead(
       req.user.id,
       notificationRecordId
     )
@@ -49,7 +65,7 @@ export class NotificationController {
    */
   @Patch('read-all')
   async markAllAsRead(@Req() req: AuthenticatedRequest) {
-    return this.notificationService.markAllAsRead(req.user.id)
+    return await this.notificationService.markAllAsRead(req.user.id)
   }
 
   /**
@@ -58,9 +74,10 @@ export class NotificationController {
   @Delete(':id')
   async deleteNotification(
     @Req() req: AuthenticatedRequest,
-    @Param('id', ParseIntPipe) notificationRecordId: number
+    @Param('id', new RequiredIntPipe('notificationRecordId'))
+    notificationRecordId: number
   ) {
-    return this.notificationService.deleteNotification(
+    return await this.notificationService.deleteNotification(
       req.user.id,
       notificationRecordId
     )

--- a/apps/backend/apps/client/src/notification/notification.service.spec.ts
+++ b/apps/backend/apps/client/src/notification/notification.service.spec.ts
@@ -109,7 +109,7 @@ describe('NotificationService', () => {
         notificationRecordWithNotification
       ])
 
-      const result = await service.getNotifications(userId, null, 8)
+      const result = await service.getNotifications(userId, null, 8, null)
 
       expect(result).to.deep.equal([formattedNotification])
     })
@@ -117,9 +117,47 @@ describe('NotificationService', () => {
     it('should return empty array when no notifications exist', async () => {
       db.notificationRecord.findMany.resolves([])
 
-      const result = await service.getNotifications(userId, null, 8)
+      const result = await service.getNotifications(userId, null, 8, null)
 
       expect(result).to.deep.equal([])
+    })
+
+    it('should filter by isRead when provided', async () => {
+      db.notificationRecord.findMany.resolves([
+        notificationRecordWithNotification
+      ])
+
+      const result = await service.getNotifications(userId, null, 8, false)
+
+      expect(result).to.deep.equal([formattedNotification])
+    })
+
+    it('should return all notifications when isRead is null', async () => {
+      db.notificationRecord.findMany.resolves([
+        notificationRecordWithNotification
+      ])
+
+      const result = await service.getNotifications(userId, null, 8, null)
+
+      expect(result).to.deep.equal([formattedNotification])
+    })
+  })
+
+  describe('getUnreadCount', () => {
+    it('should return unread notification count', async () => {
+      db.notificationRecord.count.resolves(5)
+
+      const result = await service.getUnreadCount(userId)
+
+      expect(result).to.equal(5)
+    })
+
+    it('should return zero when no unread notifications exist', async () => {
+      db.notificationRecord.count.resolves(0)
+
+      const result = await service.getUnreadCount(userId)
+
+      expect(result).to.equal(0)
     })
   })
 

--- a/apps/backend/apps/client/src/notification/notification.service.ts
+++ b/apps/backend/apps/client/src/notification/notification.service.ts
@@ -12,15 +12,23 @@ export class NotificationService {
    * @param cursor - 커서 기반 페이징을 위한 마지막 알림 ID
    * @param take - 가져올 알림 수 (기본값: 8)
    */
-  async getNotifications(userId: number, cursor: number | null, take: number) {
+  async getNotifications(
+    userId: number,
+    cursor: number | null,
+    take: number,
+    isRead: boolean | null
+  ) {
     const paginator = this.prisma.getPaginator(cursor)
+
+    const whereOptions = {
+      userId,
+      isRead: isRead !== null ? isRead : undefined
+    }
 
     const notificationRecords = await this.prisma.notificationRecord.findMany({
       ...paginator,
       take,
-      where: {
-        userId
-      },
+      where: whereOptions,
       include: {
         notification: true
       },
@@ -39,6 +47,19 @@ export class NotificationService {
       isRead: record.isRead,
       createTime: record.createTime
     }))
+  }
+
+  /**
+   * 사용자의 읽지 않은 알림 개수를 조회합니다
+   * @param userId - 사용자 ID
+   */
+  async getUnreadCount(userId: number) {
+    return this.prisma.notificationRecord.count({
+      where: {
+        userId,
+        isRead: false
+      }
+    })
   }
 
   /**

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -662,7 +662,7 @@ export class SubmissionService {
           select: {
             userGroup: {
               where: {
-                userId: userId,
+                userId,
                 isGroupLeader: true
               }
             }
@@ -674,7 +674,7 @@ export class SubmissionService {
               select: {
                 userContest: {
                   where: {
-                    userId: userId,
+                    userId,
                     role: { in: ['Admin', 'Manager', 'Reviewer'] }
                   }
                 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -4,6 +4,7 @@ import {
   Level,
   Language,
   ResultStatus,
+  NotificationType,
   type Group,
   type User,
   type Problem,
@@ -187,14 +188,23 @@ const createUsers = async () => {
 const createGroups = async () => {
   privateGroup1 = await prisma.group.create({
     data: {
-      groupName: 'Example Group',
+      groupName: '컴퓨터프로그래밍',
       description:
-        'This is an example group just for testing. This group should not be shown on production environment.',
+        'C/C++ 언어를 이용한 프로그래밍 기초를 학습합니다. 알고리즘과 자료구조의 기본 개념을 익힙니다.',
       config: {
         showOnList: false,
         allowJoinFromSearch: false,
         allowJoinWithURL: false,
         requireApprovalBeforeJoin: false
+      },
+      courseInfo: {
+        create: {
+          courseNum: 'SWE2016',
+          classNum: 1,
+          professor: '안철수',
+          semester: '2025 Spring',
+          email: 'woojoo@spacekim.org'
+        }
       }
     }
   })
@@ -229,17 +239,26 @@ const createGroups = async () => {
     }
   })
 
-  // create empty private group
-  // 'showOnList'가 true
   let tempGroup = await prisma.group.create({
     data: {
-      groupName: 'Example Private Group 2',
-      description: 'This is an example private group just for testing.',
+      groupName: '자료구조',
+      description:
+        '배열, 링크드리스트, 스택, 큐, 트리, 그래프 등 기본적인 자료구조와 알고리즘을 학습합니다.',
       config: {
         showOnList: true,
         allowJoinFromSearch: true,
         allowJoinWithURL: true,
         requireApprovalBeforeJoin: false
+      },
+      courseInfo: {
+        create: {
+          courseNum: 'SWE2017',
+          classNum: 2,
+          professor: '박영희',
+          semester: '2025 Spring',
+          email: 'example@skku.edu',
+          website: 'https://skku.edu'
+        }
       }
     }
   })
@@ -251,17 +270,26 @@ const createGroups = async () => {
     }
   })
 
-  // create empty private group
-  // 'showOnList'가 true
   tempGroup = await prisma.group.create({
     data: {
-      groupName: 'Example Private Group 3',
-      description: 'This is an example private group just for testing.',
+      groupName: '알고리즘',
+      description:
+        '정렬, 탐색, 동적계획법, 그리디 알고리즘 등 다양한 알고리즘 설계 기법을 학습합니다.',
       config: {
         showOnList: true,
         allowJoinFromSearch: true,
         allowJoinWithURL: true,
         requireApprovalBeforeJoin: false
+      },
+      courseInfo: {
+        create: {
+          courseNum: 'SWE3018',
+          classNum: 1,
+          professor: '이민수',
+          semester: '2025 Spring',
+          email: 'ms.lee@skku.edu',
+          website: 'https://algorithm.skku.edu'
+        }
       }
     }
   })
@@ -2665,6 +2693,68 @@ const createContestQnA = async () => {
   })
 }
 
+const createNotifications = async () => {
+  const notification1 = await prisma.notification.create({
+    data: {
+      title: '정보보호개론',
+      message: 'A new assignment "Homework 1" has been created.',
+      type: NotificationType.Assignment,
+      url: '/assignment/1'
+    }
+  })
+
+  const notification2 = await prisma.notification.create({
+    data: {
+      title: '정보보호개론',
+      message: 'Your assignment "Homework 1" has been graded.',
+      type: NotificationType.Assignment
+    }
+  })
+
+  const notification3 = await prisma.notification.create({
+    data: {
+      title: 'System Notice',
+      message: 'Platform maintenance scheduled for tomorrow.',
+      type: NotificationType.Other
+    }
+  })
+
+  await prisma.notificationRecord.createMany({
+    data: [
+      {
+        notificationId: notification1.id,
+        userId: users[0].id,
+        isRead: false
+      },
+      {
+        notificationId: notification2.id,
+        userId: users[0].id,
+        isRead: false
+      },
+      {
+        notificationId: notification3.id,
+        userId: users[0].id,
+        isRead: false
+      },
+      {
+        notificationId: notification1.id,
+        userId: users[1].id,
+        isRead: true
+      },
+      {
+        notificationId: notification2.id,
+        userId: users[1].id,
+        isRead: false
+      },
+      {
+        notificationId: notification3.id,
+        userId: users[1].id,
+        isRead: true
+      }
+    ]
+  })
+}
+
 const main = async () => {
   await createUsers()
   await createGroups()
@@ -2681,6 +2771,7 @@ const main = async () => {
   await createAssignmentRecords()
   await createContestProblemRecords()
   await createContestQnA()
+  await createNotifications()
 }
 
 main()

--- a/apps/backend/schema.gql
+++ b/apps/backend/schema.gql
@@ -1693,6 +1693,112 @@ type NoticeSumAggregate {
   id: Int
 }
 
+type Notification {
+  NotificationRecord: [NotificationRecord!]
+  _count: NotificationCount!
+  createTime: DateTime!
+  id: ID!
+  message: String!
+  title: String!
+  type: NotificationType!
+  url: String
+}
+
+type NotificationAvgAggregate {
+  id: Float
+}
+
+type NotificationCount {
+  NotificationRecord: Int!
+}
+
+type NotificationCountAggregate {
+  _all: Int!
+  createTime: Int!
+  id: Int!
+  message: Int!
+  title: Int!
+  type: Int!
+  url: Int!
+}
+
+type NotificationMaxAggregate {
+  createTime: DateTime
+  id: Int
+  message: String
+  title: String
+  type: NotificationType
+  url: String
+}
+
+type NotificationMinAggregate {
+  createTime: DateTime
+  id: Int
+  message: String
+  title: String
+  type: NotificationType
+  url: String
+}
+
+type NotificationRecord {
+  createTime: DateTime!
+  id: ID!
+  isRead: Boolean!
+  notification: Notification!
+  notificationId: Int!
+  user: User!
+  userId: Int!
+}
+
+type NotificationRecordAvgAggregate {
+  id: Float
+  notificationId: Float
+  userId: Float
+}
+
+type NotificationRecordCountAggregate {
+  _all: Int!
+  createTime: Int!
+  id: Int!
+  isRead: Int!
+  notificationId: Int!
+  userId: Int!
+}
+
+type NotificationRecordMaxAggregate {
+  createTime: DateTime
+  id: Int
+  isRead: Boolean
+  notificationId: Int
+  userId: Int
+}
+
+type NotificationRecordMinAggregate {
+  createTime: DateTime
+  id: Int
+  isRead: Boolean
+  notificationId: Int
+  userId: Int
+}
+
+type NotificationRecordSumAggregate {
+  id: Int
+  notificationId: Int
+  userId: Int
+}
+
+type NotificationSumAggregate {
+  id: Int
+}
+
+enum NotificationType {
+  Announcement
+  Assignment
+  Contest
+  Course
+  Other
+}
+
 type Problem {
   _count: ProblemCount!
   acceptedCount: Int!
@@ -2715,6 +2821,7 @@ input UploadTestcaseZipInput {
 }
 
 type User {
+  NotificationRecord: [NotificationRecord!]
   UpdateHistory: [UpdateHistory!]
   _count: UserCount!
   answeredQnAs: [ContestQnA!]
@@ -2843,6 +2950,7 @@ type UserContestSumAggregate {
 }
 
 type UserCount {
+  NotificationRecord: Int!
   UpdateHistory: Int!
   answeredQnAs: Int!
   assignment: Int!

--- a/collection/client/Notification/Get Notifications/Succeed.bru
+++ b/collection/client/Notification/Get Notifications/Succeed.bru
@@ -13,19 +13,19 @@ get {
 query {
   take: 8
   ~cursor: 1
+  ~isRead: true
 }
 
 assert {
   res.status: eq 200
-  res.body.data: isArray
-  res.body.data[0].id: isNumber
-  res.body.data[0].notificationId: isNumber
-  res.body.data[0].title: isString
-  res.body.data[0].message: isString
-  res.body.data[0].type: isString
-  res.body.data[0].isRead: isBoolean
-  res.body.data[0].createTime: isString
-  res.body.total: isNumber
+  res.body: isArray
+  res.body[0].id: isNumber
+  res.body[0].notificationId: isNumber
+  res.body[0].title: isString
+  res.body[0].message: isString
+  res.body[0].type: isString
+  res.body[0].isRead: isBoolean
+  res.body[0].createTime: isString
 }
 
 script:pre-request {
@@ -43,19 +43,20 @@ docs {
   |-----|-----|-----|
   | take | Integer | 가져올 알림 수 (기본값: 8) |
   | cursor | Integer | 커서 기반 페이징을 위한 마지막 알림 ID |
+  | isRead | Boolean | 읽음 여부 필터 (optional) |
 
   ## Response
 
+  알림 객체의 배열을 반환합니다.
+
   | 이름 | 타입 | 설명 |
   |-----|-----|-----|
-  | data | Array | 알림 목록 |
-  | data[].id | Integer | 알림 레코드 ID |
-  | data[].notificationId | Integer | 알림 ID |
-  | data[].title | String | 알림 제목 |
-  | data[].message | String | 알림 메시지 |
-  | data[].url | String | 관련 URL (nullable) |
-  | data[].type | String | 알림 타입 |
-  | data[].isRead | Boolean | 읽음 여부 |
-  | data[].createTime | String | 생성 시간 |
-  | total | Integer | 전체 알림 수 |
+  | id | Integer | 알림 레코드 ID |
+  | notificationId | Integer | 알림 ID |
+  | title | String | 알림 제목 |
+  | message | String | 알림 메시지 |
+  | url | String | 관련 URL (nullable) |
+  | type | String | 알림 타입 |
+  | isRead | Boolean | 읽음 여부 |
+  | createTime | String | 생성 시간 |
 }

--- a/collection/client/Notification/Get Unread Count/Succeed.bru
+++ b/collection/client/Notification/Get Unread Count/Succeed.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Succeed
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/notification/unread-count
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isNumber
+}
+
+script:pre-request {
+  await require("./login").loginUser(req);
+}
+
+docs {
+  # Get Unread Count
+
+  사용자의 읽지 않은 알림 개수를 가져옵니다.
+
+  ## Response
+
+  읽지 않은 알림의 개수를 나타내는 숫자를 반환합니다.
+
+  **Example Response:**
+  ```
+  5
+  ```
+}


### PR DESCRIPTION
### Description

getNotifications에서 isRead를 기준으로 필터링을 가능하게 합니다.
읽지 않은 알림의 개수를 조회하는 api를 추가합니다.

seed 데이터를 수정했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

Closes TAS-1955

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
