### PR TITLE
fix(infra): replace cluster-issuer in frontend-preview correctly

### DIFF
--- a/apps/k8s/argocd/applications/frontend-preview.yaml
+++ b/apps/k8s/argocd/applications/frontend-preview.yaml
@@ -60,7 +60,7 @@ spec:
                 name: frontend-ingress
               patch: |-
                 - op: replace
-                  path: /metadata/annotations/cert-manager\.io/cluster-issuer
+                  path: /metadata/annotations/cert-manager.io~1cluster-issuer
                   value: letsencrypt-dns01
                 - op: replace
                   path: /spec/tls/0/hosts/0
@@ -87,7 +87,7 @@ spec:
                   value: 'preview-{{.number}}-frontend'
       destination:
         name: stage
-        namespace: 'frontend-preview-{{.number}}'
+        namespace: 'frontend-preview'
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
### Description

Argo CD `frontend-preview`에서 cluster-issuer를 letsencrypt 대신 letsencrypt-dns01로 replace하는 과정에서,
annotation 안에 있는 `.`과 `/`가 올바르게 escape되지 않았습니다.

`.`은 escape할 필요가 없고, `/`은 `~1`로 대신 적어야합니다.
https://github.com/kubernetes-sigs/kustomize/issues/1256#issuecomment-535007229

### Additional context

frontend-preview resource를 모두 frontend-preview namespace에만 생성하고, 새로운 namespace(frontend-preview-{{.number}})를 생성하지 않도록 합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
