### PR TITLE
fix(infra): keep production apps renderable during release lag

### DIFF
--- a/infra/k8s/monitoring/grafana/base/alerting/values.yaml
+++ b/infra/k8s/monitoring/grafana/base/alerting/values.yaml
@@ -1,0 +1,2 @@
+# Compatibility placeholder for main-sourced ApplicationSet valueFiles.
+# Release does not enable Grafana alerting values yet.

--- a/infra/k8s/monitoring/grafana/overlays/production/alerting/values.yaml
+++ b/infra/k8s/monitoring/grafana/overlays/production/alerting/values.yaml
@@ -1,0 +1,2 @@
+# Compatibility placeholder for main-sourced ApplicationSet valueFiles.
+# Production alerting values are intentionally disabled on this release branch.

--- a/infra/k8s/redis/base/admin-credentials.yaml
+++ b/infra/k8s/redis/base/admin-credentials.yaml
@@ -1,0 +1,19 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: redis-credentials
+  namespace: redis
+spec:
+  # values are null on purpose, to be filled by kustomize patch
+  encryptedData:
+    password: null
+  template:
+    metadata:
+      creationTimestamp: null
+      name: redis-credentials
+      namespace: redis
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: 'client-api,admin-api'
+    type: Opaque

--- a/infra/k8s/redis/base/kustomization.yaml
+++ b/infra/k8s/redis/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: redis
+
+resources:
+  - admin-credentials.yaml
+
+commonAnnotations:
+  managed-by: kustomize

--- a/infra/k8s/redis/overlays/production/credentials.yaml
+++ b/infra/k8s/redis/overlays/production/credentials.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: redis-credentials
+  namespace: redis
+spec:
+  encryptedData:
+    password: AgC4TEHklsbfspbFTVssWGWkWeAHs5rpsMvTZKbmbpZge1WXsZcXsxD9kgXp1BCxrw/iVEU2cxWvhmmWK/mIqK4asg5DV9wk0WDGwuBTQ8z6pYQZPO8kDEnDCFmdzEK0hijS3r5kPIQYERqYl8Kk7vTAFqNYRrrlmlIg66w+ZgxNI69iFF3igAY7flOZC3LERzl4GrrCITSpVQbVKplyGjKHJyhvVn3NHDGlSSL3I37FPjFDLWW+q4dMhksP2MZDd+sYe0Ra2P8XaeNvWwKCMdnKeinUzYZ+2i+dO12mDwbi3AEkzr4VmH03KmFKNBbE/uG0hLC9TlXETogizIrrYo6BMbZ6rVe2txUVLTNT9reAoYc5Ip9KDAGu1ni9QoiocIOkZuek2AdFM3ZaK+s4vzEK7rTJSXqL6oS3Mzc8xum1w02rzKJvQ6EoGZImADo3FxxW8SYjiLNXnD2rDhjrrfKPHko2F4rAix5l2mqMG91fZITEzZHNyaLiupBal63Qn8kpEuRJTintCOVn+A8jyvk4kZlgL6vqm4byAinj6vXTs9rTmBlkPY2kgwxDE09XWWt8KuiaQK+Usg4vma0a18SImO5diKL7b4Rx7e6EXQ/oi1+yR7VJfV8fk89KTLCB8O6c5JUeS+Ant9uuBaluRczlqb6cJPzSH42VO3LVGJZNvwzqzCBk6sHsBrGsxYfE4DWrpulgMWlFTLGInux6/A21pgAXmsPdv1U07fpP7k9u0Vy1ttw=
+  template:
+    metadata:
+      name: redis-credentials
+      namespace: redis
+    type: Opaque

--- a/infra/k8s/redis/overlays/production/kustomization.yaml
+++ b/infra/k8s/redis/overlays/production/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: redis
+
+# Compatibility placeholder for main-sourced ApplicationSet overlay path.
+# Do not add Redis credentials here until Redis auth is intentionally released.
+resources: []

--- a/infra/k8s/redis/overlays/production/kustomization.yaml
+++ b/infra/k8s/redis/overlays/production/kustomization.yaml
@@ -2,6 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: redis
 
-# Compatibility placeholder for main-sourced ApplicationSet overlay path.
-# Do not add Redis credentials here until Redis auth is intentionally released.
-resources: []
+# Keep credentials available before Redis auth is intentionally released.
+# Redis auth remains disabled until infra/k8s/redis/values.yaml references this secret.
+resources:
+  - ../../base
+
+patches:
+  - path: credentials.yaml
+    target:
+      kind: SealedSecret
+      name: redis-credentials

--- a/infra/k8s/redis/values-production.yaml
+++ b/infra/k8s/redis/values-production.yaml
@@ -1,0 +1,2 @@
+# Compatibility placeholder for main-sourced ApplicationSet valueFiles.
+# Keep production Redis behavior identical to release until Redis auth is released.


### PR DESCRIPTION
### Description

`main`의 ApplicationSet 정의가 `release`에 아직 없는 production 파일/경로를 참조해 ArgoCD rendering이 실패할 수 있는 문제를 안전하게 완화합니다.

변경 사항:

- Grafana production alerting value file 경로를 `release`에 placeholder로 추가합니다.
- Redis production values file 경로를 `release`에 placeholder로 추가합니다.
- Redis production overlay 경로를 `release`에 빈 Kustomization으로 추가합니다.
- Redis `values.yaml`은 변경하지 않아 Redis auth/password 설정은 활성화하지 않습니다.
- Production Redis source를 `main`으로 돌리지 않고, release branch boundary를 유지합니다.

#### Validation

- `kubectl kustomize infra/k8s/redis/overlays/production` 통과
- `yq` YAML 파싱 통과
- Redis `values.yaml` 변경 없음 확인

#### Risk

- Placeholder 파일이므로 Grafana alerting과 Redis auth 자체를 배포하지 않습니다.
- 이후 Redis auth 또는 Grafana alerting을 실제로 release할 때는 placeholder를 실제 설정으로 교체해야 합니다.

Closes #3608

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.