### PR TITLE
fix(infra): add production redis credentials placeholder

### DIFF
--- a/infra/k8s/redis/overlays/production/kustomization.yaml
+++ b/infra/k8s/redis/overlays/production/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: redis
 
+# Keep credentials available before Redis auth is intentionally released.
+# Redis auth remains disabled until infra/k8s/redis/values.yaml references this secret.
 resources:
   - ../../base
 


### PR DESCRIPTION
Cherry-pick follow-up for #3611 targeting main.

Most of #3611 already exists on main, so conflict resolution reduced this PR to the Redis credential intent comments in the production overlay.

Validation:
- `kubectl kustomize infra/k8s/redis/overlays/production`