### PR TITLE
fix(infra): add kakao callback url env (stage,prod)

### DIFF
--- a/infra/k8s/client-api/overlays/production/configmap.yaml
+++ b/infra/k8s/client-api/overlays/production/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: client-api-env
+  namespace: client-api
+data:
+  KAKAO_CALLBACK_URL: 'https://codedang.com/api/auth/kakao-callback'

--- a/infra/k8s/client-api/overlays/production/kustomization.yaml
+++ b/infra/k8s/client-api/overlays/production/kustomization.yaml
@@ -8,3 +8,9 @@ resources:
   - secrets/database-credentials.yaml
   - secrets/oauth-credentials.yaml
   - secrets/security-keys.yaml
+
+patches:
+  - path: configmap.yaml
+    target:
+      kind: ConfigMap
+      name: client-api-env

--- a/infra/k8s/client-api/overlays/stage/configmap.yaml
+++ b/infra/k8s/client-api/overlays/stage/configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: client-api
 data:
   MINIO_ENDPOINT_URL: 'https://minio.stage.codedang.com'
+  KAKAO_CALLBACK_URL: 'https://stage.codedang.com/api/auth/kakao-callback'


### PR DESCRIPTION
### Description

`client-api/overlays/stage/configmap.yaml`에 `KAKAO_CALLBACK_URL`을 추가했습니다.

- 백엔드 코드에서 `KAKAO_CALLBACK_URL`을 환경변수로 읽고 있으나,  stage 인프라 파일에는 해당 값이 없어 관련 pod가 crash off가 발생하고 있습니다. (configuration key "KAKAO_CALLBACK_URL" does not exist)


### Additional context


### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
