### PR TITLE
fix(fe): modify course end month logic

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/CourseCard.tsx
@@ -9,47 +9,30 @@ interface CourseCardProps {
   index: number
 }
 
-const TERM_ORDER = {
-  spring: 0,
-  summer: 1,
-  fall: 2,
-  winter: 3
+// 각 학기가 '활성'으로 보이는 마지막 월 (그 다음 달부터 회색처리)
+// 봄: 6월까지 / 여름: 7월까지 / 가을: 12월까지 / 겨울: (다음해) 1월까지
+const SEASON_END = {
+  spring: { yearOffset: 0, lastMonth: 6 },
+  summer: { yearOffset: 0, lastMonth: 7 },
+  fall: { yearOffset: 0, lastMonth: 12 },
+  winter: { yearOffset: 1, lastMonth: 1 }
 } as const
 
-const getCourseRank = (semester: string) => {
+const isPastCourse = (semester: string) => {
   const [yearText, termText] = semester.trim().split(/\s+/)
   const year = Number(yearText)
-  const term = TERM_ORDER[termText.toLowerCase() as keyof typeof TERM_ORDER]
+  const end = SEASON_END[termText?.toLowerCase() as keyof typeof SEASON_END]
 
-  return year * 10 + term
-}
-
-const getCurrentRank = () => {
-  const now = new Date()
-  const currentYear = now.getFullYear()
-  const month = now.getMonth() + 1
-
-  let currentSeasonIdx = 0
-  let baseYear = currentYear
-
-  if (month >= 3 && month <= 5) {
-    currentSeasonIdx = 0
-  } else if (month >= 6 && month <= 8) {
-    currentSeasonIdx = 1
-  } else if (month >= 9 && month <= 11) {
-    currentSeasonIdx = 2
-  } else {
-    if (month <= 2) {
-      baseYear = baseYear - 1
-    }
-    currentSeasonIdx = 3
+  // 포맷이 예상과 다르면(연도 NaN, 알 수 없는 학기) 회색처리하지 않음
+  if (!end || Number.isNaN(year)) {
+    return false
   }
 
-  return baseYear * 10 + currentSeasonIdx
-}
+  const now = new Date()
+  const nowMarker = now.getFullYear() * 12 + (now.getMonth() + 1)
+  const endMarker = (year + end.yearOffset) * 12 + end.lastMonth
 
-const isPastCourse = (semester: string) => {
-  return getCourseRank(semester) < getCurrentRank()
+  return nowMarker > endMarker
 }
 
 export function CourseCard({ course }: CourseCardProps) {


### PR DESCRIPTION
### Description

<img width="2518" height="1014" alt="image" src="https://github.com/user-attachments/assets/efb4a8c6-bce4-425f-ba15-e3b746cfa3de" />


현재 Course 탭에서 강좌 회색처리를 위한 종료 시점 판단이 Spring/Summer/Fall/Winter 별로 4등분하고있습니다. Spring의 경우 5월 이후 종료처리가 되고 있어 각 학기별 종료 시점을 다음과 같이 임의로 설정했습니다.

Spring: 6월 / Summer: 7월 / Fall: 12월 / Winter: 1월

TODO : 강좌 종료일을 받아 강좌 별로 종료일에 맞춰 비활성화 처리하는 로직이 필요할 것 같습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
