### PR TITLE
fix(fe): match each submission with according problem based on problemId

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentAccordion.tsx
@@ -295,15 +295,20 @@ function AssignmentAccordionItem({
                     {record && submission && (
                       <div className="flex items-center justify-between text-xs text-gray-600">
                         <div className="flex flex-col gap-1">
-                          {submission[index].submission?.submissionTime && (
-                            <span>
-                              Last Submission :{' '}
-                              {dateFormatter(
-                                submission[index].submission.submissionTime,
-                                'MMM D, HH:mm'
-                              )}
-                            </span>
-                          )}
+                          {(() => {
+                            const problemSubmission = submission.find(
+                              (sub) => sub.problemId === problem.id
+                            )
+                            const submissionTime =
+                              problemSubmission?.submission?.submissionTime
+
+                            return submissionTime ? (
+                              <span>
+                                Last Submission :{' '}
+                                {dateFormatter(submissionTime, 'MMM D, HH:mm')}
+                              </span>
+                            ) : null
+                          })()}
                           <span>
                             Score:{' '}
                             {dayjs().isAfter(
@@ -347,15 +352,20 @@ function AssignmentAccordionItem({
                     </div>
 
                     <div className="w-[30%]">
-                      {submission?.[index].submission?.submissionTime && (
-                        <div className="text-primary flex w-full justify-center text-sm font-normal">
-                          Last Submission :{' '}
-                          {dateFormatter(
-                            submission[index].submission.submissionTime,
-                            'MMM D, HH:mm:ss'
-                          )}
-                        </div>
-                      )}
+                      {(() => {
+                        const problemSubmission = submission?.find(
+                          (sub) => sub.problemId === problem.id
+                        )
+                        const submissionTime =
+                          problemSubmission?.submission?.submissionTime
+
+                        return submissionTime ? (
+                          <div className="text-primary flex w-full justify-center text-sm font-normal">
+                            Last Submission :{' '}
+                            {dateFormatter(submissionTime, 'MMM D, HH:mm:ss')}
+                          </div>
+                        ) : null
+                      })()}
                     </div>
 
                     <div className="flex w-[10%] justify-center text-base font-medium">

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/ExerciseAccordion.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/ExerciseAccordion.tsx
@@ -243,15 +243,20 @@ function ExerciseAccordionItem({
                     {record && submission && (
                       <div className="flex items-center justify-between text-xs text-gray-600">
                         <div className="flex flex-col gap-1">
-                          {submission[index].submission?.submissionTime && (
-                            <span>
-                              Last Submission :{' '}
-                              {dateFormatter(
-                                submission[index].submission.submissionTime,
-                                'MMM D, HH:mm'
-                              )}
-                            </span>
-                          )}
+                          {(() => {
+                            const problemSubmission = submission.find(
+                              (sub) => sub.problemId === problem.id
+                            )
+                            const submissionTime =
+                              problemSubmission?.submission?.submissionTime
+
+                            return submissionTime ? (
+                              <span>
+                                Last Submission :{' '}
+                                {dateFormatter(submissionTime, 'MMM D, HH:mm')}
+                              </span>
+                            ) : null
+                          })()}
                         </div>
                         <ResultBadge assignmentSubmission={submission[index]} />
                       </div>
@@ -284,15 +289,20 @@ function ExerciseAccordionItem({
                     </div>
 
                     <div className="w-[30%]">
-                      {submission?.[index].submission?.submissionTime && (
-                        <div className="text-primary flex w-full justify-center text-sm font-normal">
-                          Last Submission :{' '}
-                          {dateFormatter(
-                            submission[index].submission.submissionTime,
-                            'MMM D, HH:mm:ss'
-                          )}
-                        </div>
-                      )}
+                      {(() => {
+                        const problemSubmission = submission?.find(
+                          (sub) => sub.problemId === problem.id
+                        )
+                        const submissionTime =
+                          problemSubmission?.submission?.submissionTime
+
+                        return submissionTime ? (
+                          <div className="text-primary flex w-full justify-center text-sm font-normal">
+                            Last Submission :{' '}
+                            {dateFormatter(submissionTime, 'MMM D, HH:mm:ss')}
+                          </div>
+                        ) : null
+                      })()}
                     </div>
 
                     <div className="flex w-[13%] justify-center font-medium">


### PR DESCRIPTION
### Description
일부 제출내역이 관련없는 문제의 제출내역이라고 아코디언에 렌더링 되는 문제가 있었습니다.

원인은 'submission[index].submission.submissionTime,' 
이렇게 submissoin의 배열의 인덱스를 맹목적으로 사용하고 있어서 생긴 문제인 것 같습니다.
ubmission배열에서 problemId가 일치하는 제출내역을 찾아서 매칭시키는 방법으로 해결했습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
