### PR TITLE
fix(infra): skip image compression for release prs

### DIFF
--- a/.github/workflows/compress-image.yml
+++ b/.github/workflows/compress-image.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   compress:
     # Only run on Pull Requests within the same repository, and not from forks.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref != 'release'
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

`release` 브랜치를 대상으로 하는 PR에서는 `Compress Images` 워크플로우가 실행되지 않도록 조건을 추가했습니다.

### Additional context

릴리즈 복구 PR에서 `calibre/image-actions`가 배너 이미지를 다시 압축하는 문제가 발생했습니다. 해당 문제를 

Merge conflict check:
- `git merge-tree --write-tree origin/main HEAD` passed
- `git merge-tree --write-tree origin/release HEAD` passed

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
