### PR TITLE
chore(infra): update RDS version to 14.22

### DIFF
--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -14,8 +14,8 @@ resource "random_password" "postgres_password" {
 resource "aws_db_instance" "postgres" {
   identifier = "terraform-20250506182211604800000001"
 
-  db_name                    = "codedang_db"
-  engine                     = "postgres"
+  db_name = "codedang_db"
+  engine  = "postgres"
   # Pinned version — check for updates quarterly: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/
   engine_version             = "14.22"
   auto_minor_version_upgrade = false

--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -14,12 +14,14 @@ resource "random_password" "postgres_password" {
 resource "aws_db_instance" "postgres" {
   identifier = "terraform-20250506182211604800000001"
 
-  db_name               = "codedang_db"
-  engine                = "postgres"
-  engine_version        = "14.22"
-  allocated_storage     = 10
-  max_allocated_storage = 25
-  instance_class        = "db.t4g.small"
+  db_name                    = "codedang_db"
+  engine                     = "postgres"
+  # Pinned version — check for updates quarterly: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/
+  engine_version             = "14.22"
+  auto_minor_version_upgrade = false
+  allocated_storage          = 10
+  max_allocated_storage      = 25
+  instance_class             = "db.t4g.small"
 
   username = var.postgres_username
   password = random_password.postgres_password.result

--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -14,9 +14,9 @@ resource "random_password" "postgres_password" {
 resource "aws_db_instance" "postgres" {
   identifier = "terraform-20250506182211604800000001"
 
-  db_name           = "codedang_db"
-  engine            = "postgres"
-  engine_version    = "14"
+  db_name               = "codedang_db"
+  engine                = "postgres"
+  engine_version        = "14.22"
   allocated_storage     = 10
   max_allocated_storage = 25
   instance_class        = "db.t4g.small"
@@ -35,7 +35,7 @@ resource "aws_db_instance" "postgres" {
 
   # Backup
   backup_retention_period = 7
-  backup_window           = "16:00-17:00"              # KST 01:00-02:00
+  backup_window           = "16:00-17:00" # KST 01:00-02:00
 
   # Monitoring
   performance_insights_enabled = true


### PR DESCRIPTION
### Description

RDS 버전이 메이저 버전인 14로만 고정되어 있던 것을 14.22로 더욱 자세히 기술합니다.
약간의 가독성 향상은 덤.

### Additional context

<img width="1176" height="1320" alt="image" src="https://github.com/user-attachments/assets/9075028e-c52b-423d-85f5-6c53db530a8e" />

이전에 저희 RDS Postgres 버전은 14.17 버전이었기에, AWS의 지원 종료 대상이었습니다.
Terraform에서 DB 버전을 메이저 버전만 지정해두면 AWS는 특별한 이유 없이 버전 업그레이드를 해주지 않습니다.
그래서 업그레이드를 위해 마이너 버전까지 서술하였습니다.

<img width="305" height="193" alt="image" src="https://github.com/user-attachments/assets/4ccdbc21-7424-4233-85c6-3834a7e62008" />

DB업그레이드는 이미 완료된 상태입니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

Closes TAS-2672