### PR TITLE
chore(be): chore of get problem

### DIFF
--- a/apps/backend/apps/admin/src/problem/services/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/problem.service.ts
@@ -401,7 +401,7 @@ export class ProblemService {
   }
 
   async getProblem(id: number, userRole: Role, userId: number) {
-    const problem = await this.prisma.problem.findFirstOrThrow({
+    const problem = await this.prisma.problem.findFirst({
       where: {
         id
       },
@@ -409,6 +409,7 @@ export class ProblemService {
         sharedGroups: true
       }
     })
+    if (!problem) throw new EntityNotExistException('Problem')
     if (userRole != Role.Admin) {
       const leaderGroupIds = (
         await this.prisma.userGroup.findMany({

--- a/apps/backend/apps/admin/src/problem/services/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/problem.service.ts
@@ -11,6 +11,7 @@ import { ContestRole, ProblemField, Role } from '@prisma/client'
 import { Workbook } from 'exceljs'
 import { MAX_DATE, MIN_DATE } from '@libs/constants'
 import {
+  EntityNotExistException,
   UnprocessableDataException,
   UnprocessableFileDataException
 } from '@libs/exception'
@@ -431,11 +432,12 @@ export class ProblemService {
   }
 
   async getProblemById(id: number) {
-    const problem = await this.prisma.problem.findFirstOrThrow({
+    const problem = await this.prisma.problem.findFirst({
       where: {
         id
       }
     })
+    if (!problem) throw new EntityNotExistException('Problem')
     return this.changeVisibleLockTimeToIsVisible(problem)
   }
 

--- a/collection/admin/Problem/Get a Problem/Succeed.bru
+++ b/collection/admin/Problem/Get a Problem/Succeed.bru
@@ -51,7 +51,7 @@ body:graphql {
 
 body:graphql:vars {
   {
-    "id": 11
+    "id": 1
   }
 }
 


### PR DESCRIPTION
### Description

1. admin 단의 get a problem 중 succeed 케이스를 의도한대로 동작하도록 수정합니다.
2. 예외 처리에 대한 설명을 확인하기 쉽게 findFirstOrThrow 대신 findFirst와 조건문으로 EntityNotExistException을 반환하도록 수정합니다.

### Additional context


---

Closes TAS-2094

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
