### PR TITLE
fix(infra): correct server field to use production name in redis-prod

### DIFF
--- a/apps/k8s/argocd/applications/redis-prod.yaml
+++ b/apps/k8s/argocd/applications/redis-prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   destination:
     namespace: redis
-    server: https://kubernetes.default.svc
+    name: production
   sources:
     - repoURL: https://charts.bitnami.com/bitnami
       chart: redis


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

stage 환경에만 `spec.destination.name` 속성을 사용했던 실수가 있었습니다.
이제 production 환경에서도 이를 적용합니다.

<img width="1312" height="1001" alt="image" src="https://github.com/user-attachments/assets/73628c28-6a7a-4669-a80f-530533ecc178" />


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
