### PR TITLE
feat(infra): build frontend image manually for porting to k8s

### DIFF
--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -10,6 +10,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-frontend:
+    name: Build frontend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./apps/frontend/Dockerfile # build with root context
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/codedang-frontend:${{github.sha}}
+            ghcr.io/${{ github.repository_owner }}/codedang-frontend:latest
+
   build-client-api:
     name: Build client-api image
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -28,6 +28,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # TODO: add a custom tag(e.g. 2025.1) like other images, maybe after refactoring those steps
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -48,6 +49,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
+      # TODO: refactor this step to a reusable action
       - name: Determine next image tag
         id: tag
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,29 +94,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if source code has changed
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            backend:
-              - 'apps/backend/**'
-
       - uses: ./.github/actions/setup-pnpm
-        if: steps.filter.outputs.backend == 'true'
 
       - name: Generate Prisma Client
-        if: steps.filter.outputs.backend == 'true'
         run: pnpm --filter="@codedang/backend" exec prisma generate
 
-      - name: Check types (backend) # For spec files
-        if: steps.filter.outputs.backend == 'true'
-        run: pnpm --filter="@codedang/backend" exec tsc --noEmit
-
-      # Typecheck is not performed for frontend intentionally.
-      # Check: https://github.com/vercel/next.js/issues/53959
-      # Unlike backend, we don't have spec file to check types.
-      # So typechecking performed in the build step is enough.
+      - name: Check types
+        run: pnpm exec tsc --noEmit
 
   lint:
     name: Lint

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -18,7 +18,7 @@ COPY apps/backend/schema.gql apps/backend/
 
 WORKDIR /build/apps/frontend
 
-RUN pnpm build
+RUN pnpm build --no-lint
 
 ### INSTALL PACKAGES ###
 FROM node:22.17.1-alpine AS install

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,47 @@
+# [NOTE] Build image from the root directory of this repository.
+# ex) `docker build -f apps/frontend/Dockerfile .`
+
+### BUILD ###
+FROM node:22.17.1-alpine AS build
+
+WORKDIR /build
+
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY pnpm-lock.yaml .
+COPY apps/frontend/package.json apps/frontend/
+
+RUN corepack enable && pnpm install --frozen-lockfile
+
+COPY apps/frontend apps/frontend
+COPY apps/backend/schema.gql apps/backend/
+
+WORKDIR /build/apps/frontend
+
+RUN pnpm build
+
+### INSTALL PACKAGES ###
+FROM node:22.17.1-alpine AS install
+
+WORKDIR /app
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY pnpm-lock.yaml .
+COPY apps/frontend/package.json apps/frontend/
+
+RUN corepack enable && pnpm deploy --filter=@codedang/frontend --prod /app/install
+
+### PRODUCTION ###
+FROM node:22.17.1-alpine AS production
+
+WORKDIR /app
+
+COPY --from=build /build/apps/frontend/.next/standalone ./
+COPY --from=build /build/apps/frontend/.next/static ./apps/frontend/.next/static
+COPY --from=build /build/apps/frontend/public ./apps/frontend/public
+COPY --from=install /app/install/node_modules ./node_modules
+
+ENV NODE_ENV=production
+ENV PORT=5525
+
+CMD ["node", "apps/frontend/server.js"]

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -18,7 +18,7 @@ COPY apps/backend/schema.gql apps/backend/
 
 WORKDIR /build/apps/frontend
 
-RUN pnpm build --no-lint
+RUN pnpm build
 
 ### INSTALL PACKAGES ###
 FROM node:22.17.1-alpine AS install

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -2,7 +2,6 @@
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true'
 })
-/** @type {import('next').NextConfig} */
 const MEDIA_BUCKET_NAME = process.env.MEDIA_BUCKET_NAME
 
 // const domains =
@@ -25,6 +24,7 @@ const remotePatterns = [
   }
 ]
 
+/** * @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
     typedRoutes: process.env.NODE_ENV !== 'development'
@@ -34,6 +34,9 @@ const nextConfig = {
     remotePatterns
   },
   output: 'standalone',
+  eslint: {
+    ignoreDuringBuilds: true
+  },
   env: {
     NEXTAUTH_URL: process.env.NEXTAUTH_URL
   }


### PR DESCRIPTION
### Description

프론트엔드를 on-premise k8s에서 실행하기 위해 Dockerfile을 작성하였습니다.
multi-stage build를 활용하였고 [빌드 / 패키지 설치 / 실제 이미지]로 나눴습니다.

### Additional context

- 조금 더 빠른 빌드를 위해 Next.js 빌드 중 lint를 해제하였습니다. (lint는 CI로 실행됩니다)
- 이를 위해 기존 CI의 TypeScript typechecking을 frontend에도 적용하였습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
