### PR TITLE
fix(be): add contest staff condition check

### DIFF
--- a/apps/backend/apps/client/src/problem/problem.service.ts
+++ b/apps/backend/apps/client/src/problem/problem.service.ts
@@ -433,7 +433,14 @@ export class ContestProblemService {
       select: {
         order: true,
         problem: {
-          select: problemSelectOption
+          select: {
+            ...problemSelectOption,
+            problemTestcase: {
+              ...(contest.isPrivilegedRole
+                ? {}
+                : { where: { isHidden: false } })
+            }
+          }
         }
       }
     })


### PR DESCRIPTION
### Description

contestProblem 조회 시 대회 운영진의 경우 Hidden TC도 같이 보내주도록 수정합니다.

### Additional context

이전 태스크에서는 submitTest와 test 결과를 가져오는 부분에서만 hidden TC를 포함했지만, 프론트 측에서 초기에 문제에 대한 정보를 가져올 때도 hidden TC를 포함해서 가져와야한다고 해서 그에 맞게 수정했습니다.

---
Closes TAS-1959

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
