### PR TITLE
fix(fe): fix admin course sidebar alignment

### DIFF
--- a/apps/frontend/app/admin/_components/ManagementSidebar.tsx
+++ b/apps/frontend/app/admin/_components/ManagementSidebar.tsx
@@ -331,7 +331,7 @@ export function ManagementSidebar({ session }: ManagementSidebarProps) {
               <div className="font-semibold text-gray-700">
                 [{selectedCourse.code}]
               </div>
-              <div>{selectedCourse.name}</div>
+              <div className="w-[190px] truncate">{selectedCourse.name}</div>
               <div className="mt-5 w-[190px]">
                 <Separator />
               </div>


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
강의명에 truncate을 적용하여 긴 강의 제목이 Home과 겹치는 문제를 수정했습니다.

<img width="570" height="661" alt="image" src="https://github.com/user-attachments/assets/31db735f-5294-4ebd-be5f-45fd61ee1818" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
closes TAS-2681

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
