### PR TITLE
feat(be): extend getAssignments to handle month filtering

### DIFF
--- a/apps/backend/apps/client/src/assignment/assignment.controller.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.controller.ts
@@ -1,13 +1,14 @@
 import {
   Controller,
-  Param,
-  Post,
-  Req,
-  Get,
-  Query,
+  DefaultValuePipe,
   Delete,
+  Get,
+  Param,
   ParseBoolPipe,
-  DefaultValuePipe
+  ParseIntPipe,
+  Post,
+  Query,
+  Req
 } from '@nestjs/common'
 import { AuthenticatedRequest } from '@libs/auth'
 import { GroupIDPipe, IDValidationPipe, RequiredIntPipe } from '@libs/pipe'
@@ -22,6 +23,8 @@ export class AssignmentController {
    *
    * @param {number} groupId 조회할 그룹 아이디
    * @param {boolean} isExercise exercise를 가져올지 혹은 assignment를 가져올지 여부
+   * @param {number} month 조회할 월 (1-12, 선택적, 기본값: 현재 월)
+   * @param {number} year 조회할 년도 (선택적, 기본값: 현재 년도)
    * @returns 조회된 모든 assignment
    */
   @Get('')
@@ -32,9 +35,18 @@ export class AssignmentController {
       new ParseBoolPipe({ optional: true }),
       new DefaultValuePipe(false)
     )
-    isExercise: boolean
+    isExercise: boolean,
+    @Query('month', new ParseIntPipe({ optional: true }))
+    month?: number,
+    @Query('year', new ParseIntPipe({ optional: true }))
+    year?: number
   ) {
-    return await this.assignmentService.getAssignments(groupId, isExercise)
+    return await this.assignmentService.getAssignments(
+      groupId,
+      isExercise,
+      month,
+      year
+    )
   }
 
   /**

--- a/apps/backend/apps/client/src/assignment/assignment.service.spec.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.spec.ts
@@ -81,6 +81,39 @@ describe('AssignmentService', () => {
       expect(assignments[0].group).to.have.property('id')
       expect(assignments[0].group).to.have.property('groupName')
     })
+
+    it('should filter assignments by month and year when provided', async () => {
+      // Test with current month and year (should work with test data)
+      const currentDate = new Date()
+      const currentMonth = currentDate.getMonth() + 1
+      const currentYear = currentDate.getFullYear()
+
+      const filteredAssignments = await service.getAssignments(
+        groupId,
+        false,
+        currentMonth,
+        currentYear
+      )
+
+      // Check that all returned assignments have dueTime in the specified month/year
+      for (const assignment of filteredAssignments) {
+        const dueDate = new Date(assignment.dueTime)
+        expect(dueDate.getMonth() + 1).to.equal(currentMonth)
+        expect(dueDate.getFullYear()).to.equal(currentYear)
+      }
+    })
+
+    it('should return empty array when filtering by non-existent month/year', async () => {
+      // Test with a future year that shouldn't have any assignments
+      const futureYear = new Date().getFullYear() + 10
+      const assignments = await service.getAssignments(
+        groupId,
+        false,
+        1,
+        futureYear
+      )
+      expect(assignments).to.have.lengthOf(0)
+    })
   })
 
   describe('getAssignment', () => {

--- a/apps/backend/apps/client/src/assignment/assignment.service.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.ts
@@ -52,16 +52,37 @@ export class AssignmentService {
    *
    * @param {number} groupId 그룹 아이디
    * @param {boolean} isExercise exercise를 가져올지 assignment를 가져올지 여부
+   * @param {number} month 조회할 월 (1-12, 선택적)
+   * @param {number} year 조회할 년도 (선택적)
    * @returns 특정 그룹의 모든 assignment를 문제 개수와 함께 반환합니다.
    * 아직 시작되지 않은 assignment의 경우 문제 개수는 0이 됩니다.
+   * month와 year가 제공되면 해당 월에 dueTime이 속한 assignment만 반환합니다.
    */
-  async getAssignments(groupId: number, isExercise: boolean) {
+  async getAssignments(
+    groupId: number,
+    isExercise: boolean,
+    month?: number,
+    year?: number
+  ) {
+    const whereCondition: Record<string, unknown> = {
+      groupId,
+      isVisible: true
+    }
+
+    if (month !== undefined && year !== undefined) {
+      const startOfMonth = new Date(year, month - 1, 1)
+      const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999)
+
+      whereCondition.dueTime = {
+        gte: startOfMonth,
+        lte: endOfMonth
+      }
+    } else {
+      whereCondition.isExercise = isExercise
+    }
+
     const assignments = await this.prisma.assignment.findMany({
-      where: {
-        groupId,
-        isExercise,
-        isVisible: true
-      },
+      where: whereCondition,
       select: {
         ...assignmentSelectOption
       },


### PR DESCRIPTION
### Description
client - course의 대시보드에서 사용할 api작업입니다.

기존 getAssignments에서 month와 year를 쿼리에 넣고 호출하면, 
isExercise의 여부와 관계없이 dueTime이 해당 년월에 포함되는 과제/실습 들만 필터링돼서 응답으로 전달됩니다.

<img width="1915" height="1168" alt="스크린샷 2025-08-05 오전 10 07 09" src="https://github.com/user-attachments/assets/ff3b3e60-6fd3-4bf8-9476-50258611a53b" />
<img width="1915" height="1168" alt="스크린샷 2025-08-05 오전 10 07 01" src="https://github.com/user-attachments/assets/006f03a7-2f82-4ee9-9fa5-1a5dc7666bdc" />

### Additional context
아직 작업 중입니다.

---

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [X] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
