### PR TITLE
fix(infra): enable TSDB index pre-loading for loki

### DIFF
--- a/infra/k8s/monitoring/loki/values.yaml
+++ b/infra/k8s/monitoring/loki/values.yaml
@@ -39,6 +39,9 @@ loki:
       default_resource_attributes_as_index_labels:
         # these keys will be indexed
         ['service.name', 'service.version', 'service.environment']
+  storage_config:
+    tsdb_shipper:
+      query_ready_num_days: 90
 
 singleBinary:
   extraArgs:


### PR DESCRIPTION
## Summary
- Loki 3.6.5의 TSDB index shipper가 S3에서 인덱스 테이블을 사전 로드하지 않아, ingester 메모리 범위(3시간) 밖의 모든 과거 로그 쿼리가 불가능했던 문제 수정
- `query_ready_num_days: 90` 설정 추가 (retention_period 2160h = 90일과 일치)
- 시작 시 S3에서 90일치 인덱스 테이블을 다운로드하여 과거 데이터 쿼리 활성화

## Root Cause
- `query_ready_num_days: 0` (기본값)으로 인해 `ensureQueryReadiness()`가 S3 테이블 목록 조회 없이 즉시 반환
- SingleBinary 모드에서 온디맨드 인덱스 로딩 경로가 정상 동작하지 않아, 사전 로딩이 필수

### Additional context
- #3435 와 같은 수정사항이며, `release` 로 실수로 머지되었었습니다.
- Original commit: aef722ed1acd6a5d3471c0829b742e4b20c799db