### PR TITLE
feat(fe): add Confirm Modal when Changing Language

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -6,6 +6,7 @@ import { assignmentSubmissionQueries } from '@/app/(client)/_libs/queries/assign
 import { contestProblemQueries } from '@/app/(client)/_libs/queries/contestProblem'
 import { contestSubmissionQueries } from '@/app/(client)/_libs/queries/contestSubmission'
 import { problemSubmissionQueries } from '@/app/(client)/_libs/queries/problemSubmission'
+import { AlertModal } from '@/components/AlertModal'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -96,6 +97,8 @@ export function EditorHeader({
   const getCode = useCodeStore((state) => state.getCode)
 
   const isTesting = useTestPollingStore((state) => state.isTesting)
+  const [isLanguageModalOpen, setIsLanguageModalOpen] = useState(false)
+  const [selectedLanguage, setSelectedLanguage] = useState(language)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const loading = isTesting || isSubmitting
 
@@ -483,16 +486,18 @@ export function EditorHeader({
       document.querySelector<HTMLButtonElement>('.test-button')?.click()
     }
   }
-
+  const handleLanguageChange = (newLanguage: Language) => {
+    setSelectedLanguage(newLanguage)
+    setIsLanguageModalOpen(true)
+  }
+  const handleConfirmLanguageChange = () => {
+    setLanguage(selectedLanguage)
+    setIsLanguageModalOpen(false)
+  }
   return (
     <div className="flex shrink-0 items-center justify-between border-b border-b-slate-700 bg-[#222939] px-6">
       <div>
-        <Select
-          onValueChange={(language: Language) => {
-            setLanguage(language)
-          }}
-          value={language}
-        >
+        <Select onValueChange={handleLanguageChange} value={language}>
           <SelectTrigger className="focus:outline-hidden h-8 min-w-[86px] max-w-fit shrink-0 rounded-[4px] border-none bg-slate-600 px-2 font-mono hover:bg-slate-700 focus:ring-0 focus:ring-offset-0">
             <p className="px-1">
               <SelectValue />
@@ -512,6 +517,19 @@ export function EditorHeader({
             </SelectGroup>
           </SelectContent>
         </Select>
+        <AlertModal
+          open={isLanguageModalOpen}
+          onOpenChange={setIsLanguageModalOpen}
+          size="sm"
+          title="Change Language"
+          description={`Change language to ${selectedLanguage}?\nOnce you change it, Your code will be deleted.`}
+          onClose={() => setIsLanguageModalOpen(false)}
+          primaryButton={{
+            text: isSubmitting ? 'Changing...' : 'Confirm',
+            onClick: handleConfirmLanguageChange
+          }}
+          type="confirm"
+        />
       </div>
       <div className="flex items-center gap-3">
         <AlertDialog>

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -518,7 +518,7 @@ export function EditorHeader({
             text: isSubmitting ? 'Changing...' : 'Confirm',
             onClick: handleConfirmLanguageChange
           }}
-          type="confirm"
+          type="warning"
         />
       </div>
       <div className="flex items-center gap-3">
@@ -544,7 +544,7 @@ export function EditorHeader({
               setIsResetModalOpen(false)
             }
           }}
-          type="confirm"
+          type="warning"
         />
 
         <TooltipProvider>

--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorHeader/EditorHeader.tsx
@@ -7,17 +7,6 @@ import { contestProblemQueries } from '@/app/(client)/_libs/queries/contestProbl
 import { contestSubmissionQueries } from '@/app/(client)/_libs/queries/contestSubmission'
 import { problemSubmissionQueries } from '@/app/(client)/_libs/queries/problemSubmission'
 import { AlertModal } from '@/components/AlertModal'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger
-} from '@/components/shadcn/alert-dialog'
 import { Button } from '@/components/shadcn/button'
 import {
   Select,
@@ -118,6 +107,7 @@ export function EditorHeader({
       exerciseId
     )
   )
+  const [isResetModalOpen, setIsResetModalOpen] = useState(false)
   const session = useSession()
   const showSignIn = useAuthModalStore((state) => state.showSignIn)
   const [showModal, setShowModal] = useState<boolean>(false)
@@ -532,38 +522,30 @@ export function EditorHeader({
         />
       </div>
       <div className="flex items-center gap-3">
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              size="icon"
-              className="size-7 h-8 w-[77px] shrink-0 gap-[5px] rounded-[4px] bg-slate-600 font-normal text-red-500 hover:bg-slate-700"
-            >
-              <BsTrash3 size={17} />
-              Reset
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent className="h-[200px] w-[500px] rounded-2xl border border-slate-800 bg-slate-900 pb-7 pl-8 pr-[30px] pt-8 sm:rounded-2xl">
-            <AlertDialogHeader>
-              <AlertDialogTitle className="font-size-5 text-slate-50">
-                Reset code
-              </AlertDialogTitle>
-              <AlertDialogDescription className="font-size-4 text-slate-300">
-                Are you sure you want to reset to the default code?
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter className="flex gap-2">
-              <AlertDialogCancel className="self-end rounded-[1000px] border-none bg-[#DCE3E5] text-[#787E80] hover:bg-[#c9cfd1]">
-                Cancel
-              </AlertDialogCancel>
-              <AlertDialogAction
-                className="self-end rounded-[1000px] bg-red-500 hover:bg-red-600"
-                onClick={resetCode}
-              >
-                Reset
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <Button
+          size="icon"
+          className="size-7 h-8 w-[77px] shrink-0 gap-[5px] rounded-[4px] bg-slate-600 font-normal text-red-500 hover:bg-slate-700"
+          onClick={() => setIsResetModalOpen(true)}
+        >
+          <BsTrash3 size={17} />
+          Reset
+        </Button>
+        <AlertModal
+          open={isResetModalOpen}
+          onOpenChange={setIsResetModalOpen}
+          size="sm"
+          title="Reset code"
+          description="Are you sure you want to reset to the default code?"
+          onClose={() => setIsResetModalOpen(false)}
+          primaryButton={{
+            text: 'Reset',
+            onClick: () => {
+              resetCode()
+              setIsResetModalOpen(false)
+            }
+          }}
+          type="confirm"
+        />
 
         <TooltipProvider>
           {contestId === undefined && (


### PR DESCRIPTION
### Description

언어 바꾸면 기존에 썼던 코드가 소리소문 없이 사라지는게 아무리 생각해도 좀 불안해서 모달을 넣었습니다...
언어바꾸는 드롭다운과 리셋모달 확인해주세요!

<img width="666" height="430" alt="image" src="https://github.com/user-attachments/assets/48fdde6a-55c7-4a5e-9607-12641bb08fc4" />

<img width="587" height="425" alt="image" src="https://github.com/user-attachments/assets/ed5f0b2d-3155-4f1a-9cdf-466b6146deb4" />

warning으로 변경.

### Additional context

closes.

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
