### PR TITLE
fix(be): separate cache db

### DIFF
--- a/apps/backend/apps/admin/src/admin.module.ts
+++ b/apps/backend/apps/admin/src/admin.module.ts
@@ -53,7 +53,8 @@ import { WorkbookModule } from './workbook/workbook.module'
       useFactory: (configService: ConfigService) => ({
         connection: {
           host: configService.get<string>('REDIS_HOST'),
-          port: configService.get<number>('REDIS_PORT')
+          port: configService.get<number>('REDIS_PORT'),
+          db: 1 // use database 1 for BullMQ to avoid conflicts with other Redis clients
         },
         prefix: 'bull'
       }),

--- a/apps/backend/libs/cache/src/cache-config.service.ts
+++ b/apps/backend/libs/cache/src/cache-config.service.ts
@@ -14,12 +14,13 @@ export class CacheConfigService implements CacheOptionsFactory {
   async createCacheOptions(): Promise<CacheModuleOptions> {
     const host = this.config.get<string>('REDIS_HOST')
     const port = this.config.get<string>('REDIS_PORT')
+    const db = 0
 
     if (!host || !port) {
       throw new Error('Redis host and port must be configured')
     }
 
-    const store = createKeyv(`redis://${host}:${port}`, {
+    const store = createKeyv(`redis://${host}:${port}/${db}`, {
       throwOnErrors: true,
       throwOnConnectError: true
     })


### PR DESCRIPTION
### Description
<img width="948" height="415" alt="image" src="https://github.com/user-attachments/assets/0a84eadc-582a-4c56-a9d0-89663d69971d" />

Admin API 컨테이너 시작 시 캐시 연결 test 실패가 확률적으로 실패합니다.
아마 BullMQ와 기존 캐시 저장소가 사용하는 Redis의 DB가 겹쳐서 발생하는 문제로 예상됩니다.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- BullMQ와 기존 캐시 저장소가 사용하는 Redis DB를 분리합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
