### PR TITLE
fix(infra): keep production apps renderable during release lag

### DIFF
--- a/infra/k8s/argocd/applications/monitoring/grafana.yaml
+++ b/infra/k8s/argocd/applications/monitoring/grafana.yaml
@@ -30,6 +30,7 @@ spec:
           targetRevision: '10.5.13'
           helm:
             releaseName: grafana
+            ignoreMissingValueFiles: true
             valueFiles:
               - '$codedang/infra/k8s/monitoring/grafana/overlays/{{.env}}/values.yaml'
               - '$codedang/infra/k8s/monitoring/grafana/base/alerting/values.yaml'

--- a/infra/k8s/argocd/applications/redis.yaml
+++ b/infra/k8s/argocd/applications/redis.yaml
@@ -37,7 +37,7 @@ spec:
           targetRevision: '{{.branch}}'
           ref: codedang
         - repoURL: https://github.com/skkuding/codedang
-          targetRevision: '{{.branch}}'
+          targetRevision: main
           path: infra/k8s/redis/overlays/{{.env}}
       destination:
         namespace: redis


### PR DESCRIPTION
### Description

`main`의 ApplicationSet 변경이 `release`에 아직 없는 파일/경로를 참조해 production ArgoCD rendering이 실패할 수 있는 문제를 완화합니다.

변경 사항:

- Grafana Helm source에 `ignoreMissingValueFiles: true`를 추가해 alerting values가 `release`에 없을 때도 rendering이 계속되도록 합니다.
- Redis Helm values는 기존처럼 env별 branch(`production`은 `release`)에서 읽도록 유지합니다.
- Redis Kustomize overlay source만 임시로 `main`을 보도록 해 `release/infra/k8s/redis/overlays/production` 부재로 인한 production render failure를 막습니다.

### Additional context

#### Validation

- `git diff --check origin/main...HEAD` 통과
- `kubectl kustomize infra/k8s/redis/overlays/production` 통과
- `kubectl kustomize infra/k8s/monitoring/grafana/overlays/production` 통과
- `yq` YAML 파싱 통과

#### Risk

- Redis production overlay가 임시로 `main`에서 읽히므로 overlay-only 변경은 `release` 전에도 production에 반영될 수 있습니다.
- Helm values는 여전히 production에서 `release`를 사용합니다.

Closes #3608

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.