### PR TITLE
fix(infra): use loki chart minio instead of custom minio

### DIFF
--- a/apps/k8s/monitoring/grafana/values.yaml
+++ b/apps/k8s/monitoring/grafana/values.yaml
@@ -44,16 +44,12 @@ datasources:
         type: loki
         access: proxy
         url: http://loki.monitoring-loki.svc.cluster.local:3100
-        editable: true # TODO: set false after testing
-        jsonData:
-          httpHeaderName1: 'X-Scope-OrgID'
-        secureJsonData:
-          httpHeaderValue1: '1'
+        editable: false
       - name: Prometheus-production
         type: prometheus
         access: proxy
         url: http://prometheus-kube-prometheus-prometheus.monitoring-prometheus.svc.cluster.local:9090
-        editable: true # TODO: set false after testing
+        editable: false
 
 # help grafana to detect provisioned dashboards
 sidecar:

--- a/apps/k8s/monitoring/loki/values.yaml
+++ b/apps/k8s/monitoring/loki/values.yaml
@@ -1,23 +1,29 @@
 global:
   image: {}
-  # TODO: connect minio
-  # extraEnvFrom:
-  #   - secretRef:
-  #       name: monitoring-user
 
 deploymentMode: SingleBinary
 loki:
+  auth_enabled: false
   commonConfig:
     replication_factor: 1
-  storage:
-    bucketNames:
-      chunks: loki
-      ruler: loki
-    type: s3
-    s3:
-      endpoint: http://minio.minio.svc.cluster.local:9000
-      s3ForcePathStyle: true
-      insecure: true
+  ring:
+    kvstore:
+      store: inmemory
+  # TODO: connect minio
+  # could not find way to inject env variables with helm chart
+  # need to reference minio access key and secret
+  # instead, we will use the default minio provided by this chart
+  # storage:
+  #   bucketNames:
+  #     chunks: loki
+  #     ruler: loki
+  #   type: s3
+  #   s3:
+  #     endpoint: http://minio.monitoring-minio.svc.cluster.local:9000
+  #     accessKeyId: # TODO: inject from secret
+  #     secretAccessKey: # TODO: inject from secret
+  #     s3ForcePathStyle: true
+  #     insecure: true
   schemaConfig:
     configs:
       - from: 2025-08-15
@@ -30,5 +36,17 @@ loki:
   distributor: {otlp_config: {default_resource_attributes_as_index_labels:
             # these keys will be indexed
             ['service.name', 'service.version', 'service.environment']}}
+
 gateway:
   enabled: false
+
+# default minio by loki chart
+# need to be replaced by custom minio(monitoring-minio) for centralized storage
+minio:
+  enabled: true
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+  persistence:
+    size: 50Gi

--- a/apps/k8s/monitoring/otel-collector/otel-collector.yaml
+++ b/apps/k8s/monitoring/otel-collector/otel-collector.yaml
@@ -21,9 +21,6 @@ spec:
         endpoint: http://loki.monitoring-loki.svc.cluster.local:3100/otlp
         tls:
           insecure: true
-        # used to satisfy loki's multi-tenancy
-        headers:
-          X-Scope-OrgID: '1'
       # TODO: uncomment when ready
       # prometheus:
       #   endpoint: '0.0.0.0:8889'


### PR DESCRIPTION
### Description

#### Loki Chart에서 기본적으로 제공하는 minio를 저장소로 사용합니다.

`monitoring-minio`에 구성된 minio 유저 시크릿을 helm chart의 `values.yaml`에 주입하는 방법을 모르겠습니다.
추후 중앙화된 저장소 관리를 위해 `monitoring-minio`의 minio로 이전해야 합니다.

#### `auth_enabled: false` 적용
이를 통해 Loki의 기본 설정인 multi-tenancy 모드를 해제합니다.
따라서 이와 연결된 서비스(OTel Collector, Grafana)의 요청 헤더에 `X-Scope-OrgId`를 제거합니다.


### Additional context

다시 `monitoring-minio`의 minio에 연결하려면 아래 링크를 참조하시면 도움이 됩니다.

- https://artifacthub.io/packages/helm/grafana/loki?modal=values&path=loki.storage
- https://github.com/grafana/loki/issues/12249
- https://community.grafana.com/t/storing-s3-accesskeyid-and-secretaccesskey-securely/92133/8
- https://grafana.com/docs/loki/latest/setup/install/helm/reference/

<img width="1254" height="870" alt="image" src="https://github.com/user-attachments/assets/0ad11209-3243-4411-8ab3-4778110caf59" />

아마 이 PR만 merge 되면 위처럼 로그 확인이 가능할 겁니다.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
