### PR TITLE
feat(fe): change code editor notification design

### DIFF
--- a/apps/frontend/components/notification/NotificationDropdown.tsx
+++ b/apps/frontend/components/notification/NotificationDropdown.tsx
@@ -324,13 +324,17 @@ export function NotificationDropdown({
               handleMarkAllAsRead={handleMarkAllAsRead}
             />
           </div>
-          <div className="bg-color-neutral-99 mb-1 ml-4 flex w-[168px] rounded-full p-1">
+          <div
+            className={cn(
+              'bg-color-neutral-99 mb-1 ml-4 flex w-[168px] rounded-full p-1',
+              isEditor && 'bg-[#121728]'
+            )}
+          >
             <button
               className={cn(
-                'h-6 w-20 rounded-full text-sm font-medium transition-colors',
-                filter === 'all'
-                  ? 'text-primary bg-white'
-                  : 'bg-transparent text-gray-700'
+                'text-color-neutral-80 h-6 w-20 rounded-full bg-transparent text-sm font-medium transition-colors',
+                filter === 'all' && !isEditor && 'text-primary bg-white',
+                filter === 'all' && isEditor && 'text-primary bg-[#334155]'
               )}
               onClick={() => setFilter('all')}
             >
@@ -338,10 +342,9 @@ export function NotificationDropdown({
             </button>
             <button
               className={cn(
-                'h-6 w-20 rounded-full text-sm font-medium transition-colors',
-                filter === 'unread'
-                  ? 'text-primary bg-white'
-                  : 'bg-transparent text-gray-700'
+                'text-color-neutral-80 h-6 w-20 rounded-full bg-transparent text-sm font-medium transition-colors',
+                filter === 'unread' && !isEditor && 'text-primary bg-white',
+                filter === 'unread' && isEditor && 'text-primary bg-[#334155]'
               )}
               onClick={() => setFilter('unread')}
             >
@@ -367,7 +370,11 @@ export function NotificationDropdown({
           )}
 
           {notifications.length > 0 && (
-            <ScrollArea className="h-[426px]" bottomFade={true} topFade={true}>
+            <ScrollArea
+              className="h-[426px]"
+              bottomFade={!isEditor}
+              topFade={!isEditor}
+            >
               <div className="space-y-3 px-4 pt-2">
                 {notifications.map((notification, index) => (
                   <div
@@ -377,10 +384,7 @@ export function NotificationDropdown({
                     }
                     className={cn(
                       'hover:bg-color-neutral-99 group relative h-[114px] cursor-pointer rounded-lg bg-white p-3 shadow-[0_4px_20px_0_rgba(53,78,116,0.10)]',
-                      isEditor && 'bg-slate-700 text-white hover:bg-[#293548]',
-                      isEditor &&
-                        !notification.isRead &&
-                        'bg-slate-500 hover:bg-[#56657a]'
+                      isEditor && 'bg-[#334155] text-white hover:bg-[#293548]'
                     )}
                     role="button"
                     tabIndex={0}
@@ -409,6 +413,7 @@ export function NotificationDropdown({
                           )}
                         >
                           <Badge
+                            className={cn(isEditor && 'bg-[#41526A]')}
                             variant={
                               notification.type === 'Assignment'
                                 ? 'Course'

--- a/apps/frontend/components/notification/NotificationOptionsMenu.tsx
+++ b/apps/frontend/components/notification/NotificationOptionsMenu.tsx
@@ -39,9 +39,8 @@ export function NotificationOptionsMenu({
         <DropdownMenuItem
           onSelect={handleMarkAllAsRead}
           className={cn(
-            'flex cursor-pointer gap-2',
-            'hover:bg-color-neutral-99',
-            isEditor && 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+            'hover:!bg-color-neutral-99 flex cursor-pointer gap-2',
+            isEditor && '!bg-slate-700 !text-gray-300 hover:!bg-slate-800'
           )}
         >
           <Image src={CheckIcon} alt="check" width={16} height={16} />
@@ -49,9 +48,8 @@ export function NotificationOptionsMenu({
         </DropdownMenuItem>
         <DropdownMenuItem
           className={cn(
-            'ml-[1px] flex gap-2.5',
-            'hover:bg-color-neutral-99',
-            isEditor && 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+            'hover:!bg-color-neutral-99 ml-[1px] flex gap-2.5',
+            isEditor && '!bg-slate-700 !text-gray-300 hover:!bg-slate-800'
           )}
         >
           <Image src={SettingsIcon} alt="settings" width={13} height={12} />


### PR DESCRIPTION
### Description

코드 에디터에서의 알림 색상을 바꿨습니다
<img width="368" height="535" alt="image" src="https://github.com/user-attachments/assets/225074c7-ab5c-4799-b274-c4c5adb53886" />

closes TAS-2037

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
