### PR TITLE
fix(fe): do not import xterm directly for ssr error

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useRunner.ts
+++ b/apps/frontend/app/(client)/(code-editor)/_components/TestcasePanel/useRunner.ts
@@ -6,8 +6,9 @@ import {
   type Language,
   type RunnerMessage
 } from '@/types/type'
-import { FitAddon } from '@xterm/addon-fit'
-import { Terminal } from '@xterm/xterm'
+// Do not import xterm statically to avoid SSR issues
+// Only importing types from xterm is fine
+import type { Terminal } from '@xterm/xterm'
 import { useState, useEffect } from 'react'
 
 const compileMessageGenerator = (
@@ -374,7 +375,7 @@ export const useRunner = () => {
     }
   }, [resizeObserver, fitTerminalFn])
 
-  const startRunner = (code: string, language: Language) => {
+  const startRunner = async (code: string, language: Language) => {
     if (ws) {
       ws.close()
       setWs(null)
@@ -405,6 +406,7 @@ export const useRunner = () => {
     if (element) {
       element.innerHTML = ''
 
+      const { Terminal } = await import('@xterm/xterm')
       const terminal = new Terminal({
         convertEol: true,
         disableStdin: false,
@@ -414,6 +416,7 @@ export const useRunner = () => {
         }
       })
 
+      const { FitAddon } = await import('@xterm/addon-fit')
       const fitAddon = new FitAddon()
       terminal.loadAddon(fitAddon)
 


### PR DESCRIPTION
### Description

Next.js 서버에서 아래와 같은 에러가 종종 발생합니다. 코드 에디터 페이지에서 refresh할 때 발생하는 것으로 보아, 해당 페이지 내 SSR 이슈로 보였습니다.

```
   ▲ Next.js 15.4.6
   - Local:        http://frontend-6c5689984f-gsrbq:5525
   - Network:      http://frontend-6c5689984f-gsrbq:5525
✓ Starting...
✓ Ready in 464ms
ReferenceError: self is not defined
    at 28372 (.next/server/chunks/3915.js:1:5723)
    at c (.next/server/webpack-runtime.js:1:143)
    at 32848 (.next/server/chunks/1177.js:3:12717)
    at Function.c (.next/server/webpack-runtime.js:1:143)
⨯ unhandledRejection:  ReferenceError: self is not defined
    at 28372 (.next/server/chunks/3915.js:1:5723)
    at c (.next/server/webpack-runtime.js:1:143)
    at 32848 (.next/server/chunks/1177.js:3:12717)
    at Function.c (.next/server/webpack-runtime.js:1:143)
```

확인 결과 xterm을 직접 import하면 브라우저 기능에 접근하여 서버 측에서 에러가 발생하였습니다.
Dynamic import로 변경해 SSR에서 직접 xterm에 접근하지 않도록 하였습니다.
https://stackoverflow.com/questions/66096260/why-am-i-getting-referenceerror-self-is-not-defined-when-i-import-a-client-side

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
