### PR TITLE
fix(infra): preview domains are not caught in cors middleware

### DIFF
--- a/apps/k8s/admin-api/overlays/stage/cors-middleware.yaml
+++ b/apps/k8s/admin-api/overlays/stage/cors-middleware.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: admin-api
 spec:
   headers:
-    accessControlAllowOriginList:
-      - '*.preview.codedang.com'
+    accessControlAllowOriginListRegex:
+      - 'https://\d+\.preview\.codedang\.com'
       - 'http://localhost:5525'
     accessControlAllowMethods:
       - 'GET'

--- a/apps/k8s/client-api/overlays/stage/cors-middleware.yaml
+++ b/apps/k8s/client-api/overlays/stage/cors-middleware.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: client-api
 spec:
   headers:
-    accessControlAllowOriginList:
-      - '*.preview.codedang.com'
+    accessControlAllowOriginListRegex:
+      - 'https://\d+\.preview\.codedang\.com'
       - 'http://localhost:5525'
     accessControlAllowMethods:
       - 'GET'


### PR DESCRIPTION
### Description

기존 CORS의 'allow-origin-list'에서 wildcard가 동작하지 않아 preview에서 CORS 에러가 발생합니다.
Regex를 대신 적용해 CORS 규칙을 올바르게 적용합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
