### PR TITLE
fix(infra): add redis credentials across namespaces

### DIFF
--- a/infra/k8s/admin-api/base/kustomization.yaml
+++ b/infra/k8s/admin-api/base/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - namespace.yaml
   - rabbitmq-ca-cert.yaml
   - rabbitmq-credentials.yaml
+  - redis-credentials.yaml
   - service.yaml

--- a/infra/k8s/admin-api/base/redis-credentials.yaml
+++ b/infra/k8s/admin-api/base/redis-credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+  namespace: admin-api
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflects: 'redis/redis-credentials'

--- a/infra/k8s/client-api/base/kustomization.yaml
+++ b/infra/k8s/client-api/base/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - namespace.yaml
   - rabbitmq-ca-cert.yaml
   - rabbitmq-credentials.yaml
+  - redis-credentials.yaml
   - service.yaml

--- a/infra/k8s/client-api/base/redis-credentials.yaml
+++ b/infra/k8s/client-api/base/redis-credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+  namespace: client-api
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflects: 'redis/redis-credentials'

--- a/infra/k8s/redis/base/admin-credentials.yaml
+++ b/infra/k8s/redis/base/admin-credentials.yaml
@@ -13,4 +13,7 @@ spec:
       creationTimestamp: null
       name: redis-credentials
       namespace: redis
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: 'client-api,admin-api'
     type: Opaque

--- a/infra/k8s/redis/overlays/production/kustomization.yaml
+++ b/infra/k8s/redis/overlays/production/kustomization.yaml
@@ -4,4 +4,9 @@ namespace: redis
 
 resources:
   - ../../base
-  - credentials.yaml
+
+patches:
+  - path: credentials.yaml
+    target:
+      kind: SealedSecret
+      name: redis-credentials

--- a/infra/k8s/redis/overlays/stage/kustomization.yaml
+++ b/infra/k8s/redis/overlays/stage/kustomization.yaml
@@ -4,4 +4,9 @@ namespace: redis
 
 resources:
   - ../../base
-  - credentials.yaml
+
+patches:
+  - path: credentials.yaml
+    target:
+      kind: SealedSecret
+      name: redis-credentials

--- a/infra/k8s/redis/values.yaml
+++ b/infra/k8s/redis/values.yaml
@@ -8,8 +8,9 @@ redisStandalone:
   image: quay.io/opstree/redis
   tag: v7.0.15
   imagePullPolicy: IfNotPresent
-  secretName: redis-credentials
-  secretKey: password
+  redisSecret:
+    secretName: redis-credentials
+    secretKey: password
 # TODO: setup serviceMonitor and redis exporter for monitoring
 # # used by Prometheus Operator as a guidance
 # serviceMonitor:


### PR DESCRIPTION
### Description

redis secret이 정상적으로 생성되고 api pod에서 사용할 수 있도록 credential 설정을 수정했습니다.

- `redis/overlay`의 credential 설정을 중복 resource 등록 방식에서 Kustomize patch 방식으로 변경
- `redis/redis-credentials` secret이 `client-api`, `admin-api` namespace로 복제될 수 있도록 reflector annotation 추가
- `client-api`, `admin-api`에 `redis-credentials` reflector pull 추가
- redis Helm chart가 버전 포맷에 맞게 `values.yaml` 수정




### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
