### PR TITLE
fix(infra): change ECR tag and remove Amplify deployment steps

### DIFF
--- a/.github/workflows/cd-failover-ecs.yml
+++ b/.github/workflows/cd-failover-ecs.yml
@@ -81,15 +81,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ matrix.ecr_repo_name }}:latest
+            ${{ steps.login-ecr.outputs.registry }}/${{ matrix.ecr_repo_name }}:production
             ${{ steps.login-ecr.outputs.registry }}/${{ matrix.ecr_repo_name }}:${{ github.sha }}
-
-  deploy-amplify:
-    name: Trigger Amplify Deployment
-    runs-on: ubuntu-latest
-    needs: build-and-push-ecr
-    environment: production
-
-    steps:
-      - name: Trigger Amplify Webhook
-        run: curl -X POST -d {} "${{ secrets.AMPLIFY_WEBHOOK }}" -H "Content-Type:application/json"


### PR DESCRIPTION
### Description

- workflow에서 수동으로 amplify 배포를 실행하지 않아도, amplify 설정으로 자동 deploy할 수 있기 때문에 amplify 부분을 삭제했습니다.
- 이미지 태그를 latest에서 production으로 수정했습니다.

[관련 노션 자료](https://www.notion.so/skkuding/ECR-2a8ef9cff5458096880de8c07db32d9e?source=copy_link)