### PR TITLE
feat(be): sort results by createTime in descending order

### DIFF
--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -209,7 +209,8 @@ export class GroupService {
             }
           },
           isGroupLeader: true
-        }
+        },
+        orderBy: { createTime: 'desc' }
       })
     )
       .filter(({ group }) => groupType === group.groupType)


### PR DESCRIPTION
### Description
Client - Course에서 사용하는 /course/joined의 결과를 createdTime의 역순으로 정렬하여 응답을 보냅니다.
> [!IMPORTANT]  
> 하단 bruno결과는 다음과 같이 주석처리를 하면 나오는 결과이고, 커밋은 주석 해제한 상태로 하였습니다.
<img width="566" height="171" alt="image" src="https://github.com/user-attachments/assets/958eafef-712e-47e4-a145-54ac8f94bd6c" />


### Additional context
<img width="1579" height="520" alt="스크린샷 2025-09-17 오전 2 04 32" src="https://github.com/user-attachments/assets/84d79cc3-5835-4968-911c-972bfc7c5898" />
<img width="1392" height="997" alt="스크린샷 2025-09-17 오전 2 04 39" src="https://github.com/user-attachments/assets/199e9405-fab8-4fb7-ab4f-454f7de8fd0d" />


---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
closes TAS-2152
