### PR TITLE
fix(infra): lower frontend preview cpu usage

### DIFF
--- a/apps/k8s/frontend/base/deployment.yaml
+++ b/apps/k8s/frontend/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
               cpu: 1
               memory: 2Gi
             requests:
-              cpu: 0.5
+              cpu: 0.2
               memory: 200Mi
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### Description

현재 16코어 짜리 서버 하나에 모든 PR preview를 배포 중이라, 종종 아래처럼 CPU가 부족해 preview가 배포되지 않습니다.
대부분의 preview에서는 CPU usage가 높지 않기 때문에 기존의 0.5vCPU에서 0.2vCPU로 할당량을 낮춥니다. (최대 사용량은 기존과 동일)

<img width="1212" height="303" alt="image" src="https://github.com/user-attachments/assets/b986abcd-29c5-412e-b6ec-8e2c1148d5ee" />

### 현재 pod별 할당된 resource (`kubectl describe nodes`)

```
  Namespace                   Name                                          CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
  ---------                   ----                                          ------------  ----------  ---------------  -------------  ---
  cert-manager                cert-manager-69f748766f-75z5c                 0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  cert-manager                cert-manager-cainjector-7cf6557c49-j79kg      0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  cert-manager                cert-manager-webhook-58f4cff74d-wbzn4         0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  frontend-preview-2127       frontend-5d6c7b8b86-7xg79                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2736       frontend-67b755f544-z2xq6                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2822       frontend-777fb67f68-rxvb5                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2880       frontend-5d7696d576-xpt26                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       8h
  frontend-preview-2918       frontend-66fcf6ddf9-gn6rs                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2918       frontend-74656cb89-grsk5                      500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       4h27m
  frontend-preview-2937       frontend-64986f4656-frk9v                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2952       frontend-84455567f9-vpgw7                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2954       frontend-59bbc7ff85-fhns9                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2955       frontend-d886f7c96-8glcj                      500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       36h
  frontend-preview-2957       frontend-6b644cddfc-8r459                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2958       frontend-65c44f49cb-rc257                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       27h
  frontend-preview-2962       frontend-6f478fc54f-qgr57                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       25h
  frontend-preview-2964       frontend-7cb466dcb-xcn2s                      500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2968       frontend-68f498f97c-hfwvb                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2970       frontend-6c9984cbd6-dfslp                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2971       frontend-678496c86c-7pw89                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       9h
  frontend-preview-2971       frontend-7f58fdbd8b-stmk9                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       2d6h
  frontend-preview-2973       frontend-85d4448c4d-9zvrr                     500m (3%)     1 (6%)      512Mi (1%)       2Gi (6%)       32h
  frontend-preview-2976       frontend-64d66d5c4f-c5lbt                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       46h
  frontend-preview-2976       frontend-6797c4759c-ql5rk                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       2d5h
  frontend-preview-2977       frontend-58cddc48cf-cjx8w                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       8h
  frontend-preview-2978       frontend-5cf66bb458-tt5sd                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       28h
  frontend-preview-2979       frontend-66dbff8666-9vnmk                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       33h
  frontend-preview-2980       frontend-6496555d9d-wjw67                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       10h
  frontend-preview-2984       frontend-78884b584f-vlz56                     500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       5h28m
  frontend-preview-2985       frontend-6fd698f54-8wbm5                      500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       3h49m
  frontend-preview-2986       frontend-bb654b466-wwkpw                      200m (1%)     1 (6%)      200Mi (0%)       2Gi (6%)       52m
  frontend                    frontend-f86dcb758-dlwss                      500m (3%)     1 (6%)      200Mi (0%)       2Gi (6%)       46h
  kube-system                 coredns-5688667fd4-jtzwk                      100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     9d
  kube-system                 local-path-provisioner-774c6665dc-tjlkb       0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  kube-system                 metrics-server-6f4c6675d5-zzkhm               100m (0%)     0 (0%)      70Mi (0%)        0 (0%)         9d
  kube-system                 sealed-secrets-controller-6f44bdc558-dj8w9    0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  kube-system                 svclb-traefik-b9c5a55a-sbzmt                  0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  kube-system                 traefik-c98fdf6fb-q8vf8                       0 (0%)        0 (0%)      0 (0%)           0 (0%)         9d
  kubernetes-dashboard        kubernetes-dashboard-kong-648658d45f-hmwr4    0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
  loki-stage                  loki-canary-xqq2n                             0 (0%)        0 (0%)      0 (0%)           0 (0%)         5h3m
  loki-stage                  loki-stage-0                                  0 (0%)        0 (0%)      0 (0%)           0 (0%)         5h3m
  loki-stage                  loki-stage-chunks-cache-0                     500m (3%)     0 (0%)      9830Mi (30%)     9830Mi (30%)   5h3m
  loki-stage                  loki-stage-gateway-6dd4596b4-kv7m4            0 (0%)        0 (0%)      0 (0%)           0 (0%)         5h3m
  loki-stage                  loki-stage-minio-0                            100m (0%)     0 (0%)      128Mi (0%)       0 (0%)         5h3m
  loki-stage                  loki-stage-results-cache-0                    500m (3%)     0 (0%)      1229Mi (3%)      1229Mi (3%)    5h3m
  observability               grafana-stage-755b8958f-cwz9r                 0 (0%)        0 (0%)      0 (0%)           0 (0%)         54m
  observability               minio-stage-7dbf99f886-l6l7f                  250m (1%)     375m (2%)   256Mi (0%)       384Mi (1%)     5h7m
  observability               minio-stage-console-679cdd4d7b-t2482          100m (0%)     150m (0%)   128Mi (0%)       192Mi (0%)     5h7m
  redis                       redis-stage-master-0                          100m (0%)     150m (0%)   128Mi (0%)       192Mi (0%)     2d14h

```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
