### PR TITLE
fix(infra): drop parens in s3 bucket tag (invalid in aws tag value)

### DIFF
--- a/infra/aws/sealed-secrets-backup/s3.tf
+++ b/infra/aws/sealed-secrets-backup/s3.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "sealed_secrets_backup" {
   bucket = "codedang-sealed-secrets-backup"
   tags = {
-    Description = "Backup destination for K8s sealed-secrets keys (per-cluster prefix)"
+    Description = "Backup destination for K8s sealed-secrets keys - per-cluster prefix"
   }
 }
 


### PR DESCRIPTION
### Description

[#3553](https://github.com/skkuding/codedang/pull/3553) 머지 후 `terraform apply`가 다음 에러로 중단됨:

```
Error: setting S3 Bucket (codedang-sealed-secrets-backup) tags:
  api error InvalidTag: The TagValue you have provided is invalid
```

AWS tag value 제약은 `letters / numbers / spaces / + - = . _ : / @` 만 허용하고 **괄호 `()` 는 거부**. 내가 작성한 tag value `"... keys (per-cluster prefix)"`의 괄호가 원인. `terraform plan`은 provider schema (`map(string)`) 만 검증하고 AWS service-side value 제약은 모르므로 plan 단계에서 잡히지 않음.

#### 변경 내용

- [infra/aws/sealed-secrets-backup/s3.tf](https://github.com/skkuding/codedang/blob/main/infra/aws/sealed-secrets-backup/s3.tf): tag value의 괄호 → hyphen
  ```diff
  -Description = "Backup destination for K8s sealed-secrets keys (per-cluster prefix)"
  +Description = "Backup destination for K8s sealed-secrets keys - per-cluster prefix"
  ```

### Additional context

#### Partial apply 상태 (현재)

- terraform state 보존: `aws_iam_user`, `aws_iam_access_key`, `aws_s3_bucket.sealed_secrets_backup` (tag 없는 상태)
- AWS 실제: S3 bucket 생성됨 (versioning/encryption/public-block/lifecycle 미적용), legacy Secrets Manager 두 secret은 soft delete (30일 복원 가능)
- IAM 새 정책 미생성 → IAM user `sealed-secrets-backup` 권한 현재 0
- 데이터 손실: 없음 (로컬 백업 + Secrets Manager soft delete)
- 다음 cron까지 ~3주 시간 있음

이후 [#3553](https://github.com/skkuding/codedang/pull/3553) test plan 이어서 진행.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)