### PR TITLE
chore(be): set profileImageUrl seed into username for recent users & add not null constraint

### DIFF
--- a/apps/backend/prisma/migrations/20260528070352_add_not_null_constraint_to_profile_image_url_field/migration.sql
+++ b/apps/backend/prisma/migrations/20260528070352_add_not_null_constraint_to_profile_image_url_field/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - Made the column `profile_image_url` on table `user_profile` required. This step will fail if there are existing NULL values in that column.
+
+*/
+
+-- Set default profileImageUrl seed to username for users
+UPDATE "public"."user_profile"
+SET "profile_image_url" = 'https://api.dicebear.com/9.x/notionists/svg?seed=' || (
+  SELECT "username" FROM "public"."user" WHERE "user"."id" = "user_profile"."user_id"
+);
+
+-- Make profileImageUrl not null
+ALTER TABLE "public"."user_profile" ALTER COLUMN "profile_image_url" SET NOT NULL;
+
+
+

--- a/apps/backend/prisma/migrations/20260528070352_add_not_null_constraint_to_profile_image_url_field/migration.sql
+++ b/apps/backend/prisma/migrations/20260528070352_add_not_null_constraint_to_profile_image_url_field/migration.sql
@@ -12,8 +12,10 @@ SET "profile_image_url" = 'https://api.dicebear.com/9.x/notionists/svg?seed=' ||
 )
 WHERE "profile_image_url" IS NULL;
 
--- Make profileImageUrl not null
-ALTER TABLE "public"."user_profile" ALTER COLUMN "profile_image_url" SET NOT NULL;
+-- Make profileImageUrl not null & default ''
+ALTER TABLE "public"."user_profile"
+  ALTER COLUMN "profile_image_url" SET NOT NULL,
+  ALTER COLUMN "profile_image_url" SET DEFAULT '';
 
 
 

--- a/apps/backend/prisma/migrations/20260528070352_add_not_null_constraint_to_profile_image_url_field/migration.sql
+++ b/apps/backend/prisma/migrations/20260528070352_add_not_null_constraint_to_profile_image_url_field/migration.sql
@@ -9,7 +9,8 @@
 UPDATE "public"."user_profile"
 SET "profile_image_url" = 'https://api.dicebear.com/9.x/notionists/svg?seed=' || (
   SELECT "username" FROM "public"."user" WHERE "user"."id" = "user_profile"."user_id"
-);
+)
+WHERE "profile_image_url" IS NULL;
 
 -- Make profileImageUrl not null
 ALTER TABLE "public"."user_profile" ALTER COLUMN "profile_image_url" SET NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -120,7 +120,7 @@ model UserProfile {
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId          Int      @unique @map("user_id")
   realName        String   @map("real_name")
-  profileImageUrl String   @map("profile_image_url")
+  profileImageUrl String   @default("") @map("profile_image_url")
   createTime      DateTime @default(now()) @map("create_time")
   updateTime      DateTime @updatedAt @map("update_time")
 

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -120,7 +120,7 @@ model UserProfile {
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId          Int      @unique @map("user_id")
   realName        String   @map("real_name")
-  profileImageUrl String?  @map("profile_image_url")
+  profileImageUrl String   @map("profile_image_url")
   createTime      DateTime @default(now()) @map("create_time")
   updateTime      DateTime @updatedAt @map("update_time")
 

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -182,7 +182,7 @@ const createUsers = async () => {
     data: {
       userId: superAdminUser.id,
       realName: 'Yuljeon Kim',
-      profileImageUrl: 'dicebear:super.com'
+      profileImageUrl: 'https://api.dicebear.com/9.x/notionists/svg?seed=super'
     }
   })
 
@@ -190,7 +190,7 @@ const createUsers = async () => {
     data: {
       userId: adminUser.id,
       realName: 'Admin Kim',
-      profileImageUrl: 'dicebear:user02.com'
+      profileImageUrl: 'https://api.dicebear.com/9.x/notionists/svg?seed=admin'
     }
   })
 
@@ -199,7 +199,7 @@ const createUsers = async () => {
     data: {
       userId: users[0].id,
       realName: 'Myeongryun Lee',
-      profileImageUrl: 'dicebear:user01'
+      profileImageUrl: 'https://api.dicebear.com/9.x/notionists/svg?seed=user01'
     }
   })
 }


### PR DESCRIPTION
### Description

1. migration.sql 수정
- 기존 user들의 profileImageUrl 필드의 seed 값을 username으로 채워넣는 SQL 작성
`https://api.dicebear.com/9.x/notionists/svg?seed={username}`
- 이후 profileImageUrl 필드를 not null로 제약조건을 추가하는 SQL 작성

2. seed.ts
profileImageUrl 시드값을 채워넣는 일부 값을 실제 dicebear Url에 맞춰 수정