### PR TITLE
feat(fe): add auto finalize button

### DIFF
--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/Columns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/Columns.tsx
@@ -142,14 +142,14 @@ function ScoreEditableCell({
             }
           }}
         />
-        <span className="text-xs">/{problemScore?.maxScore ?? 0}</span>
+        <span className="text-xs"> / {problemScore?.maxScore ?? 0}</span>
       </div>
     )
   }
   return (
     <div
       className={cn(
-        'rounded-xs cursor-pointer px-1 text-xs hover:bg-gray-100',
+        'rounded-xs cursor-pointer text-xs hover:bg-gray-100',
         editing && 'bg-gray-100'
       )}
       onClick={() => {
@@ -160,7 +160,7 @@ function ScoreEditableCell({
         setEditing(true)
       }}
     >
-      {problemScore?.finalScore ?? '-'}/{problemScore?.maxScore ?? 0}
+      {problemScore?.finalScore ?? '-'} / {problemScore?.maxScore ?? 0}
     </div>
   )
 }
@@ -240,7 +240,7 @@ export const createColumns = (
       ),
       cell: ({ row }) => (
         <div className="text-xs">
-          {row.original.userAssignmentFinalScore}/
+          {row.original.userAssignmentFinalScore} /{' '}
           {row.original.assignmentPerfectScore}
         </div>
       )

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/Columns.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/Columns.tsx
@@ -170,6 +170,7 @@ export const createColumns = (
   courseId: number,
   assignmentId: number,
   isAssignmentFinished: boolean,
+  currentView: 'final' | 'auto',
   refetch: () => void
 ): ColumnDef<DataTableScoreSummary>[] => {
   return [
@@ -209,6 +210,13 @@ export const createColumns = (
         const problemScore = row.original.problemScores.find(
           (ps) => ps.problemId === problem.problemId
         )
+        if (currentView === 'auto') {
+          return (
+            <div className="text-xs">
+              {problemScore?.score ?? '-'} / {problemScore?.maxScore ?? 0}
+            </div>
+          )
+        }
         return (
           <ScoreEditableCell
             problemScore={problemScore}

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
@@ -231,8 +231,12 @@ export function ParticipantTable({
 
                   summaries.refetch()
                   setCurrentView('final')
-                } catch {
-                  toast.error('Failed to apply auto grading')
+                } catch (error) {
+                  if (error instanceof Error) {
+                    toast.error(error.message)
+                  } else {
+                    toast.error('Failed to apply auto grading')
+                  }
                 }
               }}
             >

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
@@ -70,6 +70,15 @@ export function ParticipantTable({
     })
   )
 
+  useEffect(() => {
+    if (summariesData && summariesData.length > 0) {
+      const hasAnyFinalScore = summariesData.some((item) =>
+        item.problemScores.some((problem) => problem.finalScore !== null)
+      )
+      setCurrentView(hasAnyFinalScore ? 'final' : 'auto')
+    }
+  }, [summariesData?.length])
+
   const problems = useQuery(GET_ASSIGNMENT_PROBLEMS, {
     variables: { groupId, assignmentId }
   })

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/assessment/_components/ParticipantTable.tsx
@@ -7,16 +7,33 @@ import {
   DataTableRoot,
   DataTableSearchBar
 } from '@/app/admin/_components/table'
+import { Button } from '@/components/shadcn/button'
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList
+} from '@/components/shadcn/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '@/components/shadcn/popover'
 import { Skeleton } from '@/components/shadcn/skeleton'
 import { Switch } from '@/components/shadcn/switch'
-import { UPDATE_ASSIGNMENT } from '@/graphql/assignment/mutations'
+import {
+  AUTO_FINALIZE_SCORE,
+  UPDATE_ASSIGNMENT
+} from '@/graphql/assignment/mutations'
 import {
   GET_ASSIGNMENT,
   GET_ASSIGNMENT_SCORE_SUMMARIES
 } from '@/graphql/assignment/queries'
 import { GET_ASSIGNMENT_PROBLEMS } from '@/graphql/problem/queries'
-import { useMutation, useQuery, useSuspenseQuery } from '@apollo/client'
+import { cn } from '@/libs/utils'
+import { useMutation, useQuery } from '@apollo/client'
 import dayjs from 'dayjs'
+import { Check, ChevronsUpDown } from 'lucide-react'
 import { useState, useEffect } from 'react'
 import { CSVLink } from 'react-csv'
 import { toast } from 'sonner'
@@ -38,7 +55,10 @@ export function ParticipantTable({
     }
   }).data?.getAssignment
 
+  const [currentView, setCurrentView] = useState<'final' | 'auto'>('final')
+  const [viewOpen, setViewOpen] = useState(false)
   const [updateAssignment] = useMutation(UPDATE_ASSIGNMENT)
+  const [autoFinalizeScore] = useMutation(AUTO_FINALIZE_SCORE)
 
   const summaries = useQuery(GET_ASSIGNMENT_SCORE_SUMMARIES, {
     variables: { groupId, assignmentId, take: 300 }
@@ -174,10 +194,94 @@ export function ParticipantTable({
           </CSVLink>
         </UtilityPanel>
       </div>
-      <p className="mb-3 font-medium">
-        <span className="text-primary font-bold">{summariesData?.length}</span>{' '}
-        Participants
-      </p>
+      <div className="flex items-end justify-between">
+        <p className="mb-3 font-medium">
+          <span className="text-primary font-bold">
+            {summariesData?.length}
+          </span>{' '}
+          Participants
+        </p>
+        <div className="flex gap-2">
+          {currentView === 'auto' && (
+            <Button
+              onClick={async () => {
+                try {
+                  const result = await autoFinalizeScore({
+                    variables: { groupId, assignmentId }
+                  })
+
+                  const gradedCount = result.data?.autoFinalizeScore
+                  const expectedCount =
+                    (summariesData?.length || 0) * (problemData?.length || 0)
+
+                  if (gradedCount === expectedCount) {
+                    toast.success('Successfully graded all submissions')
+                  } else {
+                    toast.success(`Graded ${gradedCount} submissions`)
+                  }
+
+                  summaries.refetch()
+                  setCurrentView('final')
+                } catch {
+                  toast.error('Failed to apply auto grading')
+                }
+              }}
+            >
+              Apply to Final Score
+            </Button>
+          )}
+          <Popover open={viewOpen} onOpenChange={setViewOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                className="w-[200px] justify-between"
+              >
+                {currentView === 'final' ? 'Final Score' : 'Auto Graded Score'}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[200px] p-0">
+              <Command>
+                <CommandList>
+                  <CommandGroup>
+                    <CommandItem
+                      value="final"
+                      onSelect={() => {
+                        setCurrentView('final')
+                        setViewOpen(false)
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4',
+                          currentView === 'final' ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      Final Score
+                    </CommandItem>
+                    <CommandItem
+                      value="auto"
+                      onSelect={() => {
+                        setCurrentView('auto')
+                        setViewOpen(false)
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4',
+                          currentView === 'auto' ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      Auto Graded Score
+                    </CommandItem>
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
       <DataTableRoot
         data={summariesData || []}
         columns={createColumns(
@@ -185,6 +289,7 @@ export function ParticipantTable({
           groupId,
           assignmentId,
           isAssignmentFinished,
+          currentView,
           summaries.refetch
         )}
       >
@@ -200,7 +305,9 @@ export function ParticipantTableFallback() {
   return (
     <div>
       <Skeleton className="mb-3 h-[24px] w-2/12" />
-      <DataTableFallback columns={createColumns([], 0, 0, true, () => {})} />
+      <DataTableFallback
+        columns={createColumns([], 0, 0, true, 'final', () => {})}
+      />
     </div>
   )
 }

--- a/apps/frontend/graphql/assignment/mutations.ts
+++ b/apps/frontend/graphql/assignment/mutations.ts
@@ -129,6 +129,12 @@ const UPDATE_ASSIGNMENT_PROBLEM_RECORD = gql(`
   }
 `)
 
+const AUTO_FINALIZE_SCORE = gql(`
+  mutation AutoFinalizeScore($groupId: Int!, $assignmentId: Int!) {
+    autoFinalizeScore(groupId: $groupId, assignmentId: $assignmentId)
+  }
+`)
+
 export {
   CREATE_ASSIGNMENT,
   DELETE_ASSIGNMENT,
@@ -137,5 +143,6 @@ export {
   REMOVE_PROBLEMS_FROM_ASSIGNMENT,
   UPDATE_ASSIGNMENT,
   UPDATE_ASSIGNMENT_PROBLEM_RECORD,
-  UPDATE_ASSIGNMENT_VISIBLE
+  UPDATE_ASSIGNMENT_VISIBLE,
+  AUTO_FINALIZE_SCORE
 }


### PR DESCRIPTION
### Description

Final Score와 Auto Graded Score를 전환할 수 있는 Combobox를 만들고, Auto Graded Score일 때 'Apply to Final Score' 버튼을 보이게 해 자동 채점 점수를 최종 점수에 반영하는 API를 연동하였습니다.
일단 두 개의 뷰로 나눈 이유는, Auto Graded Score 테이블과 비슷한 형식이 Submission 탭의 Students에도 있지만 잘 쓰이지 않고, Submissons에 있기 적절하지 않다고 생각에 추후 제거하고 Assessment에서만 자동 채점 점수를 관리하는 게 맞다고 생각했습니다. 또한 나중에 더 확장해서 특정 열(problem)을 클릭해서 해당 문제들을 전부 자동채점 처리, 특정 행(student)를 클릭해서 해당 학생의 제출들을 전부 자동채점 처리, 특정 칸(submission)을 클릭해서 해당 제출만 자동채점 처리 등의 구현이 가능할 것이라고 생각했기 때문입니다.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/6a1d8a70-d7e4-47a0-aeaa-0e8a6c3c049e" />

closes TAS-2062


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
