### PR TITLE
fix(be): testcase scoreweight fraction

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -298,23 +298,25 @@ enum Language {
 }
 
 model ProblemTestcase {
-  id              Int      @id @default(autoincrement())
-  problem         Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  problemId       Int      @map("problem_id")
-  order           Int?
+  id                     Int      @id @default(autoincrement())
+  problem                Problem  @relation(fields: [problemId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  problemId              Int      @map("problem_id")
+  order                  Int?
   // NOTE: Actual input/output value is going to be stored in S3.
   // These fields are only for backward compatibility.
   // All the new testcases are going to be stored in S3.
   // These fields are expected to be null for new testcases.
   // In future these fields will be removed after migration to S3.
-  input           String?
-  output          String?
-  scoreWeight     Int      @default(1) @map("score_weight")
-  isHidden        Boolean  @default(false) @map("is_hidden_testcase")
-  createTime      DateTime @default(now()) @map("create_time")
-  updateTime      DateTime @updatedAt @map("update_time")
-  acceptedCount   Int      @default(0) @map("accepted_count")
-  submissionCount Int      @default(0) @map("submission_count")
+  input                  String?
+  output                 String?
+  // scoreWeight     Int      @default(1) @map("score_weight")
+  scoreWeightNumerator   Int // 분자
+  scoreWeightDenominator Int // 분모
+  isHidden               Boolean  @default(false) @map("is_hidden_testcase")
+  createTime             DateTime @default(now()) @map("create_time")
+  updateTime             DateTime @updatedAt @map("update_time")
+  acceptedCount          Int      @default(0) @map("accepted_count")
+  submissionCount        Int      @default(0) @map("submission_count")
 
   submissionResult SubmissionResult[]
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
테스트케이스 점수 가중치(scoreWeight)를 정수 퍼센트가 아닌 분수로 저장하여 공정한 채점 시스템 구현
(이하 작성중)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
