### PR TITLE
chore(be): add updateContentTime to problem

### DIFF
--- a/apps/backend/apps/admin/src/problem/services/problem.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/problem.service.ts
@@ -692,7 +692,8 @@ export class ProblemService {
               }
             ]
           }
-        })
+        }),
+        updateContentTime: new Date()
       },
       include: {
         updateHistory: true // 항상 updateHistory 포함

--- a/apps/backend/prisma/migrations/20250921123231_add_update_content_time_in_problem/migration.sql
+++ b/apps/backend/prisma/migrations/20250921123231_add_update_content_time_in_problem/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."problem" ADD COLUMN     "update_content_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -233,6 +233,7 @@ model Problem {
   // MIN_DATE의 경우 모든 사용자에게 공개, 이외에는 비공개
   createTime      DateTime   @default(now()) @map("create_time")
   updateTime      DateTime   @updatedAt @map("update_time")
+  updateContentTime DateTime @default(now()) @map("update_content_time")
 
   sharedGroups      Group[]
   problemTestcase   ProblemTestcase[]


### PR DESCRIPTION
### Description

여러 모달에서 Problem Update 시간이 최종 "제출" 시간으로 나타나는 버그를 수정했습니다.

원인: submissionCount 필드가 매번 수정되면서 @updatedAt 속성이 달린 updateTime이 수정됨
해결: updateContentTime 필드를 추가하고, 실제 문제 내용이 바뀌는 updateProblem시에만 수정

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
