### PR TITLE
fix(be): get others' problem submission info when accepted

### DIFF
--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -1144,91 +1144,96 @@ export class SubmissionService {
       throw new EntityNotExistException('Submission')
     }
 
+    // 본인이나 관리자가 아닐 경우
     if (
-      contest &&
-      contest.startTime <= now &&
-      contest.endTime > now &&
       submission.userId !== userId &&
-      userRole === Role.User
+      userRole !== Role.Admin &&
+      userRole !== Role.SuperAdmin
     ) {
-      throw new ForbiddenAccessException(
-        "Contest should end first before you browse other people's submissions"
-      )
-    } else if (
-      assignment &&
-      assignment.startTime <= now &&
-      assignment.endTime > now &&
-      submission.userId !== userId &&
-      userRole === Role.User
-    ) {
-      throw new ForbiddenAccessException(
-        "Assignment should end first before you browse other people's submissions"
-      )
-    }
-
-    if (
-      submission.userId === userId ||
-      userRole === Role.Admin ||
-      userRole === Role.SuperAdmin ||
-      (contestId &&
-        (await this.prisma.submission.count({
-          where: {
-            userId,
-            problemId,
-            result: 'Accepted'
-          }
-        })))
-    ) {
-      const code = plainToInstance(Snippet, submission.code)
-      const results = submission.submissionResult
-        .filter(
-          (result) =>
-            !assignmentId ||
-            isHiddenTestcaseVisible ||
-            !result.problemTestcase.isHidden
+      if (
+        contest &&
+        contest.startTime <= now &&
+        contest.endTime > now &&
+        userRole === Role.User
+      ) {
+        // 진행 중인 contest에서 다른 사람의 제출을 볼 수 없음
+        throw new ForbiddenAccessException(
+          "Contest should end first before you browse other people's submissions"
         )
-        .map((result) => {
-          return {
-            ...result,
-            // TODO: 채점 속도가 너무 빠른경우에 대한 수정 필요 (0ms 미만)
-            cpuTime:
-              result.cpuTime || result.cpuTime === BigInt(0)
-                ? result.cpuTime.toString()
-                : null
-          }
-        })
-
-      results.sort((a, b) => a.problemTestcaseId - b.problemTestcaseId)
-
-      if (contestId && !isJudgeResultVisible) {
-        results.map((r) => {
-          r.result = 'Blind'
-          r.cpuTime = null
-          r.memoryUsage = null
-        })
-      }
-
-      if (assignmentId && !isHiddenTestcaseVisible) {
-        submission.result = this.getSampleTestcaseSubmissionResult(
-          submission.submissionResult
+      } else if (
+        assignment &&
+        assignment.startTime <= now &&
+        assignment.endTime > now &&
+        userRole === Role.User
+      ) {
+        // 진행 중인 assignment에서 다른 사람의 제출을 볼 수 없음
+        throw new ForbiddenAccessException(
+          "Assignment should end first before you browse other people's submissions"
         )
       }
 
-      return {
-        problemId,
-        username: submission.user?.username,
-        code: code.map((snippet) => snippet.text).join('\n'),
-        language: submission.language,
-        createTime: submission.createTime,
-        result:
-          !contestId || isJudgeResultVisible ? submission.result : 'Blind',
-        testcaseResult: results
+      // contest/assignment가 종료되었거나 일반 problem인 경우, 문제를 풀었는지 확인
+      if (contestId || (!contestId && !assignmentId)) {
+        const acceptedCount = await this.prisma.submission.count({
+          where: { userId, problemId, result: 'Accepted' }
+        })
+        if (acceptedCount === 0) {
+          throw new ForbiddenAccessException(
+            "You must pass the problem first to browse other people's submissions"
+          )
+        }
+      } else {
+        // assignment의 경우 문제를 풀어도 다른 사람의 코드를 볼 수 없음
+        throw new ForbiddenAccessException(
+          "You cannot view other people's submissions for an assignment."
+        )
       }
     }
 
-    throw new ForbiddenAccessException(
-      "You must pass the problem first to browse other people's submissions"
-    )
+    const code = plainToInstance(Snippet, submission.code)
+    const results = submission.submissionResult
+      .filter(
+        (result) =>
+          !assignmentId ||
+          isHiddenTestcaseVisible ||
+          !result.problemTestcase.isHidden
+      )
+      .map((result) => {
+        return {
+          ...result,
+          // TODO: 채점 속도가 너무 빠른경우에 대한 수정 필요 (0ms 미만)
+          cpuTime:
+            result.cpuTime || result.cpuTime === BigInt(0)
+              ? result.cpuTime.toString()
+              : null
+        }
+      })
+
+    results.sort((a, b) => a.problemTestcaseId - b.problemTestcaseId)
+
+    if (contestId && !isJudgeResultVisible) {
+      results.map((r) => {
+        r.result = 'Blind'
+        r.cpuTime = null
+        r.memoryUsage = null
+      })
+    }
+
+    if (assignmentId && !isHiddenTestcaseVisible) {
+      submission.result = this.getSampleTestcaseSubmissionResult(
+        submission.submissionResult
+      )
+    }
+
+    return {
+      problemId,
+      username: submission.user?.username,
+      code: code.map((snippet) => snippet.text).join('\n'),
+      language: submission.language,
+      createTime: submission.createTime,
+      result: !contestId || isJudgeResultVisible ? submission.result : 'Blind',
+      testcaseResult: results
+    }
   }
 
   // FIXME: Workbook 구분

--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -576,6 +576,33 @@ describe('SubmissionService', () => {
         })
       ).to.be.rejectedWith(ForbiddenAccessException)
     })
