### PR TITLE
fix(fe): prevent katex content xss

### DIFF
--- a/apps/frontend/libs/renderKatex.ts
+++ b/apps/frontend/libs/renderKatex.ts
@@ -7,7 +7,10 @@ export const renderKatex = (
   katexRef: RefObject<HTMLDivElement | null>
 ) => {
   if (katexRef.current) {
-    katexRef.current.innerHTML = DOMPurify.sanitize(html ?? '')
+    katexRef.current.innerHTML = DOMPurify.sanitize(html ?? '', {
+      ADD_TAGS: ['math-component'],
+      ADD_ATTR: ['content']
+    })
     const div = katexRef.current
     div.querySelectorAll('math-component').forEach((el) => {
       const content = el.getAttribute('content') || ''


### PR DESCRIPTION
### Description

XSS 공격을 예방합니다

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b07f3e98-11db-49b1-832c-0c7276850e62" />

closes TAS-2041


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
