### PR TITLE
fix(fe): enable to access detail page even when logout

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/[qnaId]/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/[qnaId]/page.tsx
@@ -51,7 +51,7 @@ export default async function QnaDetailPage({ params }: PageProps) {
         const ContestProblems = await fetcherWithAuth
           .get(`contest/${contestId}/problem`)
           .json<{ data: { order: number; id: number; title: string }[] }>()
-        const matchedProblem = ContestProblems.data.find(
+        const matchedProblem = ContestProblems.data?.find(
           ({ id }) => id === QnaData.problemId
         )
         const categoryName = matchedProblem


### PR DESCRIPTION
### Description
로그아웃했을 때 Q&A detail page에 못 들어가는 에러를 수정했습니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

closes TAS-2106
### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
