### PR TITLE
feat(infra): add layered ci validation for k8s infra (L1-L5 + L7)

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -104,9 +104,260 @@ jobs:
 
           echo "All keys are valid"
 
-  monitoring-e2e:
-    name: Monitoring Stack E2E (kind)
+  yaml-lint:
+    name: L1 YAML lint
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if k8s manifests changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            k8s:
+              - 'infra/k8s/**'
+              - '.github/workflows/ci-infra.yml'
+
+      - name: Install yamllint
+        if: steps.filter.outputs.k8s == 'true'
+        run: pip install --quiet yamllint
+
+      - name: Lint
+        if: steps.filter.outputs.k8s == 'true'
+        run: |
+          yamllint -d "{extends: relaxed, rules: {line-length: disable, comments-indentation: disable}}" infra/k8s/
+
+  kustomize-build:
+    name: L2 Kustomize build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if k8s manifests changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            k8s:
+              - 'infra/k8s/**'
+              - '.github/workflows/ci-infra.yml'
+
+      - name: Install kustomize
+        if: steps.filter.outputs.k8s == 'true'
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Build all overlays
+        if: steps.filter.outputs.k8s == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          FAIL=0
+          while IFS= read -r kfile; do
+            dir=$(dirname "$kfile")
+            echo "::group::$dir"
+            if ! kustomize build "$dir" > /dev/null 2>&1; then
+              echo "::error file=$kfile::kustomize build 실패"
+              kustomize build "$dir" 2>&1 | tail -10
+              FAIL=1
+            fi
+            echo "::endgroup::"
+          done < <(find infra/k8s -name kustomization.yaml -type f)
+          if [[ $FAIL -ne 0 ]]; then
+            echo "::error::kustomize build 실패한 overlay 있음"
+            exit 1
+          fi
+          echo "모든 overlay 정상 빌드"
+
+  helm-template:
+    name: L3 Helm template (warn-only)
+    runs-on: ubuntu-latest
+    continue-on-error: true # 베이스라인 정리 후 blocking 으로 승격
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if helm values changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            helm:
+              - 'infra/k8s/monitoring/**'
+              - 'infra/k8s/argocd/**'
+              - '.github/workflows/ci-infra.yml'
+
+      - name: Setup helm
+        if: steps.filter.outputs.helm == 'true'
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.19.2'
+
+      - name: Render charts from ApplicationSet definitions
+        if: steps.filter.outputs.helm == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          # ApplicationSet에서 chart+version+valueFiles 추출 후 helm template
+          # (단순화: monitoring stack 의 핵심 chart만 우선. 다른 stack은 점진 추가)
+          declare -A CHARTS=(
+            ["prometheus-community/kube-prometheus-stack:79.5.0"]="infra/k8s/monitoring/prometheus/values-production.yaml"
+          )
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+          helm repo update >/dev/null
+          FAIL=0
+          for k in "${!CHARTS[@]}"; do
+            chart="${k%%:*}"
+            version="${k##*:}"
+            values="${CHARTS[$k]}"
+            echo "::group::$chart $version with $values"
+            if ! helm template test "$chart" --version "$version" -f "$values" > /dev/null 2>&1; then
+              echo "::error::helm template 실패: $chart $version"
+              helm template test "$chart" --version "$version" -f "$values" 2>&1 | tail -10
+              FAIL=1
+            fi
+            echo "::endgroup::"
+          done
+          [[ $FAIL -eq 0 ]]
+
+  kubeconform:
+    name: L4 Kubeconform (warn-only)
+    runs-on: ubuntu-latest
+    continue-on-error: true # 베이스라인 정리 후 blocking 으로 승격
+    needs: [kustomize-build]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if k8s manifests changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            k8s:
+              - 'infra/k8s/**'
+              - '.github/workflows/ci-infra.yml'
+
+      - name: Install kustomize + kubeconform
+        if: steps.filter.outputs.k8s == 'true'
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+          curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | tar -xz -C /tmp kubeconform
+          sudo mv /tmp/kubeconform /usr/local/bin/
+
+      - name: Validate kustomize-built manifests against CRD schemas
+        if: steps.filter.outputs.k8s == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          FAIL=0
+          while IFS= read -r kfile; do
+            dir=$(dirname "$kfile")
+            echo "::group::$dir"
+            if ! kustomize build "$dir" 2>/dev/null | kubeconform -strict \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+                -summary 2>&1; then
+              echo "::warning file=$kfile::kubeconform 검증 실패 (warn-only)"
+              FAIL=1
+            fi
+            echo "::endgroup::"
+          done < <(find infra/k8s -name kustomization.yaml -type f)
+          [[ $FAIL -eq 0 ]]
+
+  component-dryrun:
+    name: L5 Component dry-run (warn-only)
+    runs-on: ubuntu-latest
+    continue-on-error: true # 베이스라인 정리 후 blocking 으로 승격
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if monitoring source code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            monitoring:
+              - 'infra/k8s/monitoring/**'
+              - '.github/workflows/ci-infra.yml'
+
+      - name: Setup helm
+        if: steps.filter.outputs.monitoring == 'true'
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.19.2'
+
+      - name: amtool check-config (alertmanager 0.29.0 — operator vendored 매칭)
+        if: steps.filter.outputs.monitoring == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          # CAUTION: amtool 버전을 prometheus-operator vendored alertmanager 버전과 정확히 맞춰야 함
+          # (mismatch 시 우리 PR #3543 같은 silent fail 못 잡음 — false negative)
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+          helm repo update >/dev/null
+          # alertmanager.config 만 추출
+          helm template test prometheus-community/kube-prometheus-stack --version 79.5.0 \
+            -f infra/k8s/monitoring/prometheus/values-production.yaml \
+            --set grafana.enabled=false 2>/dev/null \
+            | python3 -c "
+          import sys, yaml, base64, gzip
+          for doc in yaml.safe_load_all(sys.stdin):
+              if doc and doc.get('kind') == 'Alertmanager':
+                  cfg = doc.get('spec', {}).get('config', '')
+                  if cfg:
+                      print(cfg)
+                      sys.exit(0)
+          " > /tmp/am.yaml
+          if [[ ! -s /tmp/am.yaml ]]; then
+            echo "::warning::Alertmanager spec.config 추출 실패"
+            exit 0
+          fi
+          docker run --rm -v /tmp:/cfg quay.io/prometheus/alertmanager:v0.29.0 \
+            amtool check-config /cfg/am.yaml || {
+            echo "::warning::amtool check-config 실패 — Alertmanager config 문제 가능성"
+            exit 1
+          }
+
+      - name: promtool check rules (PrometheusRule)
+        if: steps.filter.outputs.monitoring == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          # 직접 정의한 PrometheusRule 파일 검증 (chart default 는 외부 검증 불필요)
+          FILES=$(find infra/k8s -name '*.yaml' -exec grep -l 'kind: PrometheusRule' {} \; 2>/dev/null || true)
+          if [[ -z "$FILES" ]]; then
+            echo "검증할 PrometheusRule 파일 없음"
+            exit 0
+          fi
+          for f in $FILES; do
+            echo "::group::$f"
+            docker run --rm -v "$(pwd)/$f:/rules.yaml" prom/prometheus:v3.5.0 \
+              promtool check rules /rules.yaml || true
+            echo "::endgroup::"
+          done
+
+      - name: promtail -dry-run
+        if: steps.filter.outputs.monitoring == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          # promtail config 추출 후 dry-run
+          if [[ ! -f infra/k8s/monitoring/promtail/values.yaml ]]; then
+            echo "promtail values.yaml 없음 - skip"
+            exit 0
+          fi
+          helm repo add grafana https://grafana.github.io/helm-charts >/dev/null
+          helm repo update >/dev/null
+          # promtail chart 자동 추출은 복잡 — 간단히 values.yaml 자체 검증만
+          echo "::warning::promtail dry-run 자동화 미구현 (수동 검증 필요)"
+
+  monitoring-e2e:
+    name: L7 Monitoring Stack E2E (kind)
+    runs-on: ubuntu-latest
+    needs: [yaml-lint, kustomize-build]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -103,3 +103,130 @@ jobs:
           done
 
           echo "All keys are valid"
