### PR TITLE
feat(be): modify isVisible schema and add deletion in qna

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.controller.ts
+++ b/apps/backend/apps/client/src/contest/contest.controller.ts
@@ -138,6 +138,19 @@ export class ContestController {
     )
   }
 
+  @Delete(':id/qna/:order')
+  async deleteContestQnA(
+    @Req() req: AuthenticatedRequest,
+    @Param('id', IDValidationPipe) contestId: number,
+    @Param('order', ParseIntPipe) order: number
+  ) {
+    return await this.contestService.deleteContestQnA(
+      req.user.id,
+      contestId,
+      order
+    )
+  }
+
   @Post(':id/qna/:order/comment')
   async createContestQnAComment(
     @Req() req: AuthenticatedRequest,
@@ -150,6 +163,21 @@ export class ContestController {
       contestId,
       order,
       contentQnACommentCreateDto.content
+    )
+  }
+
+  @Delete(':id/qna/:qna-order/comment/:comment-order')
+  async deleteContestQnAComment(
+    @Req() req: AuthenticatedRequest,
+    @Param('id', IDValidationPipe) contestId: number,
+    @Param('qna-order', ParseIntPipe) qnAOrder: number,
+    @Param('comment-order', ParseIntPipe) commentOrder: number
+  ) {
+    return await this.contestService.deleteContestQnAComment(
+      req.user.id,
+      contestId,
+      qnAOrder,
+      commentOrder
     )
   }
 }

