### PR TITLE
fix(infra): update targetRevision to 0.16.5 in redis.yaml

### DIFF
--- a/apps/k8s/argocd/applications/redis.yaml
+++ b/apps/k8s/argocd/applications/redis.yaml
@@ -25,7 +25,7 @@ spec:
       sources:
         - repoURL: https://ot-container-kit.github.io/helm-charts
           chart: redis
-          targetRevision: 7.0.15
+          targetRevision: 0.16.5
           helm:
             valueFiles:
               - $codedang/apps/k8s/redis/values.yaml


### PR DESCRIPTION
### Description
<img width="1508" height="666" alt="image" src="https://github.com/user-attachments/assets/4fa519ab-9660-497f-a999-efbb153d8275" />

- Redis의 버전으로 혼동한 Chart의 버전을 수정했습니다.

### Additional context
```sh
helm search repo ot-helm
```
위 명령어로 차트 버전 확인 가능하니 다른 분들은 저처럼 실수하지 마시길!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