+
+  monitoring-e2e:
+    name: Monitoring Stack E2E (kind)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if monitoring source code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            monitoring:
+              - 'infra/k8s/monitoring/**'
+              - '.github/workflows/ci-infra.yml'
+
+      - name: Setup helm
+        if: steps.filter.outputs.monitoring == 'true'
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.19.2'
+
+      - name: Boot kind cluster
+        if: steps.filter.outputs.monitoring == 'true'
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: pr-validation
+          version: v0.24.0
+          wait: 60s
+
+      - name: Create namespaces and dummy discord webhook secret
+        if: steps.filter.outputs.monitoring == 'true'
+        run: |
+          set -euo pipefail
+          kubectl create namespace monitoring-grafana
+          kubectl create namespace monitoring-prometheus
+          # 진짜 Discord webhook 노출 X — dummy URL.
+          # alertmanager 가 secret 마운트만 가능하면 검증 목표 (operator config 생성) 달성.
+          # reflector controller 는 CI 에 미설치 — 양쪽 namespace 에 직접 생성.
+          for ns in monitoring-grafana monitoring-prometheus; do
+            kubectl create secret generic discord-webhook \
+              --namespace="$ns" \
+              --from-literal=DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/0/dummy'
+          done
+
+      - name: Install kube-prometheus-stack with prod values
+        if: steps.filter.outputs.monitoring == 'true'
+        run: |
+          set -uo pipefail
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+
+          # 환경별 호환 override:
+          # - grafana: 별도 chart 로 관리 (이 chart 의 grafana subchart 비활성)
+          # - ingress: cert-manager + 학교 DNS 의존 → CI 에서 비활성
+          # - storageSpec: kind 의 local-path 와 충돌 방지
+          helm install prom prometheus-community/kube-prometheus-stack \
+            --version 79.5.0 \
+            --namespace monitoring-prometheus \
+            -f infra/k8s/monitoring/prometheus/values-production.yaml \
+            --set grafana.enabled=false \
+            --set prometheus.ingress.enabled=false \
+            --set alertmanager.ingress.enabled=false \
+            --set 'prometheus.prometheusSpec.storageSpec=null' \
+            --wait --timeout 5m \
+            || echo "::warning::helm install timed out — assertion 단계로 계속 진행 (silent fail 가능성)"
+
+      - name: Wait for operator reconcile
+        if: steps.filter.outputs.monitoring == 'true'
+        run: sleep 30
+
+      - name: Assertion - prometheus-operator log에 silent reconcile fail 없음
+        if: steps.filter.outputs.monitoring == 'true'
+        run: |
+          set -uo pipefail
+          OP_POD=$(kubectl get pod -n monitoring-prometheus \
+            -l app=kube-prometheus-stack-operator -o name 2>/dev/null | head -1)
+          if [[ -z "$OP_POD" ]]; then
+            echo "::error::prometheus-operator pod not found"
+            exit 1
+          fi
+          ERR_LOG=$(kubectl logs -n monitoring-prometheus "$OP_POD" --tail=300 2>&1 \
+            | grep -E 'failed to (initialize|provision|sync)' || true)
+          if [[ -n "$ERR_LOG" ]]; then
+            echo "::error::prometheus-operator silent reconcile fail 감지"
+            echo "$ERR_LOG"
+            exit 1
+          fi
+          echo "operator log clean"
+
+      - name: Assertion - alertmanager-generated secret 에 우리 config 반영됨
+        if: steps.filter.outputs.monitoring == 'true'
+        run: |
+          set -uo pipefail
+          GEN_SECRET="alertmanager-prom-kube-prometheus-stack-alertmanager-generated"
+          SECRET_CONTENT=$(kubectl get secret -n monitoring-prometheus "$GEN_SECRET" \
+            -o jsonpath='{.data.alertmanager\.yaml\.gz}' 2>/dev/null \
+            | base64 -d | gunzip 2>/dev/null || true)
+          if [[ -z "$SECRET_CONTENT" ]]; then
+            echo "::error::alertmanager generated secret 비어있음 — operator 가 secret 생성 못 함"
+            exit 1
+          fi
+          if ! echo "$SECRET_CONTENT" | grep -q 'discord_configs'; then
+            echo "::error::discord_configs receiver 누락 — values.yaml 변경 미반영"
+            exit 1
+          fi
+          if ! echo "$SECRET_CONTENT" | grep -q 'inhibit_rules'; then
+            echo "::error::inhibit_rules 누락 (alert storm 위험)"
+            exit 1
+          fi
+          echo "alertmanager config 정상 반영"
+
+      - name: Diagnostics on failure
+        if: failure() && steps.filter.outputs.monitoring == 'true'
+        run: |
+          echo "=== pods ==="
+          kubectl get pod -n monitoring-prometheus
+          echo
+          echo "=== alertmanager describe ==="
+          kubectl describe pod -n monitoring-prometheus -l app.kubernetes.io/name=alertmanager || true
+          echo
+          echo "=== operator logs (tail 200) ==="
+          OP_POD=$(kubectl get pod -n monitoring-prometheus \
+            -l app=kube-prometheus-stack-operator -o name 2>/dev/null | head -1)
+          if [[ -n "$OP_POD" ]]; then
+            kubectl logs -n monitoring-prometheus "$OP_POD" --tail=200 || true
+          fi


