### PR TITLE
fix(be): change Request Body to Query in getContestQnAs

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.controller.ts
+++ b/apps/backend/apps/client/src/contest/contest.controller.ts
@@ -7,7 +7,8 @@ import {
   ParseIntPipe,
   Post,
   Query,
-  Req
+  Req,
+  ValidationPipe
 } from '@nestjs/common'
 import {
   AuthenticatedRequest,
@@ -22,8 +23,8 @@ import {
 import { ContestService } from './contest.service'
 import {
   ContestQnACreateDto,
-  type ContestQnACommentCreateDto,
-  type GetContestQnAsFilter
+  GetContestQnAsFilter,
+  type ContestQnACommentCreateDto
 } from './dto/contest-qna.dto'
 
 @Controller('contest')
@@ -129,7 +130,7 @@ export class ContestController {
   async getContestQnAs(
     @Req() req: AuthenticatedRequest,
     @Param('id', IDValidationPipe) contestId: number,
-    @Body() filter: GetContestQnAsFilter
+    @Query(new ValidationPipe({ transform: true })) filter: GetContestQnAsFilter
   ) {
     return await this.contestService.getContestQnAs(
       req.user?.id,

--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -6,9 +6,9 @@ import {
   ForbiddenAccessException
 } from '@libs/exception'
 import { PrismaService } from '@libs/prisma'
-import type {
-  ContestQnACreateDto,
-  GetContestQnAsFilter
+import {
+  GetContestQnAsFilter,
+  type ContestQnACreateDto
 } from './dto/contest-qna.dto'
 
 const contestSelectOption = {
@@ -749,30 +749,42 @@ export class ContestService {
 
     // 대회 진행 중이 아니면 별도의 조건 필요 없음
 
-    const where: Prisma.ContestQnAWhereInput = {
+    const baseWhere: Prisma.ContestQnAWhereInput = {
       contestId,
       ...visibleCondition
     }
 
-    if (filter.categories && filter.categories.length > 0) {
-      where.category = { in: filter.categories }
-    }
-    if (
-      filter.categories &&
-      filter.categories.includes(QnACategory.Problem) &&
-      filter.problemOrders &&
-      filter.problemOrders.length > 0
-    ) {
-      const problemIds = await this.prisma.contestProblem
-        .findMany({
-          where: {
-            contestId,
-            order: { in: filter.problemOrders }
-          }
+    const categories = filter.categories ?? []
+    const includeProblem = categories.includes(QnACategory.Problem)
+    const general = categories.filter((c) => c !== QnACategory.Problem)
+
+    const orConds: Prisma.ContestQnAWhereInput[] = []
+
+    if (includeProblem) {
+      if (filter.problemOrders?.length) {
+        const problemIds = await this.prisma.contestProblem
+          .findMany({
+            where: { contestId, order: { in: filter.problemOrders } },
+            select: { problemId: true }
+          })
+          .then((rs) => rs.map((r) => r.problemId))
+
+        orConds.push({
+          category: QnACategory.Problem,
+          problemId: { in: problemIds }
         })
-        .then((results) => results.map((cp) => cp.problemId))
-      where.problemId = { in: problemIds }
+      } else {
+        orConds.push({ category: QnACategory.Problem })
+      }
     }
+
+    if (general.length) {
+      orConds.push({ category: { in: general } })
+    }
+
+    const where: Prisma.ContestQnAWhereInput = orConds.length
+      ? { AND: [baseWhere, { OR: orConds }] }
+      : baseWhere
 
     const qnas = await this.prisma.contestQnA.findMany({
       select: {

--- a/apps/backend/apps/client/src/contest/dto/contest-qna.dto.ts
+++ b/apps/backend/apps/client/src/contest/dto/contest-qna.dto.ts
@@ -1,4 +1,5 @@
 import { QnACategory } from '@prisma/client'
+import { Transform } from 'class-transformer'
 import {
   IsArray,
   IsEnum,
@@ -29,11 +30,32 @@ export class GetContestQnAsFilter {
   @IsArray()
   @IsOptional()
   @IsEnum(QnACategory, { each: true })
+  @Transform(
+    ({ value }) => {
+      if (value === undefined || value === null || value === '')
+        return undefined
+      const arr = Array.isArray(value) ? value : String(value).split(',')
+      return arr.map((v) => String(v).trim()).filter((v) => v.length > 0)
+    },
+    { toClassOnly: true }
+  )
   categories?: QnACategory[]
 
   @IsOptional()
   @IsArray()
   @IsNumber({}, { each: true })
+  @Transform(
+    ({ value }) => {
+      if (value === undefined || value === null || value === '')
+        return undefined
+      const arr = Array.isArray(value) ? value : String(value).split(',')
+      return arr
+        .map((v) => String(v).trim())
+        .filter((v) => v.length > 0)
+        .map((v) => Number(v))
+    },
+    { toClassOnly: true }
+  )
   problemOrders?: number[]
 
   @IsOptional()

--- a/collection/client/Contest/Get Contest QnAs/Succeed.bru
+++ b/collection/client/Contest/Get Contest QnAs/Succeed.bru
@@ -52,14 +52,13 @@ docs {
   |-----------|--------|----------|----------------------------------|
   | `id`      | number | ✅       | ID of the target contest         |
   
-  #### Request Body
-  > problemOrders
+  #### Query Parameters
   - categories에 Problem을 추가해야 문제에 속한 QnA를 필터링 할 수 있습니다
   
   | Name      | Type    | Required  | Description
   |-----------|---------|-----------|------------|
-  | categories | array  |           | General 또는 Problem을 선택할 수 있습니다.|
-  | problemOrders | array  |           | 보여줄 문제의 대회에서의 order를 배열로 요청합니다.|
+  | categories |   |           | General 또는 Problem을 선택할 수 있습니다.|
+  | problemOrders |   |           | 보여줄 문제의 대회에서의 order를 배열로 요청합니다.|
   | orderBy    | string  |          | 정렬 기준을 선택합니다. |
   
   

--- a/collection/client/Contest/Get Contest QnAs/Succeed.bru
+++ b/collection/client/Contest/Get Contest QnAs/Succeed.bru
@@ -5,17 +5,17 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/contest/1/qna
+  url: {{baseUrl}}/contest/1/qna?categories=General&categories=Problem&problemOrders=0
   body: json
   auth: none
 }
 
-body:json {
-  {
-    "categories" : ["Problem"],
-    "problemOrders" : [0,1],
-    "orderBy": "asc"
-  }
+params:query {
+  categories: General
+  categories: Problem
+  problemOrders: 0
+  ~problemOrders: 1
+  ~orderBy: asc
 }
 
 script:pre-request {

--- a/collection/client/Contest/Get Contest QnAs/[404] Nonexistent Contest.bru
+++ b/collection/client/Contest/Get Contest QnAs/[404] Nonexistent Contest.bru
@@ -5,17 +5,17 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/contest/99/qna
+  url: {{baseUrl}}/contest/99/qna?categories=General
   body: json
   auth: none
 }
 
-body:json {
-  {
-    "categories" : ["Problem"],
-    "problemOrders" : [0,1],
-    "orderBy": "asc"
-  }
+params:query {
+  categories: General
+  ~categories: Problem
+  ~problemOrders: 0
+  ~problemOrders: 1
+  ~orderBy: asc
 }
 
 script:pre-request {

--- a/collection/client/Contest/Get Contest QnAs/[404] Nonexistent Contest.bru
+++ b/collection/client/Contest/Get Contest QnAs/[404] Nonexistent Contest.bru
@@ -52,14 +52,13 @@ docs {
   |-----------|--------|----------|----------------------------------|
   | `id`      | number | ✅       | ID of the target contest         |
   
-  #### Request Body
-  > problemOrders
+  #### Query Parameters
   - categories에 Problem을 추가해야 문제에 속한 QnA를 필터링 할 수 있습니다
   
   | Name      | Type    | Required  | Description
   |-----------|---------|-----------|------------|
-  | categories | array  |           | General 또는 Problem을 선택할 수 있습니다.|
-  | problemOrders | array  |           | 보여줄 문제의 대회에서의 order를 배열로 요청합니다.|
+  | categories |   |           | General 또는 Problem을 선택할 수 있습니다.|
+  | problemOrders |   |           | 보여줄 문제의 대회에서의 order를 배열로 요청합니다.|
   | orderBy    | string  |          | 정렬 기준을 선택합니다. |
   
   


### PR DESCRIPTION
### Description

1. GET 메서드에서 Request Body를 사용할 수 없으므로 이를 Query Parameter로 변환합니다.

2. filter 중 카테고리 관련 로직이 의도대로 작동하지 않는 점을 수정합니다.

### Additional context

기존 필터로는 General과 Problem을 모두 선택한 경우에도 problemId에 대한 조건이 AND로 들어가게 되어 General 카테고리가 무시되는 문제가 있어 이를 OR로 묶었습니다.

---
Closes TAS-2016

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
