### PR TITLE
fix(infra): enforce iris topology spread

### DIFF
--- a/infra/k8s/iris/base/deployment.yaml
+++ b/infra/k8s/iris/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: iris

--- a/infra/k8s/iris/base/deployment.yaml
+++ b/infra/k8s/iris/base/deployment.yaml
@@ -13,6 +13,13 @@ spec:
       labels:
         app: iris
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: iris
       containers:
         - name: iris
           image: ghcr.io/skkuding/codedang-iris

--- a/infra/k8s/iris/overlays/production/deployment-patch.yaml
+++ b/infra/k8s/iris/overlays/production/deployment-patch.yaml
@@ -1,3 +1,6 @@
 - op: replace
+  path: /spec/template/spec/topologySpreadConstraints/0/maxSkew
+  value: 3
+- op: replace
   path: /spec/template/spec/topologySpreadConstraints/0/whenUnsatisfiable
   value: DoNotSchedule

--- a/infra/k8s/iris/overlays/production/deployment-patch.yaml
+++ b/infra/k8s/iris/overlays/production/deployment-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/topologySpreadConstraints/0/whenUnsatisfiable
+  value: DoNotSchedule

--- a/infra/k8s/iris/overlays/production/kustomization.yaml
+++ b/infra/k8s/iris/overlays/production/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
   - ../../base
   - aws-credentials.yaml
   - database-credentials.yaml
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: iris


### PR DESCRIPTION
### Description

프로덕션 iris Deployment에 `topologySpreadConstraints`를 추가하여 `kubernetes.io/hostname` 기준 스케줄링 skew를 `maxSkew: 3`으로 강제합니다. `whenUnsatisfiable: DoNotSchedule`을 사용하여 프로덕션에서 특정 노드에 pod이 크게 집중되는 문제를 방지합니다.

### Additional context

Closes TAS-2725

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** this PR is solving, or reference the issue that it solves.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

Closes TAS-2725