### PR TITLE
fix(fe): allow all sub-paths for image remote patterns

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -5,13 +5,13 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === 'true'
 })
 
-const MEDIA_BUCKET_NAME = process.env.MEDIA_BUCKET_NAME
+const BUCKET_NAME = process.env.MEDIA_BUCKET_NAME
 
 const nextConfig = {
   images: {
     remotePatterns: [
-      new URL(`https://${MEDIA_BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com`), // production
-      new URL('https://stage.codedang.com') // development
+      new URL(`https://${BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com/**`), // production
+      new URL('https://stage.codedang.com/**') // development
     ]
   },
   output: 'standalone',


### PR DESCRIPTION
### Description

Next.js 15에서 next.config.ts의 `remotePattern` 값이 `URL()` 객체로 변경되면서, `**` wildcard를 붙여야 sub-path URL을 허용하도록 변경됐습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
