### PR TITLE
feat(be): add course qna

### DIFF
--- a/apps/backend/prisma/migrations/20250924071743_add_course_qna/migration.sql
+++ b/apps/backend/prisma/migrations/20250924071743_add_course_qna/migration.sql
@@ -1,0 +1,54 @@
+-- CreateEnum
+CREATE TYPE "public"."CourseQnACategory" AS ENUM ('General', 'Problem');
+
+-- CreateTable
+CREATE TABLE "public"."course_qna" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER NOT NULL,
+    "created_by_id" INTEGER,
+    "group_id" INTEGER NOT NULL,
+    "problem_id" INTEGER,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "category" "public"."CourseQnACategory" NOT NULL DEFAULT 'General',
+    "is_resolved" BOOLEAN NOT NULL DEFAULT false,
+    "is_private" BOOLEAN NOT NULL DEFAULT false,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "read_by" INTEGER[],
+
+    CONSTRAINT "course_qna_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."course_qna_comment" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER NOT NULL,
+    "created_by_id" INTEGER,
+    "is_course_staff" BOOLEAN NOT NULL DEFAULT false,
+    "content" TEXT NOT NULL,
+    "course_qna_id" INTEGER NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_qna_comment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_qna_group_id_order_key" ON "public"."course_qna"("group_id", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_qna_comment_course_qna_id_order_key" ON "public"."course_qna_comment"("course_qna_id", "order");
+
+-- AddForeignKey
+ALTER TABLE "public"."course_qna" ADD CONSTRAINT "course_qna_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "public"."user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_qna" ADD CONSTRAINT "course_qna_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "public"."group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_qna" ADD CONSTRAINT "course_qna_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "public"."problem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_qna_comment" ADD CONSTRAINT "course_qna_comment_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "public"."user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_qna_comment" ADD CONSTRAINT "course_qna_comment_course_qna_id_fkey" FOREIGN KEY ("course_qna_id") REFERENCES "public"."course_qna"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -46,20 +46,22 @@ enum ProblemField {
 }
 
 model User {
-  id               Int       @id @default(autoincrement())
-  username         String    @unique
+  id                       Int                @id @default(autoincrement())
+  username                 String             @unique
   /// @HideField()
-  password         String
-  role             Role      @default(User)
-  email            String    @unique
-  studentId        String    @default("0000000000") @map("student_id")
-  college          String?   @default("none")
-  major            String?   @default("none")
-  lastLogin        DateTime? @map("last_login")
-  createTime       DateTime  @default(now()) @map("create_time")
-  updateTime       DateTime  @updatedAt @map("update_time")
-  canCreateCourse  Boolean   @default(false) @map("can_create_course")
-  canCreateContest Boolean   @default(false) @map("can_create_contest")
+  password                 String
+  role                     Role               @default(User)
+  email                    String             @unique
+  studentId                String             @default("0000000000") @map("student_id")
+  college                  String?            @default("none")
+  major                    String?            @default("none")
+  lastLogin                DateTime?          @map("last_login")
+  createTime               DateTime           @default(now()) @map("create_time")
+  updateTime               DateTime           @updatedAt @map("update_time")
+  canCreateCourse          Boolean            @default(false) @map("can_create_course")
+  canCreateContest         Boolean            @default(false) @map("can_create_contest")
+  createdCourseQnAs        CourseQnA[]        @relation("CreatedByUserCourseQnA")
+  createdCourseQnAComments CourseQnAComment[] @relation("CreatedByUserCourseQnAComment")
 
   userProfile        UserProfile?
   userGroup          UserGroup[]
@@ -147,6 +149,7 @@ model Group {
   workbook       Workbook[]
   GroupWhitelist GroupWhitelist[]
   sharedProblems Problem[]
+  courseQnA      CourseQnA[]
 
   @@map("group")
 }
@@ -243,6 +246,7 @@ model Problem {
   submission        Submission[]
   announcement      Announcement[]
   ContestQnA        ContestQnA[]
+  courseQnA         CourseQnA[]         @relation("ProblemToCourseQnA")
 
   updateHistory UpdateHistory[]
 
@@ -322,8 +326,8 @@ model ProblemTestcase {
   acceptedCount   Int      @default(0) @map("accepted_count")
   submissionCount Int      @default(0) @map("submission_count")
 
-  isOutdated      Boolean  @default(false) @map("is_outdated")
-  outdateTime     DateTime? @map("outdate_time")
+  isOutdated  Boolean   @default(false) @map("is_outdated")
+  outdateTime DateTime? @map("outdate_time")
 
   submissionResult SubmissionResult[]
 
@@ -815,4 +819,48 @@ model PushSubscription {
 
   @@unique([userId, endpoint])
   @@map("push_subscription")
+}
+
+enum CourseQnACategory {
+  General
+  Problem
+}
+
+model CourseQnA {
+  id          Int               @id @default(autoincrement())
+  order       Int
+  createdById Int?              @map("created_by_id")
+  groupId     Int               @map("group_id")
+  problemId   Int?              @map("problem_id")
+  title       String
+  content     String
+  category    CourseQnACategory @default(General)
+  isResolved  Boolean           @default(false) @map("is_resolved")
+  isPrivate   Boolean           @default(false) @map("is_private")
+  createTime  DateTime          @default(now()) @map("create_time")
+  readBy      Int[]             @map("read_by")
+
+  createdBy User?              @relation("CreatedByUserCourseQnA", fields: [createdById], references: [id], onDelete: SetNull)
+  group     Group              @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  problem   Problem?           @relation("ProblemToCourseQnA", fields: [problemId], references: [id], onDelete: Cascade)
+  comments  CourseQnAComment[]
+
+  @@unique([groupId, order])
+  @@map("course_qna")
+}
+
+model CourseQnAComment {
+  id            Int      @id @default(autoincrement())
+  order         Int
+  createdById   Int?     @map("created_by_id")
+  isCourseStaff Boolean  @default(false) @map("is_course_staff")
+  content       String
+  courseQnAId   Int      @map("course_qna_id")
+  createTime    DateTime @default(now()) @map("create_time")
+
+  createdBy User?     @relation("CreatedByUserCourseQnAComment", fields: [createdById], references: [id], onDelete: SetNull)
+  courseQnA CourseQnA @relation(fields: [courseQnAId], references: [id], onDelete: Cascade)
+
+  @@unique([courseQnAId, order])
+  @@map("course_qna_comment")
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Course 페이지에 종속되는 Q&A 기능 백엔드를 구현했음.
기획서 요구사항에 따라, 사용자는 질문과 댓글을 작성할 수 있으며 교수자는 이를 관리할 수 있도록 구현할 예정임.
기존 Contest Q&A 기능의 구조를 참고하여 CourseQnA와 CourseQnAComment 데이터 모델을 새롭게 정의했음.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

✅ 주요 기능 및 구현 사항
- 데이터베이스 (schema.prisma)
CourseQnA 및 CourseQnAComment 테이블 스키마를 추가했음.
Q&A는 Group(Course) 및 Problem 모델과 관계를 맺도록 설정했음.
isPrivate: 비밀글 여부를 저장하는 필드를 추가했음.
readBy: 사용자별 읽음/안 읽음 상태를 추적하기 위한 필드를 추가했음.

- Client API (/api/course/:groupId/qna) (구현 예정)
POST /: 새로운 질문을 생성함.
problemId를 쿼리 파라미터로 받아 특정 문제에 대한 질문으로 태그할 수 있음.
isPrivate 옵션을 통해 비밀글 설정이 가능함.
GET /: Q&A 목록을 필터링하여 조회함.
기획서의 요구사항인 주차(week), 답변 여부(isAnswered), 카테고리(categories) 등으로 필터링이 가능하도록 구현할 예정임.
GET /:order: 특정 질문의 상세 내용을 댓글과 함께 조회함.
비밀글의 경우 작성자와 교수/조교만 접근할 수 있음.
POST /:order/comment: 특정 질문에 댓글을 작성함.
DELETE /:order: 질문을 삭제함. (작성자 및 교수/조교만 가능)
DELETE /:qnaOrder/comment/:commentOrder: 댓글을 삭제함. (작성자 및 교수/조교만 가능)

- Admin API (GraphQL) (구현 예정)
교수 및 관리자가 강의 Q&A를 관리할 수 있도록 아래의 Query 및 Mutation을 추가할 예정임.
getCourseQnAs, getCourseQnA
createCourseQnAComment
deleteCourseQnA, deleteCourseQnAComment

---

TAS-1992

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
