### PR TITLE
fix(infra): align rabbitmq servicemonitor with tls-only listener

### DIFF
--- a/infra/k8s/rabbitmq/base/service-monitor.yaml
+++ b/infra/k8s/rabbitmq/base/service-monitor.yaml
@@ -14,5 +14,12 @@ spec:
       app.kubernetes.io/component: rabbitmq
       app.kubernetes.io/name: rabbitmq
   endpoints:
-    - port: prometheus
+    - port: prometheus-tls
       interval: 15s
+      scheme: https
+      tlsConfig:
+        ca:
+          secret:
+            name: rabbitmq-server-certs
+            key: ca.crt
+        serverName: rabbitmq.rabbitmq.svc


### PR DESCRIPTION
### Description

`grafana.stage.codedang.com`에서 `DatasourceNoData` 알림 (`RabbitMQ 메시지 적체` / `RabbitMQ 미확인 메시지 적체`)이 7일 연속 매일 firing되던 문제 해결.

**Root cause**

- skkuding/codedang#3445 (`disableNonTLSListeners: true`) 머지 후 RabbitMQ Operator가 Service에서 비-TLS prometheus 포트(15692, name=`prometheus`)를 제거하고 TLS 포트(15691, name=`prometheus-tls`)만 노출하도록 변경됨
- ServiceMonitor는 여전히 `port: prometheus`로 매칭 시도 → endpoint 0개 → Prometheus target 0개 → `rabbitmq_queue_messages_*` 메트릭 부재 → `DatasourceNoData` 발화
- skkuding/codedang#3530 expression migration 작동 시작 후 이 부재가 즉각 가시화됨 (그 전엔 expression error 상태에 가려져 있었음)

**Fix**

ServiceMonitor를 TLS 리스너와 정렬:

- `port: prometheus` → `port: prometheus-tls`
- `scheme: https` + `tlsConfig`로 cert-manager 발급 CA 검증 (`rabbitmq-server-certs/ca.crt`)
- `serverName: rabbitmq.rabbitmq.svc` (cert SAN과 매칭)

### Additional context

**라이브 검증 (stage)**

- 변경 전: `up{job="rabbitmq-monitor"}` 결과 0개, `rabbitmq_queue_messages_ready` 시리즈 없음
- Pod IP:15692 직접 스크랩 시 메트릭 정상 (`rabbitmq_queue_messages_ready 2`) — Operator-managed Service의 포트 라우팅 단계에서만 끊겨있음 확인
- 변경 후 ArgoCD sync 완료 후 `up{job="rabbitmq-monitor"} == 1` + 알림 resolve 재확인 예정

**연관 PR**

- skkuding/codedang#3445 — TLS encryption (root cause trigger)
- skkuding/codedang#3508 — RabbitMQ monitoring 도입 시 ServiceMonitor 작성 (비-TLS 전제)
- skkuding/codedang#3530 — Grafana 12 expression migration (부재를 가시화)

**Followup 필요**

- prod ArgoCD가 `release` 브랜치 추적 중이라 #3445/#3508 미포함 상태. release rebase 시 본 fix가 함께 들어가야 prod에서도 monitoring 회복.
- `rabbitmq-stage` ArgoCD app이 RabbitmqCluster CRD patch 시 `resourceVersion: 0` 오류로 OutOfSync Degraded — 본 PR 범위 밖, 별도 트러블슈팅 필요.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

> infra manifest 변경이라 unit test 대상 아님 — ArgoCD sync 후 `up{job="rabbitmq-monitor"} == 1` 라이브 검증으로 대체.