### PR TITLE
fix(infra): split promtail journal scrape into 3 jobs per matches limitation

### DIFF
--- a/infra/k8s/monitoring/promtail/values.yaml
+++ b/infra/k8s/monitoring/promtail/values.yaml
@@ -50,15 +50,19 @@ config:
   clients:
     - url: http://loki.monitoring-loki.svc.cluster.local:3100/loki/api/v1/push
   snippets:
-    # Three separate journal jobs because promtail's matches parser only accepts
+    # Two separate journal jobs because promtail's matches parser only accepts
     # FIELD=VALUE tokens (no '+' disjunction) AND sd-journal AND-combines matches
-    # across different fields. To OR across fields (units OR kernel OR sudo) we
-    # need a job per field. All jobs share `labels.job: systemd-journal` so a
+    # across different fields. To OR across fields (units OR kernel) we need
+    # a job per field. Both jobs share `labels.job: systemd-journal` so a
     # single LogQL selector `{job="systemd-journal"}` still works.
     #
     # ceiling for catch-up after positions cursor is lost (e.g. node reboot —
     # positions live on tmpfs /run/promtail/). 24h covers a weekday outage +
     # next-morning recovery while keeping startup catch-up bounded.
+    #
+    # Security signals (sshd, sudo) intentionally excluded — deferred to a
+    # dedicated L4 audit-log PR alongside k8s API audit log so they can be
+    # tuned together.
     extraScrapeConfigs: |
       - job_name: systemd-journal-units
         journal:
@@ -66,7 +70,11 @@ config:
           max_age: 24h
           labels:
             job: systemd-journal
-          matches: "_SYSTEMD_UNIT=k3s.service _SYSTEMD_UNIT=k3s-agent.service _SYSTEMD_UNIT=containerd.service _SYSTEMD_UNIT=sshd.service _SYSTEMD_UNIT=systemd-logind.service"
+          matches: >-
+            _SYSTEMD_UNIT=k3s.service
+            _SYSTEMD_UNIT=k3s-agent.service
+            _SYSTEMD_UNIT=containerd.service
+            _SYSTEMD_UNIT=systemd-logind.service
         relabel_configs:
           - source_labels: ['__journal__systemd_unit']
             target_label: unit
@@ -89,20 +97,5 @@ config:
             target_label: hostname
           - source_labels: ['__journal__transport']
             target_label: transport
-          - source_labels: ['__journal_priority_keyword']
-            target_label: level
-
-      - job_name: systemd-journal-sudo
-        journal:
-          path: /var/log/journal
-          max_age: 24h
-          labels:
-            job: systemd-journal
-          matches: "_COMM=sudo"
-        relabel_configs:
-          - source_labels: ['__journal__hostname']
-            target_label: hostname
-          - source_labels: ['__journal__comm']
-            target_label: comm
           - source_labels: ['__journal_priority_keyword']
             target_label: level

--- a/infra/k8s/monitoring/promtail/values.yaml
+++ b/infra/k8s/monitoring/promtail/values.yaml
@@ -50,25 +50,23 @@ config:
   clients:
     - url: http://loki.monitoring-loki.svc.cluster.local:3100/loki/api/v1/push
   snippets:
+    # Three separate journal jobs because promtail's matches parser only accepts
+    # FIELD=VALUE tokens (no '+' disjunction) AND sd-journal AND-combines matches
+    # across different fields. To OR across fields (units OR kernel OR sudo) we
+    # need a job per field. All jobs share `labels.job: systemd-journal` so a
+    # single LogQL selector `{job="systemd-journal"}` still works.
+    #
+    # ceiling for catch-up after positions cursor is lost (e.g. node reboot —
+    # positions live on tmpfs /run/promtail/). 24h covers a weekday outage +
+    # next-morning recovery while keeping startup catch-up bounded.
     extraScrapeConfigs: |
-      - job_name: systemd-journal
+      - job_name: systemd-journal-units
         journal:
           path: /var/log/journal
-          # ceiling for catch-up after positions cursor is lost (e.g. node reboot
-          # — positions live on tmpfs /run/promtail/). 24h covers a weekday outage
-          # + next-morning recovery while keeping startup catch-up bounded.
           max_age: 24h
           labels:
             job: systemd-journal
-          # whitelist via journalctl match syntax: same field = OR, "+" = OR across fields
-          matches: >-
-            _SYSTEMD_UNIT=k3s.service
-            _SYSTEMD_UNIT=k3s-agent.service
-            _SYSTEMD_UNIT=containerd.service
-            _SYSTEMD_UNIT=sshd.service
-            _SYSTEMD_UNIT=systemd-logind.service
-            + _TRANSPORT=kernel
-            + _COMM=sudo
+          matches: "_SYSTEMD_UNIT=k3s.service _SYSTEMD_UNIT=k3s-agent.service _SYSTEMD_UNIT=containerd.service _SYSTEMD_UNIT=sshd.service _SYSTEMD_UNIT=systemd-logind.service"
         relabel_configs:
           - source_labels: ['__journal__systemd_unit']
             target_label: unit
@@ -76,5 +74,35 @@ config:
             target_label: hostname
           - source_labels: ['__journal__transport']
             target_label: transport
