### PR TITLE
fix(infra): restore rabbitmq and app production config

### DIFF
--- a/infra/k8s/iris/overlays/production/configmap-patch.yaml
+++ b/infra/k8s/iris/overlays/production/configmap-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iris-env
+data:
+  APP_ENV: 'production'

--- a/infra/k8s/iris/overlays/production/kustomization.yaml
+++ b/infra/k8s/iris/overlays/production/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - database-credentials.yaml
 
 patches:
+  - path: configmap-patch.yaml
+    target:
+      kind: ConfigMap
+      name: iris-env
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/infra/k8s/plag/overlays/production/configmap-patch.yaml
+++ b/infra/k8s/plag/overlays/production/configmap-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plag-env
+data:
+  APP_ENV: 'production'

--- a/infra/k8s/plag/overlays/production/kustomization.yaml
+++ b/infra/k8s/plag/overlays/production/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
   - ../../base
   - aws-credentials.yaml
   - database-credentials.yaml
+
+patches:
+  - path: configmap-patch.yaml
+    target:
+      kind: ConfigMap
+      name: plag-env

--- a/infra/k8s/rabbitmq/base/rabbitmq-cluster.yaml
+++ b/infra/k8s/rabbitmq/base/rabbitmq-cluster.yaml
@@ -14,4 +14,3 @@ spec:
       management.ssl.port = 15671
       management.ssl.certfile = /etc/rabbitmq-tls/tls.crt
       management.ssl.keyfile = /etc/rabbitmq-tls/tls.key
-      management.ssl.cacertfile = /etc/rabbitmq-tls/ca.crt


### PR DESCRIPTION
### Description

프로덕션 릴리즈 중 발생한 RabbitMQ 및 앱 설정 문제를 수정합니다.

- RabbitMQ TLS secret에 없는 `ca.crt` 참조를 제거합니다.
- `iris`, `plag` production overlay에서 `APP_ENV: production`을 명시합니다.

### Additional context

검증:

- `kubectl kustomize infra/k8s/rabbitmq/overlays/production`
- `kubectl kustomize infra/k8s/iris/overlays/production`
- `kubectl kustomize infra/k8s/plag/overlays/production`
- `git diff --check origin/main...HEAD`

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
