### PR TITLE
fix(infra): reduce number of iris pods in stage

### DIFF
--- a/apps/k8s/iris/overlays/stage/kustomization.yaml
+++ b/apps/k8s/iris/overlays/stage/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - database-credentials.yaml
   - minio-credentials.yaml
 
+replicas:
+  - name: iris
+    count: 3
+
 patches:
   - path: configmap.yaml
     target:


### PR DESCRIPTION
### Description

스테이지 환경에서 iris를 기존 20개 대신 3개의 pod만 띄우도록 조정합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
