### PR TITLE
fix(be): modify contestStaff Submission logic

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(nc -zv 127.0.0.1 5432)",
       "Bash(docker compose *)",
       "Bash(psql -h 127.0.0.1 -p 5433 -U postgres -c \"\\\\l\")",
-      "Bash(fuser 5433/tcp)"
+      "Bash(fuser 5433/tcp)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/apps/backend/apps/client/src/submission/submission-sub.service.ts
+++ b/apps/backend/apps/client/src/submission/submission-sub.service.ts
@@ -1,6 +1,7 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger, type OnModuleInit } from '@nestjs/common'
 import {
+  ContestRole,
   Prisma,
   ResultStatus,
   type Submission,
@@ -552,6 +553,19 @@ export class SubmissionSubscriptionService implements OnModuleInit {
       )
 
     if (!isAccepted) return
+
+    // Contest staff(Admin/Manager/Reviewer)의 제출은 ranking 대상이 아니므로 record 갱신을 스킵합니다.
+    const isStaff = await this.prisma.userContest.findFirst({
+      where: {
+        contestId,
+        userId,
+        role: {
+          in: [ContestRole.Admin, ContestRole.Manager, ContestRole.Reviewer]
+        }
+      },
+      select: { id: true }
+    })
+    if (isStaff) return
 
     const [contest, contestProblem, contestRecord, previousSubmissions] =
       await Promise.all([

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -1066,9 +1066,10 @@ export class SubmissionService {
     } | null = null
     let isJudgeResultVisible: boolean | null = null
     let isHiddenTestcaseVisible: boolean | null = null
+    let isStaff = false
 
     if (contestId) {
-      const isStaff = await this.isContestStaff(contestId, userId)
+      isStaff = await this.isContestStaff(contestId, userId)
       if (isStaff) {
         const contestData = await this.prisma.contest.findUnique({
           where: { id: contestId },
@@ -1191,11 +1192,12 @@ export class SubmissionService {
       throw new EntityNotExistException('Submission')
     }
 
-    // 본인이나 관리자가 아닐 경우
+    // 본인이나 관리자, contest staff가 아닐 경우
     if (
       submission.userId !== userId &&
       userRole !== Role.Admin &&
-      userRole !== Role.SuperAdmin
+      userRole !== Role.SuperAdmin &&
+      !isStaff
     ) {
       if (
         contest &&

--- a/apps/backend/apps/client/src/submission/submission.service.ts
+++ b/apps/backend/apps/client/src/submission/submission.service.ts
@@ -156,17 +156,9 @@ export class SubmissionService {
     }
 
     // 대회 관리자면 진행 여부와 관계없이 bypass합니다
-    const contestStaff = await this.prisma.userContest.findFirst({
-      where: {
-        contestId,
-        userId,
-        role: {
-          in: [ContestRole.Admin, ContestRole.Manager, ContestRole.Reviewer]
-        }
-      }
-    })
+    const isStaff = await this.isContestStaff(contestId, userId)
 
-    if (!contestStaff) {
+    if (!isStaff) {
       // 대회에 등록되어 있는지 확인합니다.
       const contestRecord = await this.prisma.contestRecord.findUnique({
         where: {
@@ -628,6 +620,27 @@ export class SubmissionService {
   }
 
   /**
+   * 주어진 사용자가 해당 대회의 staff(Admin/Manager/Reviewer)인지 확인합니다.
+   *
+   * @param {number} contestId - 대회 ID
+   * @param {number} userId - 사용자 ID
+   * @returns {Promise<boolean>} staff 여부
+   */
+  async isContestStaff(contestId: number, userId: number): Promise<boolean> {
+    const staff = await this.prisma.userContest.findFirst({
+      where: {
+        contestId,
+        userId,
+        role: {
+          in: [ContestRole.Admin, ContestRole.Manager, ContestRole.Reviewer]
+        }
+      },
+      select: { id: true }
+    })
+    return !!staff
+  }
+
+  /**
    * 임의의 6자리 16진수 문자열을 생성합니다.
    *
    * @returns {string} 생성된 6자리 16진수 문자열
@@ -1055,29 +1068,46 @@ export class SubmissionService {
     let isHiddenTestcaseVisible: boolean | null = null
 
     if (contestId) {
-      const contestRecord = await this.prisma.contestRecord.findUnique({
-        where: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          contestId_userId: {
-            contestId,
-            userId
+      const isStaff = await this.isContestStaff(contestId, userId)
+      if (isStaff) {
+        const contestData = await this.prisma.contest.findUnique({
+          where: { id: contestId },
+          select: {
+            startTime: true,
+            endTime: true,
+            isJudgeResultVisible: true
           }
-        },
-        select: {
-          contest: {
-            select: {
-              startTime: true,
-              endTime: true,
-              isJudgeResultVisible: true
+        })
+        if (!contestData) {
+          throw new EntityNotExistException('Contest')
+        }
+        contest = contestData
+        isJudgeResultVisible = contest.isJudgeResultVisible
+      } else {
+        const contestRecord = await this.prisma.contestRecord.findUnique({
+          where: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            contestId_userId: {
+              contestId,
+              userId
+            }
+          },
+          select: {
+            contest: {
+              select: {
+                startTime: true,
+                endTime: true,
+                isJudgeResultVisible: true
+              }
             }
           }
+        })
+        if (!contestRecord) {
+          throw new EntityNotExistException('ContestRecord')
         }
-      })
-      if (!contestRecord) {
-        throw new EntityNotExistException('ContestRecord')
+        contest = contestRecord.contest
+        isJudgeResultVisible = contest.isJudgeResultVisible
       }
-      contest = contestRecord.contest
-      isJudgeResultVisible = contest.isJudgeResultVisible
     } else if (assignmentId) {
       const assignmentRecord = await this.prisma.assignmentRecord.findUnique({
         where: {
@@ -1327,7 +1357,11 @@ export class SubmissionService {
       }
     })
 
-    if (!isAdmin) {
+    const isStaff = isAdmin
+      ? true
+      : await this.isContestStaff(contestId, userId)
+
+    if (!isStaff) {
       const contestRecord = await this.prisma.contestRecord.findUnique({
         where: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -1373,7 +1407,7 @@ export class SubmissionService {
       where: {
         problemId,
         contestId,
-        userId: isAdmin ? undefined : userId // Admin 계정인 경우 자신이 생성한 submission이 아니더라도 조회가 가능
+        userId: isStaff ? undefined : userId // Admin/Contest staff 인 경우 자신이 생성한 submission이 아니더라도 조회가 가능
       },
       select: {
         id: true,

--- a/apps/backend/apps/client/src/submission/test/submission-sub.service.spec.ts
+++ b/apps/backend/apps/client/src/submission/test/submission-sub.service.spec.ts
@@ -119,6 +119,9 @@ const db = {
   contestProblemFirstSolver: {
     create: mockFunc
   },
+  userContest: {
+    findFirst: mockFunc
+  },
   testSubmission: {
     findUnique: mockFunc,
     update: mockFunc
@@ -687,6 +690,9 @@ describe('SubmissionSubscriptionService', () => {
 
   describe('updateContestRecord', () => {
     it('should update records when new accepted submission', async () => {
+      // 일반 참가자 제출 → staff가 아님
+      sandbox.stub(db.userContest, 'findFirst').resolves(null)
+
       const submissionCountSpy = sandbox
         .stub(db.submission, 'count')
         .resolves(0)


### PR DESCRIPTION
### Description

1. 이전 PR(#3583)에서 submitToContest만 수정했으나, 현재 contest problem이 제출된 경우 updateContestRecord가 동작합니다. 대회 관리자의 경우 contestRecord가 존재하지 않으므로 해당 부분 또한 bypass하도록 수정합니다.
3. getSubmission에서도 bypass 로직 추가

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
