### PR TITLE
fix(infra): pin isolate version for runner image

### DIFF
--- a/apps/runner/backend/Dockerfile
+++ b/apps/runner/backend/Dockerfile
@@ -29,6 +29,7 @@ RUN wget -P /tmp https://github.com/ioi/isolate/archive/refs/tags/v2.2.1.tar.gz 
     && mkdir -p /usr/local/etc \
     && cp /tmp/isolate-2.2.1/default.cf /usr/local/etc/isolate \
     && install /tmp/isolate-2.2.1/isolate /usr/local/bin/isolate \
+    && rm -rf /tmp/v2.2.1.tar.gz /tmp/isolate-2.2.1 \
     && isolate --init
 
 # Create a sandbox directory

--- a/apps/runner/backend/Dockerfile
+++ b/apps/runner/backend/Dockerfile
@@ -23,12 +23,12 @@ RUN apt update && apt install -y \
     libsystemd-dev
 
 # Install isolate (https://github.com/ioi/isolate)
-RUN wget -P /tmp https://github.com/ioi/isolate/archive/master.tar.gz \
-    && tar -xzvf /tmp/master.tar.gz -C /tmp \
-    && make -C /tmp/isolate-master isolate default.cf \
+RUN wget -P /tmp https://github.com/ioi/isolate/archive/refs/tags/v2.2.1.tar.gz \
+    && tar -xzvf /tmp/v2.2.1.tar.gz -C /tmp \
+    && make -C /tmp/isolate-2.2.1 isolate default.cf \
     && mkdir -p /usr/local/etc \
-    && cp /tmp/isolate-master/default.cf /usr/local/etc/isolate \
-    && install /tmp/isolate-master/isolate /usr/local/bin/isolate \
+    && cp /tmp/isolate-2.2.1/default.cf /usr/local/etc/isolate \
+    && install /tmp/isolate-2.2.1/isolate /usr/local/bin/isolate \
     && isolate --init
 
 # Create a sandbox directory


### PR DESCRIPTION
### Description

runner backend Docker image에서 ioi/isolate를 master가 아니라 v2.2.1 태그로 고정합니다.

stage CD 빌드가 실패한 이유는 현재 ioi/isolate master에 seccomp.h 의존성이 추가되었지만, runner image에는 seccomp development headers가 설치되어 있지 않기 때문입니다. 외부 저장소의 master 변경으로 이미지 빌드가 깨지지 않도록 기존에 호환되던 버전으로 고정합니다.

### Additional context

- v2.2.1 archive가 존재하고 isolate-2.2.1 디렉터리로 압축 해제되는 것을 확인했습니다.
- archive 안에 Dockerfile에서 사용하는 Makefile과 default.cf.in 경로가 존재하는 것을 확인했습니다.
- local Docker build를 시도했지만 시간이 오래 걸려 완료 전 hotfix push를 진행했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. fixes #123).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
