### PR TITLE
fix(fe): prevent infinite refetch when refresh

### DIFF
--- a/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
+++ b/apps/frontend/app/admin/contest/[contestId]/(overall)/@tabs/leaderboard/page.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/shadcn/input'
 import { GET_CONTEST } from '@/graphql/contest/queries'
 import { GET_CONTEST_LEADERBOARD } from '@/graphql/leaderboard/queries'
 import searchIcon from '@/public/icons/search.svg'
-import { useSuspenseQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
 import { useState, useEffect } from 'react'
@@ -35,28 +35,25 @@ export default function ContestLeaderBoard() {
   const pathname = usePathname()
   const contestId = Number(pathname.split('/')[3])
 
-  const { data: contestLeaderboard } = useSuspenseQuery(
-    GET_CONTEST_LEADERBOARD,
-    {
-      variables: { contestId }
-    }
-  )
+  const { data: contestLeaderboard } = useQuery(GET_CONTEST_LEADERBOARD, {
+    variables: { contestId }
+  })
 
   const [disableLeaderboard, setDisableLeaderboard] = useState<boolean>(true)
-  const { data: fetchedContest } = useSuspenseQuery(GET_CONTEST, {
+  const { data: fetchedContest } = useQuery(GET_CONTEST, {
     variables: { contestId }
   })
 
   const now = new Date()
   useEffect(() => {
-    const endTime = new Date(fetchedContest.getContest.endTime)
+    const endTime = new Date(fetchedContest?.getContest.endTime)
     if (endTime > now) {
       setDisableLeaderboard(true)
     } else {
       setDisableLeaderboard(false)
     }
   }, [fetchedContest])
-  const isUnfrozen = !contestLeaderboard.getContestLeaderboard.isFrozen
+  const isUnfrozen = !contestLeaderboard?.getContestLeaderboard.isFrozen
 
   const [problemSize, setProblemSize] = useState(0)
   const [leaderboardUsers, setLeaderboardUsers] = useState([
@@ -64,8 +61,10 @@ export default function ContestLeaderBoard() {
   ])
 
   useEffect(() => {
-    if (contestLeaderboard.getContestLeaderboard.leaderboard[0] === undefined) {
-      const contestStartTime = new Date(fetchedContest.getContest.startTime)
+    if (
+      contestLeaderboard?.getContestLeaderboard.leaderboard[0] === undefined
+    ) {
+      const contestStartTime = new Date(fetchedContest?.getContest.startTime)
       if (contestStartTime > now) {
         throw new Error(
           'Error(before start): There is no data in leaderboard yet.'
@@ -119,9 +118,10 @@ export default function ContestLeaderBoard() {
       <div className="mb-[62px] mt-[60px] flex w-full flex-row justify-between pl-[14px] pr-[9px]">
         <div className="flex flex-row text-2xl font-semibold text-black">
           <div className="text-[#3581FA]">
-            {contestLeaderboard.getContestLeaderboard.participatedNum}
+            {contestLeaderboard?.getContestLeaderboard.participatedNum}
           </div>
-          /{contestLeaderboard.getContestLeaderboard.registeredNum} Participants
+          /{contestLeaderboard?.getContestLeaderboard.registeredNum}{' '}
+          Participants
         </div>
         <div className="relative">
           <Image

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
@@ -40,21 +40,21 @@ export function ParticipantTable({
 
   const [updateAssignment] = useMutation(UPDATE_ASSIGNMENT)
 
-  const summaries = useSuspenseQuery(GET_ASSIGNMENT_SCORE_SUMMARIES, {
+  const summaries = useQuery(GET_ASSIGNMENT_SCORE_SUMMARIES, {
     variables: { groupId, assignmentId, take: 300 }
   })
-  const summariesData = summaries.data.getAssignmentScoreSummaries.map(
+  const summariesData = summaries.data?.getAssignmentScoreSummaries.map(
     (item) => ({
       ...item,
       id: item.userId
     })
   )
 
-  const problems = useSuspenseQuery(GET_ASSIGNMENT_PROBLEMS, {
+  const problems = useQuery(GET_ASSIGNMENT_PROBLEMS, {
     variables: { groupId, assignmentId }
   })
 
-  const problemData = problems.data.getAssignmentProblems
+  const problemData = problems.data?.getAssignmentProblems
     .slice()
     .sort((a, b) => a.order - b.order)
 
@@ -101,7 +101,7 @@ export function ParticipantTable({
     { label: 'Student Id', key: 'studentId' },
     { label: 'Name', key: 'realName' },
     {
-      label: `Total Score(MAX ${summaries?.data.getAssignmentScoreSummaries[0]?.assignmentPerfectScore || 0})`,
+      label: `Total Score(MAX ${summaries?.data?.getAssignmentScoreSummaries[0]?.assignmentPerfectScore || 0})`,
       key: 'finalScore'
     },
 
@@ -109,7 +109,7 @@ export function ParticipantTable({
   ]
 
   const csvData =
-    summaries.data.getAssignmentScoreSummaries.map((user) => {
+    summaries.data?.getAssignmentScoreSummaries.map((user) => {
       const userProblemScores = problemList.map((problem) => {
         const scoreData = user.problemScores.find(
           (ps) => ps.problemId === problem.problemId
@@ -175,13 +175,13 @@ export function ParticipantTable({
         </UtilityPanel>
       </div>
       <p className="mb-3 font-medium">
-        <span className="text-primary font-bold">{summariesData.length}</span>{' '}
+        <span className="text-primary font-bold">{summariesData?.length}</span>{' '}
         Participants
       </p>
       <DataTableRoot
-        data={summariesData}
+        data={summariesData || []}
         columns={createColumns(
-          problemData,
+          problemData || [],
           groupId,
           assignmentId,
           isAssignmentFinished,

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/page.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/shadcn/table'
 import { GET_ASSIGNMENT } from '@/graphql/assignment/queries'
 import { GET_ASSIGNMENT_PROBLEMS } from '@/graphql/problem/queries'
-import { useQuery, useSuspenseQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { ChevronDownIcon } from '@radix-ui/react-icons'
 import { ErrorBoundary } from '@suspensive/react'
 import { Suspense, useState, use } from 'react'
@@ -34,7 +34,7 @@ export default function Information(props: InformationProps) {
   }).data?.getAssignment
 
   const problemsData =
-    useSuspenseQuery(GET_ASSIGNMENT_PROBLEMS, {
+    useQuery(GET_ASSIGNMENT_PROBLEMS, {
       variables: {
         groupId: Number(params.courseId),
         assignmentId: Number(params.assignmentId)

--- a/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/exercise/[exerciseId]/(overall)/@tabs/page.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/shadcn/table'
 import { GET_ASSIGNMENT } from '@/graphql/assignment/queries'
 import { GET_ASSIGNMENT_PROBLEMS } from '@/graphql/problem/queries'
-import { useQuery, useSuspenseQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { ChevronDownIcon } from '@radix-ui/react-icons'
 import { ErrorBoundary } from '@suspensive/react'
 import { useState, use } from 'react'
@@ -33,7 +33,7 @@ export default function Information(props: InformationProps) {
   }).data?.getAssignment
 
   const problemsData =
-    useSuspenseQuery(GET_ASSIGNMENT_PROBLEMS, {
+    useQuery(GET_ASSIGNMENT_PROBLEMS, {
       variables: {
         groupId: Number(params.courseId),
         assignmentId: Number(params.exerciseId)


### PR DESCRIPTION
### Description

현재 management 쪽 contest leaderboard, assignment/exercise information, assignment assessment 페이지를 접속하고 **새로고침**(또는 URL 직접 입력해서 접속)을 하면, **순식간에 수천개의 graphql 쿼리를 무한으로 요청**하면서 페이지가 로딩되지 않는 심각한 버그가 존재합니다. 이전에 새 탭으로 열기가 디폴트인 submission별 assessment 화면에서도 발견해 급히 [useSuspenseQuery를 useQuery로 대체함으로써 해결했었던](https://github.com/skkuding/codedang/pull/2931/commits/73d949b7d4d513098169583070b617b5063f0b53) 문제인데, 이 페이지들에서도 같은 문제가 존재하는 것을 확인해 동일한 방법으로 수정하였습니다. 8/13 Preview에서는 정상적으로 동작하고, 8/15 Preview에서는 동일한 문제가 발생한다는 점을 봤을 때 8/14에 머지된 next.js 15 업그레이드가 원인일 확률이 매우 높아보입니다. 다만 변경점을 읽어보아도 정확한 이유를 발견하진 못해 현재로선 최선의 방법인 것 같습니다...

이 페이지들 외에도 다른 페이지들에 문제가 없는지 확인 부탁드립니다. 

closes TAS-2047

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
