### PR TITLE
fix(fe): restore button cursor;pointer

### DIFF
--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -18,6 +18,12 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+  button {
+    cursor: pointer;
+  }
+  button:disabled {
+    cursor: not-allowed;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
### Description

확인해보니 shadcn Button과 button 모두 직접 지정하지 않는 이상 포인터로 변하지 않길래 global.css를 수정했습니다!
인라인으로 직접 지정하는 것이 더 우선순위가 높기 때문에  global.css를 수정하는 것이 옳다고 생각해 변경합니다.

### Additional context

closes TAS-2121

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