### PR DESCRIPTION
### Description

K8s 인프라 변경에 대한 **다층 검증 stack**을 ci-infra.yml에 추가.

| Layer | Job | 모드 | 잡는 것 | 비용 |
|---|---|---|---|---|
| L1 | yaml-lint | **blocking** | YAML 구문 | <5s |
| L2 | kustomize-build | **blocking** | overlay 빌드, missing resource | <30s |
| L3 | helm-template | warn-only | Go template, required values | <30s |
| L4 | kubeconform | warn-only | CRD strict 스키마 | <30s |
| L5 | component-dryrun | warn-only | amtool/promtool/promtail 도구별 | ~1min |
| L7 | monitoring-e2e | **blocking** | operator vendored lag, silent reconcile | ~5min |

#### 하이브리드 blocking 전략 (왜)

cheap한 layer(L1, L2)와 catch-all(L7)은 처음부터 blocking. semi-noisy한 L3-L5는 baseline 부채 cleanup 전엔 warn-only로 가시화만 (다른 PR 의도치 않게 막지 않게). cleanup PR들 이후에 blocking 승격.

#### L7 (E2E)이 catch하는 unique class

prometheus-operator의 silent reconcile 실패를 PR 머지 전에 차단:

1. kind cluster 부팅
2. dummy Discord webhook secret 주입 (mock)
3. kube-prometheus-stack을 prod values로 install
4. **assertion**:
   - prometheus-operator log에 `failed to (initialize|provision|sync)` 없음
   - alertmanager-generated secret에 우리 config (discord_configs, inhibit_rules) 반영됨

