### PR TITLE
feat(infra): forward stage frontend to k8s instead of coolify

### DIFF
--- a/.github/workflows/cd-stage.yml
+++ b/.github/workflows/cd-stage.yml
@@ -39,10 +39,9 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/codedang-frontend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # TODO: change url back to stage.codedang.com
           build-args: |
-            BASEURL=https://k8s-test.stage.codedang.com/api
-            GQL_BASEURL=https://k8s-test.stage.codedang.com/graphql
+            BASEURL=https://stage.codedang.com/api
+            GQL_BASEURL=https://stage.codedang.com/graphql
 
   build-client-api:
     name: Build client-api image

--- a/apps/infra/stage/server2/Caddyfile
+++ b/apps/infra/stage/server2/Caddyfile
@@ -106,8 +106,8 @@ stage.codedang.com {
 	}
 
 	handle {
-		reverse_proxy https://coolify.codedang.com {
-			header_up Host coolify.codedang.com
+		reverse_proxy https://k8s-test.stage.codedang.com {
+			header_up Host k8s-test.stage.codedang.com
 		}
 	}
 }


### PR DESCRIPTION
### Description

Caddy로 들어오는 frontend stage 트래픽을 Coolify 대신 kubernetes로 forward합니다.
Kubernetes 내 frontend의 API URL도 stage.codedang.com으로 수정해두었습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
