### PR TITLE
fix(infra): don't use template in k8s external secret

### DIFF
--- a/apps/infra/production/codedang/message_queue_aws.tf
+++ b/apps/infra/production/codedang/message_queue_aws.tf
@@ -50,6 +50,7 @@ resource "aws_secretsmanager_secret_version" "judge_queue" {
   secret_string = jsonencode({
     username = var.rabbitmq_username
     password = random_password.rabbitmq_password.result
+    api_url  = aws_mq_broker.judge_queue.instances.0.console_url,
     host     = trimprefix(aws_mq_broker.judge_queue.instances.0.console_url, "https://"),
     port     = var.rabbitmq_port,
     vhost    = rabbitmq_vhost.vh.name

--- a/apps/k8s/client-api/deployment.yaml
+++ b/apps/k8s/client-api/deployment.yaml
@@ -32,7 +32,7 @@ spec:
                 name: aws-credentials
           env:
             - name: REDIS_HOST
-              value: 'redis-master.redis.svc.cluster.local'
+              value: 'redis-production.redis'
             - name: REDIS_PORT
               value: '6379'
             - name: RABBITMQ_SSL

--- a/apps/k8s/client-api/external-secret.yaml
+++ b/apps/k8s/client-api/external-secret.yaml
@@ -35,7 +35,6 @@ spec:
       remoteRef:
         key: Codedang-Database-Secret
         property: url
-
     - secretKey: RABBITMQ_HOST
       remoteRef:
         key: Codedang-JudgeQueue-Secret
@@ -57,5 +56,6 @@ spec:
         key: Codedang-JudgeQueue-Secret
         property: vhost
     - secretKey: RABBITMQ_API_URL
-      template:
-        template: 'https://{{ .RABBITMQ_HOST }}'
+      remoteRef:
+        key: Codedang-JudgeQueue-Secret
+        property: api_url


### PR DESCRIPTION
### Description

현재 client-api가 external-secret을 불러오지 못해 pod 실행이 안됩니다.

> one or more objects failed to apply, reason: error when patching "/dev/shm/1159703879": ExternalSecret.external-secrets.io "client-api-aws-secrets" is invalid: spec.data[6].remoteRef: Required value (retried 5 times).

`client-api-aws-secrets`에서 사용된 template이 external secret에서 제공하는 spec 문법에 맞지 않아 에러가 발생합니다.
template을 고치는 방법도 있지만, terraform에서 RabbitMQ API url을 제공하기 때문에 해당 값을 AWS secret manager에 저장합니다.

추가로 redis url도 고쳤습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
