### PR TITLE
feat(infra): add shared storage(longhorn)

### DIFF
--- a/infra/k8s/argocd/applications/longhorn.yaml
+++ b/infra/k8s/argocd/applications/longhorn.yaml
@@ -26,7 +26,7 @@ spec:
           defaultClassReplicaCount: 3
           # No effect on local-path pods
           defaultClass: false
-          reclaimPolicy: Delete
+          reclaimPolicy: Retain
   destination:
     namespace: longhorn-system
     name: stage

--- a/infra/k8s/argocd/applications/longhorn.yaml
+++ b/infra/k8s/argocd/applications/longhorn.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: longhorn-stage
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '-3'
+  labels:
+    app.kubernetes.io/environment: 'stage'
+spec:
+  project: default
+  source:
+    repoURL: https://charts.longhorn.io
+    chart: longhorn
+    targetRevision: 1.11.1
+    helm:
+      releaseName: longhorn
+      valuesObject:
+        preUpgradeChecker:
+          jobEnabled: false
+        defaultSettings:
+          defaultReplicaCount: 3
+          defaultDataPath: /var/lib/longhorn/
+          replicaSoftAntiAffinity: false
+        persistence:
+          defaultClassReplicaCount: 3
+          # No effect on local-path pods
+          defaultClass: false
+          reclaimPolicy: Delete
+  destination:
+    namespace: longhorn-system
+    name: stage
+  syncPolicy:
+    automated:
+      # Prune disabled: requires manual review before removing resources
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/k8s/argocd/applications/redis.yaml
+++ b/infra/k8s/argocd/applications/redis.yaml
@@ -29,8 +29,10 @@ spec:
           targetRevision: 0.16.5
           helm:
             releaseName: redis
+            ignoreMissingValueFiles: true
             valueFiles:
               - $codedang/infra/k8s/redis/values.yaml
+              - $codedang/infra/k8s/redis/values-{{.env}}.yaml
         - repoURL: https://github.com/skkuding/codedang
           targetRevision: '{{.branch}}'
           ref: codedang

--- a/infra/k8s/redis/values-production.yaml
+++ b/infra/k8s/redis/values-production.yaml
@@ -1,0 +1,3 @@
+# Production-specific Redis values
+# Uses default StorageClass (local-path)
+# No additional overrides needed

--- a/infra/k8s/redis/values-stage.yaml
+++ b/infra/k8s/redis/values-stage.yaml
@@ -1,0 +1,12 @@
+# Stage-specific Redis values
+# Longhorn distributed storage to remove node dependency
+# Allows Redis pod to be scheduled on any node in the cluster
+storageSpec:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
### Description

redis pod의 노드 종속성 문제 해결을 위해 stage 클러스터에 longhron을 도입했습니다. 
- `argocd/application`에 관리하도록 추가했습니다. 
- `redis values`를 환경별로 분리해 stage만 longhorn storageClass를 사용하도록 설정했습니다.


- `defaultClass: false`로 설정하여 storageClass인 `local-path`를 사용하는 pod에 영향을 주지 않도록 했습니다. 



### Additional context


### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
