### PR TITLE
fix(infra): update devcontainer base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-trixie
 
 # Install sandbox
 RUN mkdir -p /app/sandbox/policy /app/sandbox/results /app/sandbox/logs/run /app/sandbox/logs/compile


### PR DESCRIPTION
### Description

Dev Container 베이스 이미지를 `22-bullseye`에서 `22-trixie`로 변경했습니다. Java feature 설치 시 발생하는 GLIBC 버전 호환 문제를 해결합니다.

### Additional context

검증: `npx -y @devcontainers/cli build --workspace-folder .` 성공

또한, 이슈 작성자 허영님이 검증해주셨습니다.

Closes #3592

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.