### PR TITLE
fix(fe): revise qna main page

### DIFF
--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnACategoryFilter.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnACategoryFilter.tsx
@@ -20,7 +20,6 @@ import React, { type ReactNode } from 'react'
 
 export interface QnACategoryFilterProps<TData, TValue> {
   column?: Column<TData, TValue>
-  contestId: number
   options: {
     value: string
     label: ReactNode

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnADataTable.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnADataTable.tsx
@@ -41,7 +41,7 @@ interface QnADataTableProps<TData, TValue> {
   currentPage: number
   setFilteredData: (data: TData[]) => void
   resetPageIndex: () => void
-  isPrivilegedRole: boolean
+  isContestStaff: boolean
   canCreateQnA: boolean | null
 }
 
@@ -58,7 +58,7 @@ export function QnADataTable<TData extends QnAItem, TValue>({
   currentPage,
   setFilteredData,
   resetPageIndex,
-  isPrivilegedRole,
+  isContestStaff,
   canCreateQnA
 }: QnADataTableProps<TData, TValue>) {
   const table = useReactTable({
@@ -209,7 +209,7 @@ export function QnADataTable<TData extends QnAItem, TValue>({
                         </div>
                         {cell.column.id === 'title' &&
                           session &&
-                          (isPrivilegedRole
+                          (isContestStaff
                             ? !row.original.isResolved && (
                                 <div className="bg-primary h-2 w-2 rounded-full" />
                               )

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnADataTable.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnADataTable.tsx
@@ -32,6 +32,7 @@ interface QnADataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   QnADataWithCategory: TData[]
   contestProblems: ProblemDataTop
+  contestStatus: string
   headerStyle: {
     [key: string]: string
   }
@@ -50,6 +51,7 @@ export function QnADataTable<TData extends QnAItem, TValue>({
   columns,
   QnADataWithCategory,
   contestProblems,
+  contestStatus,
   headerStyle,
   emptyMessage,
   itemsPerPage,
@@ -86,7 +88,7 @@ export function QnADataTable<TData extends QnAItem, TValue>({
   >([{ value: 'General', label: 'General' }])
 
   useEffect(() => {
-    if (contestProblems?.data) {
+    if (contestProblems?.data && contestStatus !== 'Upcoming') {
       const problemOptions = contestProblems.data.map((item, index) => ({
         value: `${String.fromCharCode(65 + index)}. ${item.title}`,
         label: `${String.fromCharCode(65 + index)}. ${item.title}`
@@ -120,7 +122,6 @@ export function QnADataTable<TData extends QnAItem, TValue>({
           />
           <QnACategoryFilter
             column={table.getColumn('category')}
-            contestId={contestId}
             options={options}
             resetPageIndex={resetPageIndex}
           />

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnAMainTable.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnAMainTable.tsx
@@ -25,7 +25,7 @@ interface QnAMainTableProps {
   orderBy: string
   categories: string
   problemOrders: string
-  isPrivilegedRole: boolean
+  isContestStaff: boolean
   canCreateQnA: boolean | null
 }
 
@@ -57,7 +57,7 @@ export function QnAMainTable({
   orderBy,
   categories,
   problemOrders,
-  isPrivilegedRole,
+  isContestStaff,
   canCreateQnA
 }: QnAMainTableProps) {
   const { data: QnAData } = useSuspenseQuery({
@@ -69,7 +69,6 @@ export function QnAMainTable({
       orderBy,
       categories,
       problemOrders,
-      isPrivilegedRole,
       canCreateQnA
     ],
     queryFn: () =>
@@ -139,7 +138,7 @@ export function QnAMainTable({
         currentPage={currentPage}
         setFilteredData={setFilteredData}
         resetPageIndex={resetPageIndex}
-        isPrivilegedRole={isPrivilegedRole}
+        isContestStaff={isContestStaff}
         canCreateQnA={canCreateQnA}
       />
       <Paginator>

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnAMainTable.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/_components/QnAMainTable.tsx
@@ -20,6 +20,7 @@ interface QnAMainTableProps {
   session: Session | null
   contestId: number
   contestProblems: ProblemDataTop
+  contestStatus: string
   search: string
   orderBy: string
   categories: string
@@ -51,6 +52,7 @@ export function QnAMainTable({
   session,
   contestId,
   contestProblems,
+  contestStatus,
   search,
   orderBy,
   categories,
@@ -124,6 +126,7 @@ export function QnAMainTable({
         columns={QnAColumns}
         QnADataWithCategory={QnADataWithCategory}
         contestProblems={contestProblems}
+        contestStatus={contestStatus}
         headerStyle={{
           id: 'w-[118px]',
           category: 'w-[190px]',

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/page.tsx
@@ -37,21 +37,27 @@ export default async function ContestQna(props: ContestQnAProps) {
     .get(`contest/${contestId}/problem`)
     .json()
 
-  const state = (() => {
+  const contestStatus = (() => {
     const currentTime = new Date()
     const contestStart = new Date(contest.startTime)
     const contestEnd = new Date(contest.endTime)
-    if (currentTime >= contestStart && currentTime < contestEnd) {
+    if (currentTime < contestStart) {
+      return 'Upcoming'
+    } else if (currentTime < contestEnd) {
       return 'Ongoing'
+    } else {
+      return 'Finished'
     }
   })()
 
   const canCreateQnA =
     session &&
-    (contest.isRegistered || contest.isPrivilegedRole || state !== 'Ongoing')
+    (contest.isRegistered ||
+      contest.isPrivilegedRole ||
+      contestStatus !== 'Ongoing')
   const isPrivilegedRole = contest.isPrivilegedRole
 
-  if (!session && state === 'Ongoing') {
+  if (!session && contestStatus === 'Ongoing') {
     return (
       <div className="flex w-full max-w-7xl flex-col items-center justify-center p-5 py-48">
         <Image src={welcomeLogo} alt="welcome" />
@@ -74,6 +80,7 @@ export default async function ContestQna(props: ContestQnAProps) {
             session={session}
             contestId={contestId}
             contestProblems={contestProblems}
+            contestStatus={contestStatus}
             search={search}
             orderBy={orderBy}
             categories={categories}

--- a/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/page.tsx
+++ b/apps/frontend/app/(client)/(main)/contest/[contestId]/@tabs/qna/page.tsx
@@ -21,6 +21,13 @@ interface ContestQnAProps {
   }>
 }
 
+interface ContestRole {
+  contestId: number
+  role: Role
+}
+
+type Role = 'Admin' | 'Manager' | 'Participant' | 'Reviewer'
+
 export default async function ContestQna(props: ContestQnAProps) {
   const { contestId } = await props.params
   const searchParams = await props.searchParams
@@ -36,6 +43,14 @@ export default async function ContestQna(props: ContestQnAProps) {
   const contestProblems: ProblemDataTop = await fetcherWithAuth
     .get(`contest/${contestId}/problem`)
     .json()
+
+  const MyContestRolesRes = await fetcherWithAuth.get('contest/role')
+  const MyContestRoles: ContestRole[] = await MyContestRolesRes.json()
+  const isContestStaff = new Set(['Admin', 'Manager']).has(
+    MyContestRoles.find(
+      (ContestRole) => ContestRole.contestId === Number(contestId)
+    )?.role ?? 'nothing'
+  )
 
   const contestStatus = (() => {
     const currentTime = new Date()
@@ -55,7 +70,6 @@ export default async function ContestQna(props: ContestQnAProps) {
     (contest.isRegistered ||
       contest.isPrivilegedRole ||
       contestStatus !== 'Ongoing')
-  const isPrivilegedRole = contest.isPrivilegedRole
 
   if (!session && contestStatus === 'Ongoing') {
     return (
@@ -85,7 +99,7 @@ export default async function ContestQna(props: ContestQnAProps) {
             orderBy={orderBy}
             categories={categories}
             problemOrders={problemOrders}
-            isPrivilegedRole={isPrivilegedRole}
+            isContestStaff={isContestStaff}
             canCreateQnA={canCreateQnA}
           />
         </Suspense>


### PR DESCRIPTION
1. 대회 운영진에게도 upcoming 대회에서는 qna category filter 옵션으로 General만 표시됩니다.

2. 파란 동그라미 표시
기존: Admin, Manager, Reviewer는 isResolved=false,  Participant는 isRead=false
수정: Admin, Manager는 isResolved=false,  Reviewer, Participant는 isRead=false