### PR TITLE
fix(infra): add aws-credentials.yaml to stage client api

### DIFF
--- a/apps/k8s/client-api/overlays/stage/kustomization.yaml
+++ b/apps/k8s/client-api/overlays/stage/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: client-api
 
 resources:
   - ../../base
+  - secrets/aws-credentials.yaml
   - secrets/database-credentials.yaml
   - secrets/oauth-credentials.yaml
   - secrets/security-keys.yaml


### PR DESCRIPTION
### Description

스테이지 Client API에서 누락된 Minio 접근을 위한 정보를 추가합니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
