### PR TITLE
feat(infra): add cloud beaver to access stage db

### DIFF
--- a/apps/infra/production/dns/cloud-beaver.tf
+++ b/apps/infra/production/dns/cloud-beaver.tf
@@ -1,0 +1,9 @@
+# Purpose: CloudBeaver UI for database management
+
+resource "aws_route53_record" "cloud_beaver_stage" {
+  name    = "beaver.stage.codedang.com"
+  zone_id = data.aws_route53_zone.codedang.zone_id
+  type    = "A"
+  records = local.stage_cluster_ip
+  ttl     = 300
+}

--- a/apps/k8s/argocd/applications/cloud-beaver-stage.yaml
+++ b/apps/k8s/argocd/applications/cloud-beaver-stage.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloud-beaver-stage
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    app.kubernetes.io/environment: 'stage'
+spec:
+  project: default
+  source:
+    path: apps/k8s/cloud-beaver
+    repoURL: https://github.com/skkuding/codedang
+    targetRevision: main
+    directory:
+      recurse: true
+  destination:
+    namespace: cloud-beaver
+    name: stage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/apps/k8s/cloud-beaver/deployment.yaml
+++ b/apps/k8s/cloud-beaver/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-beaver
+  namespace: cloud-beaver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloud-beaver
+  template:
+    metadata:
+      labels:
+        app: cloud-beaver
+    spec:
+      containers:
+        - name: cloud-beaver
+          image: dbeaver/cloudbeaver:25.2.0
+          ports:
+            - containerPort: 8978
+          volumeMounts:
+            - name: cloud-beaver-data
+              mountPath: /opt/cloudbeaver/workspace
+      volumes:
+        - name: cloud-beaver-data
+          persistentVolumeClaim:
+            claimName: cloud-beaver-pvc

--- a/apps/k8s/cloud-beaver/ingress.yaml
+++ b/apps/k8s/cloud-beaver/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cloud-beaver-ingress
+  namespace: cloud-beaver
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - beaver.stage.codedang.com
+      secretName: cloud-beaver-tls
+  rules:
+    - host: beaver.stage.codedang.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cloud-beaver
+                port:
+                  number: 8978

--- a/apps/k8s/cloud-beaver/namespace.yaml
+++ b/apps/k8s/cloud-beaver/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud-beaver

--- a/apps/k8s/cloud-beaver/pvc.yaml
+++ b/apps/k8s/cloud-beaver/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cloud-beaver-pvc
+  namespace: cloud-beaver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: local-path

--- a/apps/k8s/cloud-beaver/service.yaml
+++ b/apps/k8s/cloud-beaver/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud-beaver
+  namespace: cloud-beaver
+spec:
+  selector:
+    app: cloud-beaver
+  ports:
+    - port: 8978
+      targetPort: 8978


### PR DESCRIPTION
### Description

Stage 환경 Postgres에 접속하기 위한 웹 DB IDE를 설정합니다.
CloudBeaver를 사용했고, https://beaver.stage.codedang.com/ 에서 접속할 수 있습니다.
설정 변경은 admin 로그인으로 가능하고, Notion secret 페이지에 계정 정보 적어뒀습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
