### PR TITLE
feat(infra): setup openvpn server to access private vpc from on-prem k8s

### DIFF
--- a/infra/aws/openvpn/.terraform.lock.hcl
+++ b/infra/aws/openvpn/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.100"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/aws/openvpn/bootstrap.sh
+++ b/infra/aws/openvpn/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Update and upgrade the system
+sudo apt update && sudo apt upgrade -y
+
+# Install OpenVPN
+export ENDPOINT=$(curl ifconfig.me)
+export AUTO_INSTALL=y
+curl -fsSL https://raw.githubusercontent.com/angristan/openvpn-install/master/openvpn-install.sh | sudo -E bash
+
+### NOTE: After the installation, client.ovpn file will be created in the /root directory.
+### You need to download it to your local machine to connect to the VPN server.

--- a/infra/aws/openvpn/ec2.tf
+++ b/infra/aws/openvpn/ec2.tf
@@ -1,0 +1,44 @@
+resource "aws_subnet" "public_subnet" {
+  vpc_id            = local.vpc.vpc_id
+  cidr_block        = "10.0.92.0/24"
+  availability_zone = "ap-northeast-2a"
+
+  tags = {
+    Name = "Codedang-Public-OpenVPN-Subnet"
+  }
+}
+
+resource "aws_route_table_association" "public_subnet" {
+  subnet_id      = aws_subnet.public_subnet.id
+  route_table_id = local.vpc.public_route_table_id
+}
+
+resource "aws_instance" "openvpn" {
+  ami                         = "ami-0607797cadde98e9b" # Ubuntu Server 24.04 LTS, arm64
+  instance_type               = "t4g.micro"
+  subnet_id                   = aws_subnet.public_subnet.id
+  vpc_security_group_ids      = [aws_security_group.openvpn.id]
+  associate_public_ip_address = true
+
+  # NOTE: SSH access is available via AWS console or AWS CLI with the command below.
+  # If there's no obvious reason, please do not add a key pair for minimizing security risk.
+  #
+  # aws ec2-instance-connect ssh --instance-id [INSTANCE-ID] --os-user ubuntu
+  #
+
+  user_data = file("bootstrap.sh")
+
+  tags = {
+    Name = "Codedang-OpenVPN-Server"
+  }
+}
+
+# Allocate static IPv4 address for OpenVPN server
+resource "aws_eip" "openvpn" {
+  instance = aws_instance.openvpn.id
+  domain   = "vpc"
+
+  tags = {
+    Name = "Codedang-OpenVPN-Server-EIP"
+  }
+}

--- a/infra/aws/openvpn/main.tf
+++ b/infra/aws/openvpn/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "codedang-tf-state"
+    key          = "terraform/openvpn.tfstate"
+    region       = "ap-northeast-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket = "codedang-tf-state"
+    key    = "terraform/vpc.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
+locals {
+  vpc = data.terraform_remote_state.vpc.outputs
+}

--- a/infra/aws/openvpn/security-group.tf
+++ b/infra/aws/openvpn/security-group.tf
@@ -1,0 +1,33 @@
+resource "aws_security_group" "openvpn" {
+  name        = "Codedang-SG-OpenVPN"
+  description = "Allow OpenVPN traffic"
+  vpc_id      = local.vpc.vpc_id
+  tags = {
+    Name = "Codedang-SG-OpenVPN"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh" {
+  security_group_id = aws_security_group.openvpn.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 22 # SSH default port
+  to_port     = 22
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "openvpn" {
+  security_group_id = aws_security_group.openvpn.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 1194 # OpenVPN default port
+  to_port     = 1194
+  ip_protocol = "udp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "anywhere" {
+  security_group_id = aws_security_group.openvpn.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = -1 # all protocols
+}

--- a/infra/aws/vpc/.terraform.lock.hcl
+++ b/infra/aws/vpc/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.100"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/aws/vpc/main.tf
+++ b/infra/aws/vpc/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "codedang-tf-state"
+    key            = "terraform/vpc.tfstate"
+    region         = "ap-northeast-2"
+    encrypt        = true
+    dynamodb_table = "terraform-state-lock"
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/infra/aws/vpc/outputs.tf
+++ b/infra/aws/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_route_table_id" {
+  value = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}

--- a/infra/aws/vpc/route_tables.tf
+++ b/infra/aws/vpc/route_tables.tf
@@ -1,0 +1,33 @@
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "Codedang-InternetFacing"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "Codedang-Public-RT"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "Codedang-Private-RT"
+  }
+}

--- a/infra/aws/vpc/vpc.tf
+++ b/infra/aws/vpc/vpc.tf
@@ -1,0 +1,13 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  # Not a recommended setting for production environment,
+  # but temporarily enabled to put RDS instance in public subnet.
+  # TODO: disable this and use default after setting up VPN
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "Codedang-VPC"
+  }
+}


### PR DESCRIPTION
### Description

RDS 보호를 위해 AWS VPC의 private subnet 안에 두는 게 바람직하지만, 지금은 빠른 세팅을 위해 public subnet에 둔 상태입니다.

<img width="571" height="372" alt="image" src="https://github.com/user-attachments/assets/ad4a4643-34f6-488b-a4ea-954d200eba48" />

보안을 위해 RDS(와 앞으로 추가될 AWS 리소스들)를 private subnet으로 옮기고, OpenVPN 서버를 통해 접근하도록 합니다.
이번 PR에서는 OpenVPN Server만 세팅합니다.


> [!NOTE]
> 가장 바람직한 솔루션은 직접 OpenVPN을 세팅하기보다 Site-to-Site VPN을 사용하는 것이지만, (1) 직접 서버 측 라우터에 설정 파일을 설치해야하는데 상당히 까다로운 작업이고 학교 라우터 설정을 변경해야해서 현실적으로 어렵고, (2) 비용이 꽤 나갑니다. (월 30달러 이상)
> 최대한 단순한 구조를 가져가면서 비용 절감을 위한 솔루션으로 OpenVPN을 택했습니다.

<img width="756" height="382" alt="image" src="https://github.com/user-attachments/assets/83f1af48-5736-43cc-b655-65b57704237b" />

이를 위해 두 개의 Terraform module을 추가했습니다.

```
aws
├── dns
├── k8s-iam
├── openvpn (NEW)
├── terraform-backend
└── vpc (NEW)
```

- `openvpn`: OpenVPN 서버가 동작하는 EC2와 관련 설정
- `vpc`: 코드당 VPC (기존 설정과 유사)

### 

### Additional context



---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
