### PR TITLE
fix(fe): redesign course cards

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
@@ -4,7 +4,7 @@ import calendarIcon from '@/public/icons/calendar-gray.svg'
 import personFillIcon from '@/public/icons/person-gray.svg'
 import type { JoinedCourse } from '@/types/type'
 import Image from 'next/image'
-import 'react-circular-progressbar/dist/styles.css'
+// import 'react-circular-progressbar/dist/styles.css'
 import { StatusBadge } from '../../../(main)/_components/StatusBadge'
 
 interface CourseCardProps {
@@ -65,10 +65,10 @@ export function CourseCard({ course }: CourseCardProps) {
       }`}
     >
       <div className="flex w-full flex-col justify-between gap-2 px-5 pt-4">
-        <StatusBadge variant={pastCourse ? 'finished' : 'ongoing'} />
-        <div className="h-[62px] text-ellipsis whitespace-pre-wrap text-xl font-medium leading-tight tracking-[-0.72px] md:text-2xl">
+        <span className="text-primary">
           [{course.courseInfo.courseNum}_{course.courseInfo.classNum}]{' '}
-          <br className="md:hidden" />
+        </span>
+        <div className="text-head6_m_24 line-clamp-2 h-[62px]">
           {course.groupName}
         </div>
         <div className="flex flex-col gap-[6px] pb-8 pt-4">

--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
@@ -4,8 +4,6 @@ import calendarIcon from '@/public/icons/calendar-gray.svg'
 import personFillIcon from '@/public/icons/person-gray.svg'
 import type { JoinedCourse } from '@/types/type'
 import Image from 'next/image'
-// import 'react-circular-progressbar/dist/styles.css'
-import { StatusBadge } from '../../../(main)/_components/StatusBadge'
 
 interface CourseCardProps {
   course: JoinedCourse
@@ -60,21 +58,21 @@ export function CourseCard({ course }: CourseCardProps) {
 
   return (
     <div
-      className={`mt-3 flex h-[200px] flex-col justify-between overflow-hidden rounded-xl shadow-[0_4px_20px_rgba(53,78,116,0.1)] ${
+      className={`mt-3 flex h-[202px] flex-col justify-between overflow-hidden rounded-xl pb-2 shadow-[0_4px_20px_rgba(53,78,116,0.1)] ${
         pastCourse ? 'opacity-50 grayscale' : ''
       }`}
     >
       <div className="flex w-full flex-col justify-between gap-2 px-5 pt-4">
-        <span className="text-primary">
+        <span className="text-primary text-sub3_sb_16">
           [{course.courseInfo.courseNum}_{course.courseInfo.classNum}]{' '}
         </span>
         <div className="text-head6_m_24 line-clamp-2 h-[62px]">
           {course.groupName}
         </div>
-        <div className="flex flex-col gap-[6px] pb-8 pt-4">
+        <div className="flex flex-col gap-[6px] pt-4">
           <div className="inline-flex items-center gap-[14px] whitespace-nowrap">
-            <Image src={calendarIcon} alt="calendar" width={16} height={16} />
-            <span className="text-sm font-medium tracking-[-0.42px] text-[#8A8A8A]">
+            <Image src={calendarIcon} alt="calendar" width={24} height={24} />
+            <span className="text-color-cool-neutral-40 text-body3_r_16">
               {course.courseInfo.semester}
             </span>
           </div>
@@ -82,10 +80,10 @@ export function CourseCard({ course }: CourseCardProps) {
             <Image
               src={personFillIcon}
               alt="person-fill"
-              width={16}
-              height={16}
+              width={24}
+              height={24}
             />
-            <span className="text-sm font-medium tracking-[-0.42px] text-[#8A8A8A]">
+            <span className="text-color-cool-neutral-40 text-body3_r_16">
               Prof. {course.courseInfo.professor}
             </span>
           </div>

--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCardList.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCardList.tsx
@@ -30,8 +30,10 @@ export function CourseCardList({ title }: CourseCardListProps) {
   const courseColumns = useMemo(() => {
     const columns: JoinedCourse[][] = []
 
-    for (let i = 0; i < courses.length; i += 2) {
-      columns.push(courses.slice(i, i + 2))
+    const itemsPerColumn = courses.length <= 8 ? 4 : 2
+
+    for (let i = 0; i < courses.length; i += itemsPerColumn) {
+      columns.push(courses.slice(i, i + itemsPerColumn))
     }
 
     return columns
@@ -40,11 +42,11 @@ export function CourseCardList({ title }: CourseCardListProps) {
   if (courses.length === 0) {
     return (
       <div className="flex w-full flex-col gap-10 md:items-center md:justify-between">
-        <div className="flex w-full justify-between gap-4 text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
-          <span>{title}</span>
+        <div className="flex gap-4 text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
+          {title}
           <RegisterCourseButton />
         </div>
-        <div className="mb-20 flex h-60 w-full flex-col items-center justify-center rounded-[20px] border border-[#DFDFDF] text-xl font-normal text-[#737373]">
+        <div className="flex h-72 w-full flex-col items-center justify-center rounded-[20px] border border-[#DFDFDF] text-xl font-normal text-[#737373]">
           <p>There are no courses registered!</p>
           <p>
             Please click the register button at the top to enroll in a course.
@@ -55,42 +57,69 @@ export function CourseCardList({ title }: CourseCardListProps) {
   }
 
   return (
-    <Carousel opts={{ align: 'start' }} className="flex w-full flex-col">
-      <div className="mb-3 flex w-full items-center justify-between">
-        <span className="text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
-          {title}
-        </span>
-        <div className="flex items-center gap-3">
-          <CarouselPrevious className="h-6 w-6" />
-          <CarouselNext className="h-6 w-6" />
-          <RegisterCourseButton />
+    <div>
+      {courses.length <= 8 ? (
+        <div className="flex w-full flex-col">
+          <div className="mb-3 flex w-full items-center justify-between">
+            <span className="text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
+              {title}
+            </span>
+            <RegisterCourseButton />
+          </div>
+          <div className="grid grid-cols-4 gap-3 pb-[100px]">
+            {courses.map((course) => (
+              <Link
+                key={course.id}
+                href={`/course/${course.id}`}
+                className="block"
+              >
+                <CourseCard course={course} index={0} />
+              </Link>
+            ))}
+          </div>
         </div>
-      </div>
-
-      <CarouselContent className="mb-[100px] ml-2">
-        {courseColumns.map((column, columnIndex) => (
-          <CarouselItem
-            key={`course-column-${columnIndex}`}
-            className="basis-[240px] md:basis-[293px]"
-          >
-            <div className="flex flex-col gap-3">
-              {column.map((course, rowIndex) => {
-                const originalIndex = columnIndex * 2 + rowIndex
-
-                return (
-                  <Link
-                    key={course.id}
-                    href={`/course/${course.id}` as const}
-                    className="block w-full"
-                  >
-                    <CourseCard course={course} index={originalIndex} />
-                  </Link>
-                )
-              })}
+      ) : (
+        <Carousel
+          opts={{ align: 'start', slidesToScroll: 1 }}
+          className="flex w-full flex-col"
+        >
+          <div className="mb-3 flex w-full items-center justify-between">
+            <span className="text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
+              {title}
+            </span>
+            <div className="flex items-center gap-3">
+              <CarouselPrevious className="h-6 w-6" />
+              <CarouselNext className="h-6 w-6" />
+              <RegisterCourseButton />
             </div>
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-    </Carousel>
+          </div>
+
+          <CarouselContent className="mb-[100px] ml-2">
+            {courseColumns.map((column, columnIndex) => (
+              <CarouselItem
+                key={`course-column-${columnIndex}`}
+                className="basis-[240px] md:basis-[293px]"
+              >
+                <div className="flex flex-col gap-3">
+                  {column.map((course, rowIndex) => {
+                    const originalIndex = columnIndex * 2 + rowIndex
+
+                    return (
+                      <Link
+                        key={course.id}
+                        href={`/course/${course.id}` as const}
+                        className="block w-full"
+                      >
+                        <CourseCard course={course} index={originalIndex} />
+                      </Link>
+                    )
+                  })}
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
+      )}
+    </div>
   )
 }

--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCardList.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCardList.tsx
@@ -30,7 +30,7 @@ export function CourseCardList({ title }: CourseCardListProps) {
   const courseColumns = useMemo(() => {
     const columns: JoinedCourse[][] = []
 
-    const itemsPerColumn = courses.length <= 8 ? 4 : 2
+    const itemsPerColumn = courses.length <= 4 ? 4 : 2
 
     for (let i = 0; i < courses.length; i += itemsPerColumn) {
       columns.push(courses.slice(i, i + itemsPerColumn))
@@ -42,11 +42,11 @@ export function CourseCardList({ title }: CourseCardListProps) {
   if (courses.length === 0) {
     return (
       <div className="flex w-full flex-col gap-10 md:items-center md:justify-between">
-        <div className="flex gap-4 text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
+        <div className="text-head5_sb_24 md:text-head3_sb_28 flex w-full justify-between gap-4">
           {title}
           <RegisterCourseButton />
         </div>
-        <div className="flex h-72 w-full flex-col items-center justify-center rounded-[20px] border border-[#DFDFDF] text-xl font-normal text-[#737373]">
+        <div className="text-title2_m_20 flex h-72 w-full flex-col items-center justify-center rounded-[20px] border border-[#DFDFDF] text-[#737373]">
           <p>There are no courses registered!</p>
           <p>
             Please click the register button at the top to enroll in a course.
@@ -58,15 +58,15 @@ export function CourseCardList({ title }: CourseCardListProps) {
 
   return (
     <div>
-      {courses.length <= 8 ? (
-        <div className="flex w-full flex-col">
+      {courses.length <= 4 ? (
+        <>
           <div className="mb-3 flex w-full items-center justify-between">
-            <span className="text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
+            <span className="text-head5_sb_24 md:text-head3_sb_28">
               {title}
             </span>
             <RegisterCourseButton />
           </div>
-          <div className="grid grid-cols-4 gap-3 pb-[100px]">
+          <div className="hidden gap-3 md:grid md:grid-cols-4">
             {courses.map((course) => (
               <Link
                 key={course.id}
@@ -77,14 +77,43 @@ export function CourseCardList({ title }: CourseCardListProps) {
               </Link>
             ))}
           </div>
-        </div>
+          <Carousel
+            opts={{ align: 'start', slidesToScroll: 1 }}
+            className="flex w-full flex-col md:hidden"
+          >
+            <CarouselContent className="mb-[15px] ml-2">
+              {courseColumns.map((column, columnIndex) => (
+                <CarouselItem
+                  key={`course-column-${columnIndex}`}
+                  className="basis-[240px]"
+                >
+                  <div className="flex flex-col gap-3">
+                    {column.map((course, rowIndex) => {
+                      const originalIndex = columnIndex * 4 + rowIndex
+
+                      return (
+                        <Link
+                          key={course.id}
+                          href={`/course/${course.id}` as const}
+                          className="block w-full"
+                        >
+                          <CourseCard course={course} index={originalIndex} />
+                        </Link>
+                      )
+                    })}
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+          </Carousel>
+        </>
       ) : (
         <Carousel
           opts={{ align: 'start', slidesToScroll: 1 }}
           className="flex w-full flex-col"
         >
           <div className="mb-3 flex w-full items-center justify-between">
-            <span className="text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
+            <span className="text-head5_sb_24 md:text-head3_sb_28">
               {title}
             </span>
             <div className="flex items-center gap-3">
@@ -94,7 +123,7 @@ export function CourseCardList({ title }: CourseCardListProps) {
             </div>
           </div>
 
-          <CarouselContent className="mb-[100px] ml-2">
+          <CarouselContent className="mb-[15px] ml-2">
             {courseColumns.map((column, columnIndex) => (
               <CarouselItem
                 key={`course-column-${columnIndex}`}

--- a/apps/frontend/app/(client)/(main)/course/_components/Dashboard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/Dashboard.tsx
@@ -273,9 +273,7 @@ export function Dashboard() {
   return (
     <section className="mx-auto max-w-[1208px]">
       <div className="pb-4 sm:pb-[30px]">
-        <h2 className="text-2xl font-semibold leading-9 tracking-[-0.9px] md:text-[28px]">
-          나의 대시보드
-        </h2>
+        <h2 className="text-head5_sb_24 md:text-head3_sb_28">나의 대시보드</h2>
       </div>
 
       <div className="grid grid-cols-1 gap-[14px] md:grid md:grid-cols-2 lg:grid-cols-3">

--- a/apps/frontend/app/(client)/(main)/course/page.tsx
+++ b/apps/frontend/app/(client)/(main)/course/page.tsx
@@ -57,20 +57,22 @@ export default async function Course() {
     <>
       <div className="flex w-full max-w-[1440px] flex-col px-5 pt-[32px] sm:px-[116px] md:pt-[120px]">
         <div className="flex flex-col pb-12">
-          <span className="text-head1_b_40">COURSE</span>
-          <span className="text-color-neutral-40 text-sub2_m_18">
+          <span className="text-head2_b_32 md:text-head1_b_40">COURSE</span>
+          <span className="text-color-neutral-40 text-body2_m_14 md:text-sub2_m_18">
             전반적인 교육과정을 연계하여 관리해보세요
           </span>
         </div>
-        <ErrorBoundary fallback={FetchErrorFallback}>
-          <Suspense fallback={<CardListFallback />}>
-            <CourseCardList title="나의 강좌" />
-          </Suspense>
-        </ErrorBoundary>
-      </div>
+        <div className="gap-15 flex flex-col">
+          <ErrorBoundary fallback={FetchErrorFallback}>
+            <Suspense fallback={<CardListFallback />}>
+              <CourseCardList title="나의 강좌" />
+            </Suspense>
+          </ErrorBoundary>
 
-      <div className="w-full px-5 md:px-[116px]">
-        <Dashboard />
+          <div className="w-full">
+            <Dashboard />
+          </div>
+        </div>
       </div>
 
       <CourseSubBanner />


### PR DESCRIPTION
### Description

[이한국 교수님 피드백 반영]
- ongoing/finished 뱃지 대신 학수번호를 위로 올렸습니다. (+ 강의명 2줄까지 제한)
- 강의 8개까지는 가로로 먼저 렌더링되고, 9개부터는 위/아래 번갈아 렌더링 되게 수정했습니다.


<img width="984" height="415" alt="image" src="https://github.com/user-attachments/assets/0a1a10f0-d087-4cd4-9d70-a13c1b870deb" />


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2668