#3543 머지 시 alertmanager에서 silent reconcile 실패 발생 (`field webhook_url_file not found in type alertmanager.discordConfig`). 이 클래스는:

- ArgoCD: status=Synced+Healthy
- helm template / kubeconform / amtool check-config (upstream): 모두 통과
- alertmanager pod: 정상 Running (이전 config 로드 중)
- **유일한 실패 흔적**: prometheus-operator pod log

L4(kubeconform)도 못 잡음 — `Alertmanager.spec.config`는 inline string blob. operator vendored 라이브러리와 upstream 사이의 schema lag은 정적 분석 불가, **오직 reconcile만이 진실**. L7이 그 reconcile을 sandbox에서 미리 실행.

### Additional context

#### L5 amtool 버전 주의

L5의 amtool는 alertmanager 0.29.0으로 명시 pin. prometheus-operator가 vendor한 alertmanager 라이브러리 버전과 정확히 매칭해야 함. mismatch 시 #3543 같은 silent fail 못 잡음 (false negative).

향후 chart upgrade 시 amtool 버전도 같이 sync (renovate.json 추가 권장).

#### chicken-and-egg 알림

본 PR이 도입하는 L7 E2E는 main의 기존 alertmanager silent fail을 catch함 → **본 PR은 자기 자신이 도입한 CI에 fail함**. 이는 의도된 동작이며 PR이 protect하려는 정확한 case 입증.

해결: 후속 fix PR (AlertmanagerConfig CRD 방식)이 본 PR 위에 stack되어 같이 머지. 또는 본 PR을 admin override로 머지하고 fix PR 빠르게 따라감.

#### 베이스라인 cleanup 작업 (별도 PR 예상)

L3-L5가 warn-only로 surface할 violations:
- 기존 helm template 실패 항목
- 기존 CRD 스키마 위반 항목
- promtool/amtool로 잡히는 기존 alert rule / config 문제

각각 별도 cleanup PR로 처리 후 warn → blocking 승격.

#### 향후 확장

- L6 (conftest/OPA): Rego 룰 정의 후 추가
- L7 E2E 범위 확장: grafana / loki / promtail / 인프라 stack 전체

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving
- [x] L7 E2E를 로컬 kind에서 검증 (silent fail 정확히 catch 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)