### PR TITLE
fix(fe): revert signup button to modal

### DIFF
--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -203,8 +203,8 @@ export function HeaderAuthPanel({
             }}
             className="!h-[620px] !w-[380px] rounded-[10px]"
           >
-            <DialogHeader className="sr-only">
-              <DialogTitle>Authentication</DialogTitle>
+            <DialogHeader className="hidden">
+              <DialogTitle />
             </DialogHeader>
             <AuthModal />
           </DialogContent>

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -19,9 +19,7 @@ import { useAuthModalStore } from '@/stores/authModal'
 import type { Course } from '@/types/type'
 import { ContestRole, type UserContest } from '@generated/graphql'
 import { ChevronDown } from 'lucide-react'
-import type { Route } from 'next'
 import type { Session } from 'next-auth'
-import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { BiSolidUser } from 'react-icons/bi'
@@ -179,47 +177,46 @@ export function HeaderAuthPanel({
           </Dialog>
         </>
       ) : (
-        <>
-          <Dialog open={currentModal !== ''} onOpenChange={hideModal}>
-            <DialogTrigger asChild>
-              <Button
-                onClick={() => showSignIn()}
-                variant={'outline'}
-                className={cn(
-                  'border-primary text-primary mr-3 hidden bg-transparent px-5 py-1 text-sm font-semibold hover:bg-[#EAF3FF] active:bg-[#D7E5FE] lg:block',
-                  isEditor &&
-                    'h-8 border-none bg-[#EAF3FF] text-[11px] hover:bg-[#D7E5FE]'
-                )}
-              >
-                Log In
-              </Button>
-            </DialogTrigger>
-            <DialogContent
-              onOpenAutoFocus={(e) => {
-                e.preventDefault()
-              }}
-              onInteractOutside={(e) => {
-                e.preventDefault()
-              }}
-              className="!h-[620px] !w-[380px] rounded-[10px]"
-            >
-              <DialogHeader className="hidden">
-                <DialogTitle />
-              </DialogHeader>
-              <AuthModal />
-            </DialogContent>
-          </Dialog>
-          <Link href={'/signup' as Route}>
+        <Dialog open={currentModal !== ''} onOpenChange={hideModal}>
+          <DialogTrigger asChild>
             <Button
+              onClick={() => showSignIn()}
+              variant={'outline'}
               className={cn(
-                'px-5 py-1 text-sm font-semibold',
+                'border-primary text-primary mr-3 hidden bg-transparent px-5 py-1 text-sm font-semibold hover:bg-[#EAF3FF] active:bg-[#D7E5FE] lg:block',
+                isEditor &&
+                  'h-8 border-none bg-[#EAF3FF] text-[11px] hover:bg-[#D7E5FE]'
+              )}
+            >
+              Log In
+            </Button>
+          </DialogTrigger>
+          <DialogContent
+            onOpenAutoFocus={(e) => {
+              e.preventDefault()
+            }}
+            onInteractOutside={(e) => {
+              e.preventDefault()
+            }}
+            className="!h-[620px] !w-[380px] rounded-[10px]"
+          >
+            <DialogHeader className="hidden">
+              <DialogTitle />
+            </DialogHeader>
+            <AuthModal />
+          </DialogContent>
+          <DialogTrigger asChild>
+            <Button
+              onClick={() => showSignUp()}
+              className={cn(
+                'hidden px-5 py-1 text-sm font-semibold lg:block',
                 isEditor && 'h-8 text-[11px]'
               )}
             >
               Sign Up
             </Button>
-          </Link>
-        </>
+          </DialogTrigger>
+        </Dialog>
       )}
     </div>
   )

--- a/apps/frontend/components/auth/HeaderAuthPanel.tsx
+++ b/apps/frontend/components/auth/HeaderAuthPanel.tsx
@@ -177,7 +177,10 @@ export function HeaderAuthPanel({
           </Dialog>
         </>
       ) : (
-        <Dialog open={currentModal !== ''} onOpenChange={hideModal}>
+        <Dialog
+          open={currentModal !== ''}
+          onOpenChange={(open) => !open && hideModal()}
+        >
           <DialogTrigger asChild>
             <Button
               onClick={() => showSignIn()}
@@ -200,8 +203,8 @@ export function HeaderAuthPanel({
             }}
             className="!h-[620px] !w-[380px] rounded-[10px]"
           >
-            <DialogHeader className="hidden">
-              <DialogTitle />
+            <DialogHeader className="sr-only">
+              <DialogTitle>Authentication</DialogTitle>
             </DialogHeader>
             <AuthModal />
           </DialogContent>


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Sign Up 버튼 클릭 시 /signup 페이지로 이동하는 대신 기존 방식대로 모달이 열리도록 변경했습니다. 새 회원가입 페이지는 라우트를 변경하는 대신 /signup 경로를 그대로 유지했어요.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
closes TAS-2683

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
