### PR TITLE
fix(infra): allow modifying image by argocd-image-updater

### DIFF
--- a/apps/k8s/argocd/applications/admin-api.yaml
+++ b/apps/k8s/argocd/applications/admin-api.yaml
@@ -7,6 +7,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   # Required for argocd-image-updater to make changes to the Application
+  # Otherwise, the changed image will be reverted to the original one by this ApplicationSet controller
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/admin-api.yaml
+++ b/apps/k8s/argocd/applications/admin-api.yaml
@@ -6,6 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  # Required for argocd-image-updater to make changes to the Application
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/admin-api.yaml
+++ b/apps/k8s/argocd/applications/admin-api.yaml
@@ -6,6 +6,9 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  ignoreApplicationDifferences:
+    - jsonPointers:
+        - /spec/source/kustomize/images
   goTemplate: true
   goTemplateOptions: ['missingkey=error']
   generators:
@@ -34,9 +37,6 @@ spec:
         directory:
           # kustomization.yaml is ignored if recurse is true
           recurse: false
-        kustomize:
-          images:
-            - 'ghcr.io/skkuding/codedang-admin-api:{{.env}}'
       destination:
         namespace: admin-api
         name: '{{.env}}'

--- a/apps/k8s/argocd/applications/client-api.yaml
+++ b/apps/k8s/argocd/applications/client-api.yaml
@@ -6,6 +6,9 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  ignoreApplicationDifferences:
+    - jsonPointers:
+        - /spec/source/kustomize/images
   goTemplate: true
   goTemplateOptions: ['missingkey=error']
   generators:
@@ -34,9 +37,6 @@ spec:
         directory:
           # kustomization.yaml is ignored if recurse is true
           recurse: false
-        kustomize:
-          images:
-            - 'ghcr.io/skkuding/codedang-client-api:{{.env}}'
       destination:
         namespace: client-api
         name: '{{.env}}'

--- a/apps/k8s/argocd/applications/client-api.yaml
+++ b/apps/k8s/argocd/applications/client-api.yaml
@@ -7,6 +7,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   # Required for argocd-image-updater to make changes to the Application
+  # Otherwise, the changed image will be reverted to the original one by this ApplicationSet controller
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/client-api.yaml
+++ b/apps/k8s/argocd/applications/client-api.yaml
@@ -6,6 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  # Required for argocd-image-updater to make changes to the Application
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/frontend.yaml
+++ b/apps/k8s/argocd/applications/frontend.yaml
@@ -7,6 +7,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   # Required for argocd-image-updater to make changes to the Application
+  # Otherwise, the changed image will be reverted to the original one by this ApplicationSet controller
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/frontend.yaml
+++ b/apps/k8s/argocd/applications/frontend.yaml
@@ -6,6 +6,9 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  ignoreApplicationDifferences:
+    - jsonPointers:
+        - /spec/source/kustomize/images
   goTemplate: true
   goTemplateOptions: ['missingkey=error']
   generators:
@@ -39,9 +42,6 @@ spec:
         directory:
           # kustomization.yaml is ignored if recurse is true
           recurse: false
-        kustomize:
-          images:
-            - 'ghcr.io/skkuding/codedang-frontend:{{.env}}'
       destination:
         namespace: frontend
         name: '{{.env}}'

--- a/apps/k8s/argocd/applications/frontend.yaml
+++ b/apps/k8s/argocd/applications/frontend.yaml
@@ -6,6 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  # Required for argocd-image-updater to make changes to the Application
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/iris.yaml
+++ b/apps/k8s/argocd/applications/iris.yaml
@@ -7,6 +7,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   # Required for argocd-image-updater to make changes to the Application
+  # Otherwise, the changed image will be reverted to the original one by this ApplicationSet controller
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images

--- a/apps/k8s/argocd/applications/iris.yaml
+++ b/apps/k8s/argocd/applications/iris.yaml
@@ -6,6 +6,9 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  ignoreApplicationDifferences:
+    - jsonPointers:
+        - /spec/source/kustomize/images
   goTemplate: true
   goTemplateOptions: ['missingkey=error']
   generators:
@@ -34,9 +37,6 @@ spec:
         directory:
           # kustomization.yaml is ignored if recurse is true
           recurse: false
-        kustomize:
-          images:
-            - 'ghcr.io/skkuding/codedang-iris:{{.env}}'
       destination:
         namespace: iris
         name: '{{.env}}'

--- a/apps/k8s/argocd/applications/iris.yaml
+++ b/apps/k8s/argocd/applications/iris.yaml
@@ -6,6 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
+  # Required for argocd-image-updater to make changes to the Application
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/source/kustomize/images


### PR DESCRIPTION
### Description

Argo CD에서 image-updater를 적용해도 이미지가 새로 pull되지 않는 문제가 있습니다. (fronend는 10일 전 이미지 사용 중)
지금 ApplicationSet이 모든 spec을 강제로 sync해, argocd-image-updater가 image를 변경해도 다시 ApplicationSet의 이미지로 변경되거나 초기화되는 것이 문제였습니다.
ApplicationSet의 `ignoreApplicationDifferences` 옵션을 설정해 이미지만 sync에서 예외 설정을 해둡니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
