### PR TITLE
fix(infra): update secret references in frontend preview configuration

### DIFF
--- a/infra/k8s/argocd/applications/frontend-preview.yaml
+++ b/infra/k8s/argocd/applications/frontend-preview.yaml
@@ -77,7 +77,10 @@ spec:
               patch: |-
                 - op: replace
                   path: /spec/template/spec/containers/0/envFrom/1/secretRef/name
-                  value: 'preview-{{.number}}-frontend-secrets'
+                  value: 'preview-{{.number}}-security-keys'
+                - op: replace
+                  path: /spec/template/spec/containers/0/envFrom/2/secretRef/name
+                  value: 'preview-{{.number}}-aws-credentials'
             - target:
                 kind: Service
                 name: frontend


### PR DESCRIPTION
### Description

<img width="346" height="146" alt="image" src="https://github.com/user-attachments/assets/b4e4eea1-837d-46ef-9341-3569b3f5fc34" />

frontend 프리뷰에 [최근에 변경된 시크릿 구조](https://github.com/skkuding/codedang/pull/3193)가 반영되지 않고 있습니다.
새롭게 추가된 `security-keys`와 `aws-credentials`에 대한 patch를 추가합니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
<img width="672" height="61" alt="image" src="https://github.com/user-attachments/assets/779a56a2-8003-41bb-a7e3-843dbbf58014" />

frontend 프리뷰 앱 정의는 `main` 브랜치 기준이기에 이 PR을 위한 Argocd check는 무조건 실패할 것으로 예상됩니다.
어쩔 수 없이 merge 후 상태 확인이 불가피해보입니다.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
