### PR TITLE
fix(infra): rabbitmq-tls-unify-insecure-skip-verify

### DIFF
--- a/apps/backend/libs/amqp/src/amqp.module.ts
+++ b/apps/backend/libs/amqp/src/amqp.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { RabbitMQModule } from '@golevelup/nestjs-rabbitmq'
-import { readFileSync } from 'fs'
 import { CONSUME_CHANNEL, PUBLISH_CHANNEL } from '@libs/constants'
 import { CheckAMQPService, JudgeAMQPService } from './amqp.service'
 
@@ -40,7 +39,7 @@ import { CheckAMQPService, JudgeAMQPService } from './amqp.service'
           ...(config.get('RABBITMQ_SSL') === 'true' && {
             connectionManagerOptions: {
               connectionOptions: {
-                ca: [readFileSync('/etc/ssl/rabbitmq/ca.crt')]
+                rejectUnauthorized: false
               }
             }
           })

--- a/apps/iris/main.go
+++ b/apps/iris/main.go
@@ -103,7 +103,7 @@ func main() {
 
 	// amqps://skku:1234@broker-id.mq.us-west-2.amazonaws.com:5671
 	var uri string
-	if utils.Getenv("RABBITMQ_SSL", "") != "" {
+	if utils.Getenv("RABBITMQ_SSL", "") == "true" {
 		uri = "amqps://"
 	} else {
 		uri = "amqp://"

--- a/apps/iris/src/connector/rabbitmq/consumer.go
+++ b/apps/iris/src/connector/rabbitmq/consumer.go
@@ -2,7 +2,6 @@ package rabbitmq
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"os"
 
@@ -40,13 +39,7 @@ func NewConsumer(config ConsumerConfig, logger logger.Logger) (*consumer, error)
 		Properties: amqp.NewConnectionProperties(),
 	}
 	if os.Getenv("RABBITMQ_SSL") == "true" {
-		caCert, err := os.ReadFile("/etc/ssl/rabbitmq/ca.crt")
-		if err != nil {
-			return nil, fmt.Errorf("consumer: failed to read RabbitMQ CA cert: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
-		amqpConfig.TLSClientConfig = &tls.Config{RootCAs: caCertPool}
+		amqpConfig.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	amqpConfig.Properties.SetClientConnectionName(config.ConnectionName)
 	connection, err := amqp.DialConfig(config.AmqpURI, amqpConfig)

--- a/apps/iris/src/connector/rabbitmq/producer.go
+++ b/apps/iris/src/connector/rabbitmq/producer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	instrumentation "github.com/skkuding/codedang/apps/iris/src"
@@ -41,8 +42,10 @@ func NewProducer(config ProducerConfig, logger logger.Logger) (*producer, error)
 
 	// Create New RabbitMQ Connection (go <-> RabbitMQ)
 	amqpConfig := amqp.Config{
-		Properties:      amqp.NewConnectionProperties(),
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Properties: amqp.NewConnectionProperties(),
+	}
+	if os.Getenv("RABBITMQ_SSL") == "true" {
+		amqpConfig.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	amqpConfig.Properties.SetClientConnectionName(config.ConnectionName)
 	connection, err := amqp.DialConfig(config.AmqpURI, amqpConfig)

--- a/apps/plag/main.go
+++ b/apps/plag/main.go
@@ -100,7 +100,7 @@ func main() {
 
 	// amqps://skku:1234@broker-id.mq.us-west-2.amazonaws.com:5671
 	var uri string
-	if utils.Getenv("RABBITMQ_SSL", "") != "" {
+	if utils.Getenv("RABBITMQ_SSL", "") == "true" {
 		uri = "amqps://"
 	} else {
 		uri = "amqp://"

--- a/apps/plag/src/connector/rabbitmq/consumer.go
+++ b/apps/plag/src/connector/rabbitmq/consumer.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"crypto/tls"
 	"fmt"
+	"os"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/skkuding/codedang/apps/plag/src/service/logger"
@@ -35,8 +36,10 @@ func NewConsumer(config ConsumerConfig, logger logger.Logger) (*consumer, error)
 
 	// Create New RabbitMQ Connection (go <-> RabbitMQ)
 	amqpConfig := amqp.Config{
-		Properties:      amqp.NewConnectionProperties(),
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Properties: amqp.NewConnectionProperties(),
+	}
+	if os.Getenv("RABBITMQ_SSL") == "true" {
+		amqpConfig.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	amqpConfig.Properties.SetClientConnectionName(config.ConnectionName)
 	connection, err := amqp.DialConfig(config.AmqpURI, amqpConfig)

--- a/apps/plag/src/connector/rabbitmq/producer.go
+++ b/apps/plag/src/connector/rabbitmq/producer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	instrumentation "github.com/skkuding/codedang/apps/plag/src"
@@ -41,8 +42,10 @@ func NewProducer(config ProducerConfig, logger logger.Logger) (*producer, error)
 
 	// Create New RabbitMQ Connection (go <-> RabbitMQ)
 	amqpConfig := amqp.Config{
-		Properties:      amqp.NewConnectionProperties(),
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Properties: amqp.NewConnectionProperties(),
+	}
+	if os.Getenv("RABBITMQ_SSL") == "true" {
+		amqpConfig.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	amqpConfig.Properties.SetClientConnectionName(config.ConnectionName)
 	connection, err := amqp.DialConfig(config.AmqpURI, amqpConfig)

--- a/infra/k8s/admin-api/base/deployment.yaml
+++ b/infra/k8s/admin-api/base/deployment.yaml
@@ -32,10 +32,6 @@ spec:
                 name: database-credentials
             - secretRef:
                 name: security-keys
-          volumeMounts:
-            - name: rabbitmq-ca-cert
-              mountPath: /etc/ssl/rabbitmq
-              readOnly: true
           env:
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
@@ -52,10 +48,3 @@ spec:
                 secretKeyRef:
                   name: redis-credentials
                   key: password
-      volumes:
-        - name: rabbitmq-ca-cert
-          secret:
-            secretName: rabbitmq-ca-cert
-            items:
-              - key: ca.crt
-                path: ca.crt

--- a/infra/k8s/admin-api/base/kustomization.yaml
+++ b/infra/k8s/admin-api/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - deployment.yaml
   - ingress.yaml
   - namespace.yaml
-  - rabbitmq-ca-cert.yaml
   - rabbitmq-credentials.yaml
   - redis-credentials.yaml
   - service.yaml

--- a/infra/k8s/admin-api/base/rabbitmq-ca-cert.yaml
+++ b/infra/k8s/admin-api/base/rabbitmq-ca-cert.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rabbitmq-ca-cert
-  namespace: admin-api
-  annotations:
-    reflector.v1.k8s.emberstack.com/reflects: 'rabbitmq/rabbitmq-server-certs'

--- a/infra/k8s/client-api/base/deployment.yaml
+++ b/infra/k8s/client-api/base/deployment.yaml
@@ -34,10 +34,6 @@ spec:
                 name: oauth-credentials
             - secretRef:
                 name: security-keys
-          volumeMounts:
-            - name: rabbitmq-ca-cert
-              mountPath: /etc/ssl/rabbitmq
-              readOnly: true
           env:
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
@@ -54,10 +50,3 @@ spec:
                 secretKeyRef:
                   name: redis-credentials
                   key: password
-      volumes:
-        - name: rabbitmq-ca-cert
-          secret:
-            secretName: rabbitmq-ca-cert
-            items:
-              - key: ca.crt
-                path: ca.crt

--- a/infra/k8s/client-api/base/kustomization.yaml
+++ b/infra/k8s/client-api/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - deployment.yaml
   - ingress.yaml
   - namespace.yaml
-  - rabbitmq-ca-cert.yaml
   - rabbitmq-credentials.yaml
   - redis-credentials.yaml
   - service.yaml

--- a/infra/k8s/client-api/base/rabbitmq-ca-cert.yaml
+++ b/infra/k8s/client-api/base/rabbitmq-ca-cert.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rabbitmq-ca-cert
-  namespace: client-api
-  annotations:
-    reflector.v1.k8s.emberstack.com/reflects: 'rabbitmq/rabbitmq-server-certs'

--- a/infra/k8s/iris/base/deployment.yaml
+++ b/infra/k8s/iris/base/deployment.yaml
@@ -27,9 +27,6 @@ spec:
             - name: cgroup
               mountPath: /sys/fs/cgroup
               readOnly: false
-            - name: rabbitmq-ca-cert
-              mountPath: /etc/ssl/rabbitmq
-              readOnly: true
           securityContext:
             privileged: true
           envFrom:
@@ -55,9 +52,3 @@ spec:
           hostPath:
             path: /sys/fs/cgroup
             type: Directory
-        - name: rabbitmq-ca-cert
-          secret:
-            secretName: rabbitmq-ca-cert
-            items:
-              - key: ca.crt
-                path: ca.crt

--- a/infra/k8s/iris/base/kustomization.yaml
+++ b/infra/k8s/iris/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
-  - rabbitmq-ca-cert.yaml
   - rabbitmq-credentials.yaml
 
 commonAnnotations:

--- a/infra/k8s/iris/base/rabbitmq-ca-cert.yaml
+++ b/infra/k8s/iris/base/rabbitmq-ca-cert.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rabbitmq-ca-cert
-  namespace: iris
-  annotations:
-    reflector.v1.k8s.emberstack.com/reflects: 'rabbitmq/rabbitmq-server-certs'

--- a/infra/k8s/plag/base/deployment.yaml
+++ b/infra/k8s/plag/base/deployment.yaml
@@ -32,10 +32,6 @@ spec:
                 name: aws-credentials
             - secretRef:
                 name: database-credentials
-          volumeMounts:
-            - name: rabbitmq-ca-cert
-              mountPath: /etc/ssl/rabbitmq
-              readOnly: true
           env:
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
@@ -47,10 +43,3 @@ spec:
                 secretKeyRef:
                   name: rabbitmq-credentials
                   key: password
-      volumes:
-        - name: rabbitmq-ca-cert
-          secret:
-            secretName: rabbitmq-ca-cert
-            items:
-              - key: ca.crt
-                path: ca.crt

--- a/infra/k8s/plag/base/kustomization.yaml
+++ b/infra/k8s/plag/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - namespace.yaml
-  - rabbitmq-ca-cert.yaml
   - rabbitmq-credentials.yaml
 
 commonAnnotations:

--- a/infra/k8s/plag/base/rabbitmq-ca-cert.yaml
+++ b/infra/k8s/plag/base/rabbitmq-ca-cert.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rabbitmq-ca-cert
-  namespace: plag
-  annotations:
-    reflector.v1.k8s.emberstack.com/reflects: 'rabbitmq/rabbitmq-server-certs'

--- a/infra/k8s/rabbitmq/base/tls-certificate.yaml
+++ b/infra/k8s/rabbitmq/base/tls-certificate.yaml
@@ -13,10 +13,6 @@ metadata:
   namespace: rabbitmq
 spec:
   secretName: rabbitmq-server-certs
-  secretTemplate:
-    annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: 'iris,plag,admin-api,client-api'
   issuerRef:
     name: rabbitmq-selfsigned-issuer
     kind: Issuer


### PR DESCRIPTION
### Description

RabbitMQ TLS 연결 방식을 모든 서비스에서 통일합니다.

기존 PR #3445에서 `iris/consumer`는 CA cert 파일을 직접 읽는 방식, 나머지(`iris/producer`, `plag/consumer`, `plag/producer`, backend)는 `InsecureSkipVerify`를 사용하는 방식으로 구현이 혼재되어 있었습니다. CA cert 파일을 읽는 방식은 cert-manager 인증서 발급 → reflector 복제 완료 전에 Pod가 뜨면 파일을 찾지 못해 crash가 발생하는 race condition이 있었고, 이로 인해 release 브랜치 머지 시 서비스 장애가 발생했습니다.

클러스터 내부 통신에서는 CA cert 검증의 실질적인 보안 이득이 크지 않으므로, 전 서비스를 `InsecureSkipVerify` 방식으로 통일합니다. TLS 암호화는 그대로 유지되며, `rabbitmq-ca-cert` Secret 및 reflector 의존성이 제거됩니다.

**변경 사항**
- `iris/consumer`: CA cert 파일 읽기 → `InsecureSkipVerify`
- `iris/producer`, `plag/consumer`, `plag/producer`: 무조건 적용 → `RABBITMQ_SSL=true` 조건부 적용
- `amqp.module.ts`: `readFileSync(ca.crt)` → `rejectUnauthorized: false`
- 각 서비스 deployment에서 `rabbitmq-ca-cert` volume mount 제거
- `rabbitmq-ca-cert.yaml` 및 kustomization 참조 제거

### Additional context

closes #3445 관련 장애 원인 수정

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
