### PR TITLE
chore(fe): prevent isPasswordVisible activation when pressing enter on signIn modal

### DIFF
--- a/apps/frontend/components/auth/SignIn.tsx
+++ b/apps/frontend/components/auth/SignIn.tsx
@@ -80,6 +80,7 @@ export function SignIn() {
             {...register('password')}
           />
           <button
+            type="button"
             className="absolute inset-y-0 right-[21.67px] flex items-center"
             onClick={() => setIsPasswordVisible(!isPasswordVisible)}
           >


### PR DESCRIPTION
### Description
저 눈동자 버튼이 submit 버튼으로 인식되어 엔터를 누르면 패스워드가 보이던 버그를 수정합니다.
<img width="487" height="542" alt="image" src="https://github.com/user-attachments/assets/1af96718-c049-4001-bd4e-a1214e146bc3" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

Closes TAS-2093

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
