### PR TITLE
feat(fe): prevent editting testcase if submission exists

### DIFF
--- a/apps/frontend/app/admin/problem/[problemId]/edit/_components/EditProblemForm.tsx
+++ b/apps/frontend/app/admin/problem/[problemId]/edit/_components/EditProblemForm.tsx
@@ -22,12 +22,14 @@ interface EditProblemFormProps {
   problemId: number
   children: ReactNode
   methods: UseFormReturn<UpdateProblemInput>
+  isTestcaseEditBlocked: boolean
 }
 
 export function EditProblemForm({
   problemId,
   children,
-  methods
+  methods,
+  isTestcaseEditBlocked
 }: EditProblemFormProps) {
   const [message, setMessage] = useState('')
   const [showCautionModal, setShowCautionModal] = useState(false)
@@ -138,9 +140,13 @@ export function EditProblemForm({
 
   const handleUpdate = async () => {
     if (pendingInput.current) {
+      const inputForMutation = { ...pendingInput.current }
+      if (isTestcaseEditBlocked) {
+        delete inputForMutation.testcases
+      }
       await updateProblem({
         variables: {
-          input: pendingInput.current
+          input: inputForMutation
         }
       })
     }

--- a/apps/frontend/app/admin/problem/_components/TestcaseField.tsx
+++ b/apps/frontend/app/admin/problem/_components/TestcaseField.tsx
@@ -336,54 +336,55 @@ export function TestcaseField({ blockEdit = false }: { blockEdit?: boolean }) {
               />
             </div>
             <div className="flex items-center justify-between gap-2">
-              <TestcaseUploadModal
-                onUpload={handleUploadTestcases}
-                isHidden={false}
-              />
-              <button
-                onClick={() => {
-                  deleteSelectedTestcases()
-                  setDataChangeTrigger((prev) => prev + 1)
-                }}
-                type="button"
-                className={cn(
-                  'flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] px-[22px] py-[10px]',
-                  selectedTestcases.length > 0
-                    ? 'bg-[#FC5555] text-white'
-                    : 'bg-gray-300 text-gray-600'
-                )}
-                disabled={selectedTestcases.length === 0}
-              >
-                <Image
-                  src="/icons/trashcan.svg"
-                  alt="trashcan Icon"
-                  width={18}
-                  height={18}
-                />
-                <span className="ml-[6px] flex items-center text-center text-white">
-                  Delete
-                </span>
-              </button>
-
               {!blockEdit && (
-                <button
-                  onClick={() => {
-                    addTestcase(false)
-                    setDataChangeTrigger((prev) => prev + 1)
-                  }}
-                  type="button"
-                  className="flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] bg-[#3581FA] px-[22px] py-[10px]"
-                >
-                  <Image
-                    src="/icons/plus-circle-white.svg"
-                    alt="plus circle white Icon"
-                    width={18}
-                    height={18}
+                <>
+                  <TestcaseUploadModal
+                    onUpload={handleUploadTestcases}
+                    isHidden={false}
                   />
-                  <span className="ml-[6px] flex items-center text-center text-white">
-                    Add
-                  </span>
-                </button>
+                  <button
+                    onClick={() => {
+                      deleteSelectedTestcases()
+                      setDataChangeTrigger((prev) => prev + 1)
+                    }}
+                    type="button"
+                    className={cn(
+                      'flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] px-[22px] py-[10px]',
+                      selectedTestcases.length > 0
+                        ? 'bg-[#FC5555] text-white'
+                        : 'bg-gray-300 text-gray-600'
+                    )}
+                    disabled={selectedTestcases.length === 0}
+                  >
+                    <Image
+                      src="/icons/trashcan.svg"
+                      alt="trashcan Icon"
+                      width={18}
+                      height={18}
+                    />
+                    <span className="ml-[6px] flex items-center text-center text-white">
+                      Delete
+                    </span>
+                  </button>
+                  <button
+                    onClick={() => {
+                      addTestcase(false)
+                      setDataChangeTrigger((prev) => prev + 1)
+                    }}
+                    type="button"
+                    className="flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] bg-[#3581FA] px-[22px] py-[10px]"
+                  >
+                    <Image
+                      src="/icons/plus-circle-white.svg"
+                      alt="plus circle white Icon"
+                      width={18}
+                      height={18}
+                    />
+                    <span className="ml-[6px] flex items-center text-center text-white">
+                      Add
+                    </span>
+                  </button>
+                </>
               )}
             </div>
           </div>
@@ -435,54 +436,56 @@ export function TestcaseField({ blockEdit = false }: { blockEdit?: boolean }) {
               />
             </div>
             <div className="flex items-center justify-between gap-2">
-              <TestcaseUploadModal
-                onUpload={handleUploadTestcases}
-                isHidden={true}
-              />
-              <button
-                onClick={() => {
-                  deleteSelectedTestcases()
-                  setDataChangeTrigger((prev) => prev + 1)
-                }}
-                type="button"
-                className={cn(
-                  'flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] px-[22px] py-[10px]',
-                  selectedTestcases.length > 0
-                    ? 'bg-[#FC5555] text-white'
-                    : 'bg-gray-300 text-gray-600'
-                )}
-                disabled={selectedTestcases.length === 0}
-              >
-                <Image
-                  src="/icons/trashcan.svg"
-                  alt="trashcan Icon"
-                  width={18}
-                  height={18}
-                />
-                <span className="ml-[6px] flex items-center text-center text-white">
-                  Delete
-                </span>
-              </button>
-
               {!blockEdit && (
-                <button
-                  onClick={() => {
-                    addTestcase(true)
-                    setDataChangeTrigger((prev) => prev + 1)
-                  }}
-                  type="button"
-                  className="flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] bg-[#3581FA] px-[22px] py-[10px]"
-                >
-                  <Image
-                    src="/icons/plus-circle-white.svg"
-                    alt="plus circle white Icon"
-                    width={18}
-                    height={18}
+                <>
+                  <TestcaseUploadModal
+                    onUpload={handleUploadTestcases}
+                    isHidden={true}
                   />
-                  <span className="ml-[6px] flex items-center text-center text-white">
-                    Add
-                  </span>
-                </button>
+                  <button
+                    onClick={() => {
+                      deleteSelectedTestcases()
+                      setDataChangeTrigger((prev) => prev + 1)
+                    }}
+                    type="button"
+                    className={cn(
+                      'flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] px-[22px] py-[10px]',
+                      selectedTestcases.length > 0
+                        ? 'bg-[#FC5555] text-white'
+                        : 'bg-gray-300 text-gray-600'
+                    )}
+                    disabled={selectedTestcases.length === 0}
+                  >
+                    <Image
+                      src="/icons/trashcan.svg"
+                      alt="trashcan Icon"
+                      width={18}
+                      height={18}
+                    />
+                    <span className="ml-[6px] flex items-center text-center text-white">
+                      Delete
+                    </span>
+                  </button>
+
+                  <button
+                    onClick={() => {
+                      addTestcase(true)
+                      setDataChangeTrigger((prev) => prev + 1)
+                    }}
+                    type="button"
+                    className="flex w-[109px] cursor-pointer items-center justify-center rounded-[1000px] bg-[#3581FA] px-[22px] py-[10px]"
+                  >
+                    <Image
+                      src="/icons/plus-circle-white.svg"
+                      alt="plus circle white Icon"
+                      width={18}
+                      height={18}
+                    />
+                    <span className="ml-[6px] flex items-center text-center text-white">
+                      Add
+                    </span>
+                  </button>
+                </>
               )}
             </div>
           </div>
@@ -523,7 +526,7 @@ export function TestcaseField({ blockEdit = false }: { blockEdit?: boolean }) {
                   initializeScore()
                   setDataChangeTrigger((prev) => prev + 1)
                 }}
-                disabled={isScoreNull}
+                disabled={isScoreNull || blockEdit}
               >
                 <FaArrowRotateLeft
                   fontSize={20}
@@ -562,7 +565,7 @@ export function TestcaseField({ blockEdit = false }: { blockEdit?: boolean }) {
                   equalDistribution()
                   setDataChangeTrigger((prev) => prev + 1)
                 }}
-                disabled={disableDistribution}
+                disabled={disableDistribution || blockEdit}
               >
                 <IoIosCheckmarkCircle
                   fontSize={20}

--- a/apps/frontend/app/admin/problem/_components/TestcaseItem.tsx
+++ b/apps/frontend/app/admin/problem/_components/TestcaseItem.tsx
@@ -44,38 +44,42 @@ export function TestcaseItem({
           <p className="text-lg font-medium text-[#5C5C5C]">
             #{(currentIndex + 1).toString().padStart(2, '0')}
           </p>
-          <input
-            type="checkbox"
-            className="text-primary-light h-5 w-5"
-            checked={isSelected}
-            onChange={(e) => onSelect(e.target.checked)}
-          />
+          {!blockEdit && (
+            <input
+              type="checkbox"
+              className="text-primary-light h-5 w-5"
+              checked={isSelected}
+              onChange={(e) => onSelect(e.target.checked)}
+            />
+          )}
         </div>
 
         <div className="flex items-center gap-1">
-          <div className="mr-2 flex">
-            <label className="flex items-center gap-1">
-              <input
-                type="checkbox"
-                className="text-primary-light h-4 w-4"
-                onBlur={isHiddenField.onBlur}
-                onChange={(e) => {
-                  isHiddenField.onChange(e.target.checked)
-                }}
-                checked={isHiddenField.value}
-              />
-              <p
-                className={cn(
-                  'text-base font-medium text-[#737373]',
-                  isHiddenField.value === true
-                    ? 'font-medium text-gray-500'
-                    : 'text-gray-400'
-                )}
-              >
-                Hidden
-              </p>
-            </label>
-          </div>
+          {!blockEdit && (
+            <div className="mr-2 flex">
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  className="text-primary-light h-4 w-4"
+                  onBlur={isHiddenField.onBlur}
+                  onChange={(e) => {
+                    isHiddenField.onChange(e.target.checked)
+                  }}
+                  checked={isHiddenField.value}
+                />
+                <p
+                  className={cn(
+                    'text-base font-medium text-[#737373]',
+                    isHiddenField.value === true
+                      ? 'font-medium text-gray-500'
+                      : 'text-gray-400'
+                  )}
+                >
+                  Hidden
+                </p>
+              </label>
+            </div>
+          )}
           {getValues(`testcases.${index}.scoreWeightNumerator`) ? (
             <div className="relative flex items-center">
               <input

--- a/apps/frontend/graphql/submission/queries.ts
+++ b/apps/frontend/graphql/submission/queries.ts
@@ -131,6 +131,36 @@ const GET_SUBMISSION = gql(`query GetSubmission(
   }
 }`)
 
+const GET_SUBMISSIONS = gql(`
+  query GetSubmissions(
+    $problemId: Int!
+    $cursor: Int
+    $take: Int
+  ) {
+    getSubmissions(
+      problemId: $problemId
+      cursor: $cursor
+      take: $take
+    ) {
+      data {
+        id
+        user {
+          id
+          username
+          studentId
+        }
+        userIp
+        codeSize
+        createTime
+        language
+        result
+        score
+      }
+      total
+    }
+  }
+`)
+
 const GET_ASSIGNMENT_LATEST_SUBMISSION = gql(`
   query GetAssignmentLatestSubmission(
     $groupId: Int!
@@ -184,5 +214,6 @@ export {
   GET_CONTEST_SUBMISSIONS,
   GET_ASSIGNMENT_LATEST_SUBMISSION,
   GET_ASSIGNMENT_SUBMISSIONS,
-  GET_SUBMISSION
+  GET_SUBMISSION,
+  GET_SUBMISSIONS
 }


### PR DESCRIPTION
### Description

기존에 problem을 edit할 때마다 모든 submissionResults(TC 결과)가 삭제되는 현상이 있었는데, 
problem을 edit할 때 submission이 존재하는지 확인해 존재할 경우 blockEdit을 활성화해 TestcaseField를 수정할 수 없도록 제한하고, updateProblem할 때도 testcases를 제외하고 보내도록 하였습니다. (제외하고 보내면 백엔드에서 걸러줘 submissionResults가 삭제되지 않음.)

추가로 blockEdit이 적용되지 않는 일부 필드들을 수정했습니다.

closes TAS-2084

### Additional context

현재 GetSubmissions 할 때 submission이 하나도 없으면 "Only allowed to access submissions included in your group"라는 에러를 반환하는데, 결국 제출이 없으니까 tc 수정을 막지 않는 작동에는 문제가 없지만, 추후 백엔드에서 수정해야 할 것 같습니다..!

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