+          - source_labels: ['__journal_priority_keyword']
+            target_label: level
+
+      - job_name: systemd-journal-kernel
+        journal:
+          path: /var/log/journal
+          max_age: 24h
+          labels:
+            job: systemd-journal
+          matches: "_TRANSPORT=kernel"
+        relabel_configs:
+          - source_labels: ['__journal__hostname']
+            target_label: hostname
+          - source_labels: ['__journal__transport']
+            target_label: transport
+          - source_labels: ['__journal_priority_keyword']
+            target_label: level
+
+      - job_name: systemd-journal-sudo
+        journal:
+          path: /var/log/journal
+          max_age: 24h
+          labels:
+            job: systemd-journal
+          matches: "_COMM=sudo"
+        relabel_configs:
+          - source_labels: ['__journal__hostname']
+            target_label: hostname
+          - source_labels: ['__journal__comm']
+            target_label: comm
           - source_labels: ['__journal_priority_keyword']
             target_label: level


### PR DESCRIPTION
### Description

[#3542](https://github.com/skkuding/codedang/pull/3542) 머지 후 stage 클러스터 promtail이 즉시 CrashLoop에 빠진 것을 핫픽스합니다. 동시에 봇 리뷰에서 발견된 sshd-내-sudo 중복 ingest 문제도 같이 정리합니다.

**증상**: 머지 직후(`2026-04-27 02:19 KST`) stage `promtail-stage` ApplicationSet이 자동 sync → DaemonSet rolling update 시도 → skkuding-1 노드의 새 pod이 시작 즉시 죽음, 24+회 재시작.

**에러 로그** (stage promtail-5hqsh):
```
{"level":"error","msg":"error creating promtail",
 "error":"failed to make journal target manager: Error parsing journal reader 'matches' config value"}
```

**원인 두 가지**:

1. promtail의 matches 파서는 모든 토큰이 `FIELD=VALUE` 형식이어야 함. `+` 토큰은 `=`이 없어서 거부됨. ([grafana/loki journaltarget.go의 `journalTargetWithReader`](https://github.com/grafana/loki/blob/v2.9.13/clients/pkg/promtail/targets/journal/journaltarget.go))
2. `+` 빼도 의미가 깨짐. sd-journal은 **다른 필드 간엔 AND**로 결합 — `_SYSTEMD_UNIT=foo`와 `_TRANSPORT=kernel`을 같은 `matches`에 두면 "unit=foo이면서 transport=kernel"인 entry를 찾으려고 해서 0건 매치.

**수정**: 필드 패밀리별로 journal job 분리. **2개**: `systemd-journal-units`, `systemd-journal-kernel`. 둘 다 `labels.job: systemd-journal`로 같은 정적 라벨 부여 → 기존 PR description의 모든 LogQL 예시 (`{job="systemd-journal"}`, `{transport="kernel"}` 등) 그대로 동작.

**보안 시그널 (sshd, sudo)은 의도적으로 제외** — sshd 안에서 실행한 sudo entry가 두 job 모두에 매치되어 Loki에 중복 저장되는 문제 (gemini + codex 봇 모두 지적)가 있어, L4 보안 작업 별도 PR에서 k8s API audit log와 함께 묶어 처리할 예정. 이번 PR은 L1-L3에 집중.

### 수집 범위 (이번 PR 기준)

| 계층 | unit |
|---|---|
| L2 Platform | `k3s.service`, `k3s-agent.service`, `containerd.service` |
| L3 OS | kernel transport, `systemd-logind.service` |

L4-cheap (sshd, sudo)은 별도 PR에서 K8s audit log + Falco 검토와 묶어 처리.

### Additional context

**왜 stage에서만 잡혔나** — `kubectl run` + `helm template`으론 YAML 문법만 검증, 실제 promtail 런타임 파서 검증 안 됨. stage가 첫 통합 검증 단계로 정확히 작동한 셈. 이 PR의 수정은 **머지 전 docker dry-run으로 사전 검증** 완료:
```bash
docker run --rm \
  -v <rendered>:/cfg/promtail.yaml:ro \
  -v /var/log/journal:/var/log/journal:ro \
  -v /etc/machine-id:/etc/machine-id:ro \
  --user root grafana/promtail:3.5.1 \
  -config.file=/cfg/promtail.yaml
```
"Error parsing journal reader 'matches'" 등 fatal 에러 0건, journal target 정상 기동, Loki push 시도 (= 데이터 read 됨) 확인.

**원본 PR의 안전 캐비엇**: stage가 자동 배포 채널이라 prod에는 영향 없음 (사용자가 prod 승격을 수동 처리하므로). 이번 핫픽스 머지 후 stage 자동 회복 → 검증 → 사용자 prod 승격 결정.

**리뷰 포인트**

- `matches:` 화이트리스트는 folded scalar `>-`로 작성 (units job은 4개 entry, kernel job은 1개라 그대로 인라인)
- 메모리 256Mi 그대로 — 2 job × cursor 1개씩, journal 볼륨 작아서 충분
- 봇 리뷰 4건 모두 resolved (3건은 sudo job 제거로 해결, 1건은 folded scalar 적용)

**검증 계획** (이 PR 머지 후 stage):

- [ ] stage promtail DaemonSet 3/3 Ready, RestartCount 안정화
- [ ] `{job="systemd-journal"}` 결과 등장 (2개 job 합산)
- [ ] `{job="systemd-journal", unit="k3s-agent.service"}` (units job 검증)
- [ ] `{job="systemd-journal", transport="kernel"}` (kernel job 검증)
- [ ] promtail pod 메모리 256 MiB 이내 유지
- [ ] 기존 `kubernetes-pods` scrape 회귀 없음

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it. _(런타임 검증은 docker dry-run으로 머지 전 수행. 회귀 방지를 위한 GHA 워크플로 도입은 별도 작업으로 추적 예정)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)