### PR TITLE
fix(be): bypass contest staff submission for not ongoing contest

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pg_isready -h 127.0.0.1 -p 5433 -U postgres)",
+      "Bash(pg_isready -h 127.0.0.1 -p 5432 -U postgres)",
+      "Bash(nc -zv 127.0.0.1 5433)",
+      "Bash(nc -zv 127.0.0.1 5432)",
+      "Bash(docker compose *)",
+      "Bash(psql -h 127.0.0.1 -p 5433 -U postgres -c \"\\\\l\")",
+      "Bash(fuser 5433/tcp)"
+    ]
+  }
+}

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -3,6 +3,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import {
+  ContestRole,
   Language,
   Prisma,
   Problem,
@@ -147,47 +148,54 @@ export class SubmissionService {
     // 진행 중인 대회인지 확인합니다.
     const contest = await this.prisma.contest.findFirst({
       where: {
-        id: contestId,
-        startTime: {
-          lte: now
-        },
-        endTime: {
-          gt: now
-        }
+        id: contestId
       }
     })
     if (!contest) {
       throw new EntityNotExistException('Contest')
     }
 
-    // 대회에 등록되어 있는지 확인합니다.
-    const contestRecord = await this.prisma.contestRecord.findUnique({
+    // 대회 관리자면 진행 여부와 관계없이 bypass합니다
+    const contestStaff = await this.prisma.userContest.findFirst({
       where: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        contestId_userId: {
-          contestId,
-          userId
-        }
-      },
-      select: {
-        contest: {
-          select: {
-            startTime: true,
-            endTime: true
-          }
+        contestId,
+        userId,
+        role: {
+          in: [ContestRole.Admin, ContestRole.Manager, ContestRole.Reviewer]
         }
       }
     })
-    if (!contestRecord) {
-      throw new EntityNotExistException('ContestRecord')
-    }
-    if (
-      contestRecord.contest.startTime > now ||
-      contestRecord.contest.endTime <= now
-    ) {
-      throw new ConflictFoundException(
-        'Submission is only allowed to ongoing contests'
-      )
+
+    if (!contestStaff) {
+      // 대회에 등록되어 있는지 확인합니다.
+      const contestRecord = await this.prisma.contestRecord.findUnique({
+        where: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          contestId_userId: {
+            contestId,
+            userId
+          }
+        },
+        select: {
+          contest: {
+            select: {
+              startTime: true,
+              endTime: true
+            }
+          }
+        }
+      })
+      if (!contestRecord) {
+        throw new EntityNotExistException('ContestRecord')
+      }
+      if (
+        contestRecord.contest.startTime > now ||
+        contestRecord.contest.endTime <= now
+      ) {
+        throw new ConflictFoundException(
+          'Submission is only allowed to ongoing contests'
+        )
+      }
     }
 
     const contestProblem = await this.prisma.contestProblem.findUnique({

--- a/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission.service.spec.ts
@@ -70,6 +70,9 @@ const db = {
     findUnique: stub(),
     update: stub()
   },
+  userContest: {
+    findFirst: stub()
+  },
   assignmentRecord: {
     findUnique: stub(),
     update: stub()
@@ -241,6 +244,7 @@ describe('SubmissionService', () => {
     it('should call createSubmission', async () => {
       const createSpy = stub(service, 'createSubmission')
       db.contest.findFirst.resolves(mockContest)
+      db.userContest.findFirst.resolves(null)
       db.contestRecord.findUnique.resolves({
         contest: {
           groupId: 1,


### PR DESCRIPTION
### Description

진행중이지 않은 대회의 경우에도 대회 관리자가 submit할 수 있도록 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