--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -995,7 +995,8 @@ export class ContestService {
    * @param contestId - 대회 Id
    * @param qnAOrder - 해당 대회 내에서의 QnA의 순서
    * @param commentOrder - 해당 QnA 내에서 삭제할 댓글의 순서
-   * @throws { EntityNotExistException } - 입력받은 contestId와 qnAOrder에 해당하는 QnA가 존재하지 않을 시
+   * @throws { EntityNotExistException } - contestId에 해당하는 Contest가 존재하지 않을 시
+   * @throws { EntityNotExistException } - qnAOrder에 해당하는 QnA가 존재하지 않을 시
    * @throws { EntityNotExistException } - 해당 QnA의 commentOrder에 해당하는 댓글이 존재하지 않을 시
    * @throws { ForbiddenAccessException } - 해당 댓글의 작성자 또는 대회 관리자 이외의 사용자가 요청할 시
    * @returns
@@ -1006,6 +1007,14 @@ export class ContestService {
     qnAOrder: number,
     commentOrder: number
   ) {
+    const contest = await this.prisma.contest.findFirst({
+      where: { id: contestId }
+    })
+
+    if (!contest) {
+      throw new EntityNotExistException('Contest')
+    }
+
     const contestQnA = await this.prisma.contestQnA.findFirst({
       where: {
         contestId,

--- a/collection/client/Contest/Delete Contest QnA/Succeed.bru
+++ b/collection/client/Contest/Delete Contest QnA/Succeed.bru
@@ -1,0 +1,54 @@
+meta {
+  name: Succeed
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/contest/1/qna/1
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  await require("./login").loginUser2nd(req);
+}
+
+settings {
+  encodeUrl: true
+}
+
+docs {
+  # 📘 Delete Contest QnA
+  
+  **DELETE** `/contest/:id/qna/:order`
+  
+  Delete a single QnA for a specific contest.
+  
+  특정 대회의 특정 order에 해당하는 QnA를 삭제합니다.
+  
+  이 함수는 다음과 같은 조건에 따라 QnA를 삭제하고 반환합니다.
+  
+  1. 운영진(Admin, Manager, Reviewer)
+  - 모든 QnA를 삭제할 수 있습니다.
+  2. 일반 사용자
+  - 본인이 작성한 QnA만 삭제할 수 있습니다.
+  
+  QnA를 찾을 수 없거나 접근 권한이 없는 경우 예외를 발생시킵니다.
+  
+  - Contest나 QnA가 실제로 없으면 EntityNotExistException 발생
+  - 작성자 또는 대회 운영진 이외의 사용자가 요청하는 경우 ForbiddenAccessException 발생
+  
+  ### 🔒 Authentication
+  
+  ### 📥 Request Parameters
+  
+  #### Path Parameters
+  
+  | Name | Type   | Required | Description              |
+  |------|--------|----------|--------------------------|
+  | `id` | number | ✅       | ID of the target contest |
+  | `order` | number | ✅    | order of target QnA in contest |
+  
+  
+}

--- a/collection/client/Contest/Delete Contest QnA/[403] Cannot delete others QnA.bru
+++ b/collection/client/Contest/Delete Contest QnA/[403] Cannot delete others QnA.bru
@@ -1,0 +1,54 @@
+meta {
+  name: [403] Cannot delete others QnA
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/contest/1/qna/999
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  await require("./login").loginUser2nd(req);
+}
+
+settings {
+  encodeUrl: true
+}
+
+docs {
+  # 📘 Delete Contest QnA
+  
+  **DELETE** `/contest/:id/qna/:order`
+  
+  Delete a single QnA for a specific contest.
+  
+  특정 대회의 특정 order에 해당하는 QnA를 삭제합니다.
+  
+  이 함수는 다음과 같은 조건에 따라 QnA를 삭제하고 반환합니다.
+  
+  1. 운영진(Admin, Manager, Reviewer)
+  - 모든 QnA를 삭제할 수 있습니다.
+  2. 일반 사용자
+  - 본인이 작성한 QnA만 삭제할 수 있습니다.
+  
+  QnA를 찾을 수 없거나 접근 권한이 없는 경우 예외를 발생시킵니다.
+  
+  - Contest나 QnA가 실제로 없으면 EntityNotExistException 발생
+  - 작성자 또는 대회 운영진 이외의 사용자가 요청하는 경우 ForbiddenAccessException 발생
+  
+  ### 🔒 Authentication
+  
+  ### 📥 Request Parameters
+  
+  #### Path Parameters
+  
+  | Name | Type   | Required | Description              |
+  |------|--------|----------|--------------------------|
+  | `id` | number | ✅       | ID of the target contest |
+  | `order` | number | ✅    | order of target QnA in contest |
+  
+  
+}

--- a/collection/client/Contest/Delete Contest QnA/[404] Nonexistent Contest QnA.bru
+++ b/collection/client/Contest/Delete Contest QnA/[404] Nonexistent Contest QnA.bru
@@ -1,0 +1,54 @@
+meta {
+  name: [404] Nonexistent Contest QnA
+  type: http
+  seq: 3
+}
+
+delete {
+  url: {{baseUrl}}/contest/1/qna/999
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  await require("./login").loginUser2nd(req);
+}
+
+settings {
+  encodeUrl: true
+}
+
+docs {
+  # 📘 Delete Contest QnA
+  
+  **DELETE** `/contest/:id/qna/:order`
+  
+  Delete a single QnA for a specific contest.
+  
+  특정 대회의 특정 order에 해당하는 QnA를 삭제합니다.
+  
+  이 함수는 다음과 같은 조건에 따라 QnA를 삭제하고 반환합니다.
+  
+  1. 운영진(Admin, Manager, Reviewer)
+  - 모든 QnA를 삭제할 수 있습니다.
+  2. 일반 사용자
+  - 본인이 작성한 QnA만 삭제할 수 있습니다.
+  
+  QnA를 찾을 수 없거나 접근 권한이 없는 경우 예외를 발생시킵니다.
+  
+  - Contest나 QnA가 실제로 없으면 EntityNotExistException 발생
+  - 작성자 또는 대회 운영진 이외의 사용자가 요청하는 경우 ForbiddenAccessException 발생
+  
+  ### 🔒 Authentication
+  
+  ### 📥 Request Parameters
+  
+  #### Path Parameters
+  
+  | Name | Type   | Required | Description              |
+  |------|--------|----------|--------------------------|
+  | `id` | number | ✅       | ID of the target contest |
+  | `order` | number | ✅    | order of target QnA in contest |
+  
+  
+}

--- a/collection/client/Contest/Delete Contest QnA/[404] Nonexistent Contest.bru
+++ b/collection/client/Contest/Delete Contest QnA/[404] Nonexistent Contest.bru
@@ -1,0 +1,54 @@
+meta {
+  name: [404] Nonexistent Contest
+  type: http
+  seq: 2
+}
+
+delete {
+  url: {{baseUrl}}/contest/999/qna/1
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  await require("./login").loginUser2nd(req);
+}
+
+settings {
+  encodeUrl: true
+}
+
+docs {
+  # 📘 Delete Contest QnA
+  
+  **DELETE** `/contest/:id/qna/:order`
+  
+  Delete a single QnA for a specific contest.
+  
+  특정 대회의 특정 order에 해당하는 QnA를 삭제합니다.
+  
+  이 함수는 다음과 같은 조건에 따라 QnA를 삭제하고 반환합니다.
+  
+  1. 운영진(Admin, Manager, Reviewer)
+  - 모든 QnA를 삭제할 수 있습니다.
+  2. 일반 사용자
+  - 본인이 작성한 QnA만 삭제할 수 있습니다.
+  
+  QnA를 찾을 수 없거나 접근 권한이 없는 경우 예외를 발생시킵니다.
+  
+  - Contest나 QnA가 실제로 없으면 EntityNotExistException 발생
+  - 작성자 또는 대회 운영진 이외의 사용자가 요청하는 경우 ForbiddenAccessException 발생
+  
+  ### 🔒 Authentication
+  
+  ### 📥 Request Parameters
+  
+  #### Path Parameters
+  
+  | Name | Type   | Required | Description              |
+  |------|--------|----------|--------------------------|
+  | `id` | number | ✅       | ID of the target contest |
+  | `order` | number | ✅    | order of target QnA in contest |
+  
+  
+}


### PR DESCRIPTION
### Description

feat(be): modify contest qna schema #2904에 대한 후속작업입니다.

ContestQnA 모델의 isVisible 관련 스키마를 수정합니다.
Contest QnA와 Comment에 대한 삭제 기능을 구현합니다.


### Additional context

---

Closes TAS-1960

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing
Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing
Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch)
and follow the [Commit
Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is
solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass
with it.