+
+    it('should throw exception when trying to view others submission during a contest', async () => {
+      const ongoingContest = {
+        ...mockContest,
+        startTime: new Date(Date.now() - 10000),
+        endTime: new Date(Date.now() + 10000)
+      }
+      db.contestRecord.findUnique.resolves({
+        contest: ongoingContest
+      })
+      db.problem.findFirst.resolves(problems[0])
+      db.submission.findFirst.resolves({
+        ...submissions[0],
+        userId: 2
+      })
+
+      await expect(
+        service.getSubmission({
+          id: submissions[0].id,
+          problemId: problems[0].id,
+          userId: 1,
+          userRole: Role.User,
+          contestId: CONTEST_ID,
+          assignmentId: null
+        })
+      ).to.be.rejectedWith(ForbiddenAccessException)
+    })
   })
 
   describe('getContestSubmissions', () => {

--- a/apps/backend/libs/auth/src/authenticated-user.class.ts
+++ b/apps/backend/libs/auth/src/authenticated-user.class.ts
@@ -5,9 +5,10 @@ export class AuthenticatedUser {
   #username: string
   #role: Role
 
-  constructor(id, username) {
+  constructor(id, username, role) {
     this.#id = id
     this.#username = username
+    this.#role = role
   }
 
   get id() {

--- a/apps/backend/libs/auth/src/jwt/jwt.strategy.ts
+++ b/apps/backend/libs/auth/src/jwt/jwt.strategy.ts
@@ -22,6 +22,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtObject): Promise<AuthenticatedUser> {
-    return new AuthenticatedUser(payload.userId, payload.username)
+    return new AuthenticatedUser(
+      payload.userId,
+      payload.username,
+      payload.userRole
+    )
   }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Problem 탭에서 문제를 풀고(Accepted) 다른 유저의 제출 내역을 보려고 하는 경우,
아래와 같이 Access Denied가 뜨는 오류를 해결합니다.
<img width="1004" height="1485" alt="image" src="https://github.com/user-attachments/assets/ceabc981-eb3a-4af3-b1d9-e7de694abde7" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
