### PR TITLE
fix(fe): track latest plag request with id

### DIFF
--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
@@ -66,11 +66,16 @@ export function PlagiarismCheckRequestButton({
   const [enableMerging, setEnableMerging] = useState(false)
   const [useJplagClustering, setUseJplagClustering] = useState(true)
   const [isPolling, setIsPolling] = useState(false)
+  // id of the check request created by this re-request. While polling, only this
+  // request's status is tracked, so a previously Completed request can't end
+  // polling immediately (race condition guard).
+  const [currentCheckId, setCurrentCheckId] = useState<string | null>(null)
   const pollingStartedAt = useRef<number | null>(null)
 
   const [checkAssignmentSubmissions, { loading: mutationLoading }] =
     useMutation(CHECK_ASSIGNMENT_SUBMISSIONS, {
-      onCompleted: () => {
+      onCompleted: (data) => {
+        setCurrentCheckId(data?.checkAssignmentSubmissions?.id ?? null)
         setIsPolling(true)
       },
       onError: (error) => {
@@ -110,8 +115,13 @@ export function PlagiarismCheckRequestButton({
   })
 
   const checkRequests = checkRequestsData?.getCheckRequests ?? []
-  const latestRequest = checkRequests[0]
-  const latestStatus = latestRequest?.result as CheckResultStatus | undefined
+  // Track only the request created by this re-request, by id. Until it appears in
+  // the polled list, trackedStatus stays undefined so polling keeps running
+  // instead of reading a previously Completed request.
+  const trackedRequest = currentCheckId
+    ? checkRequests.find((req) => req.id === currentCheckId)
+    : undefined
+  const trackedStatus = trackedRequest?.result as CheckResultStatus | undefined
   const hasExistingResults = checkRequests.length > 0
 
   const { data: submissionCountsData, loading: submissionCountsLoading } =
@@ -182,6 +192,7 @@ export function PlagiarismCheckRequestButton({
         : 0
       if (elapsed > MAX_POLL_ATTEMPTS * POLL_INTERVAL_MS) {
         setIsPolling(false)
+        setCurrentCheckId(null)
         pollingStartedAt.current = null
         toast.error(
           'Plagiarism check timed out. Please check the result later.'
@@ -193,25 +204,27 @@ export function PlagiarismCheckRequestButton({
   }, [isPolling])
 
   useEffect(() => {
-    if (!isPolling || !latestStatus) {
+    if (!isPolling || !trackedStatus) {
       return
     }
-    if (latestStatus === 'Completed') {
+    if (trackedStatus === 'Completed') {
       setIsPolling(false)
+      setCurrentCheckId(null)
       pollingStartedAt.current = null
       toast.success('Plagiarism check completed.')
       onRequestComplete()
       setOpen(false)
     } else if (
-      latestStatus === 'JplagError' ||
-      latestStatus === 'TokenError' ||
-      latestStatus === 'ServerError'
+      trackedStatus === 'JplagError' ||
+      trackedStatus === 'TokenError' ||
+      trackedStatus === 'ServerError'
     ) {
       setIsPolling(false)
+      setCurrentCheckId(null)
       pollingStartedAt.current = null
-      toast.error(`Plagiarism check failed: ${latestStatus}`)
+      toast.error(`Plagiarism check failed: ${trackedStatus}`)
     }
-  }, [isPolling, latestStatus, onRequestComplete])
+  }, [isPolling, trackedStatus, onRequestComplete])
 
   const handleSubmit = useCallback(() => {
     checkAssignmentSubmissions({
@@ -229,6 +242,7 @@ export function PlagiarismCheckRequestButton({
     })
   }, [
     assignmentId,
+    courseId,
     problemId,
     language,
     minTokens,

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
@@ -66,9 +66,6 @@ export function PlagiarismCheckRequestButton({
   const [enableMerging, setEnableMerging] = useState(false)
   const [useJplagClustering, setUseJplagClustering] = useState(true)
   const [isPolling, setIsPolling] = useState(false)
-  // id of the check request created by this re-request. While polling, only this
-  // request's status is tracked, so a previously Completed request can't end
-  // polling immediately (race condition guard).
   const [currentCheckId, setCurrentCheckId] = useState<number | null>(null)
   const pollingStartedAt = useRef<number | null>(null)
 
@@ -118,9 +115,6 @@ export function PlagiarismCheckRequestButton({
   })
 
   const checkRequests = checkRequestsData?.getCheckRequests ?? []
-  // Track only the request created by this re-request, by id. Until it appears in
-  // the polled list, trackedStatus stays undefined so polling keeps running
-  // instead of reading a previously Completed request.
   const trackedRequest = currentCheckId
     ? checkRequests.find((req) => Number(req.id) === currentCheckId)
     : undefined

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
@@ -75,7 +75,10 @@ export function PlagiarismCheckRequestButton({
   const [checkAssignmentSubmissions, { loading: mutationLoading }] =
     useMutation(CHECK_ASSIGNMENT_SUBMISSIONS, {
       onCompleted: (data) => {
-        setCurrentCheckId(data?.checkAssignmentSubmissions?.id ?? null)
+        const newId = data?.checkAssignmentSubmissions?.id
+        setCurrentCheckId(
+          newId !== null && newId !== undefined ? Number(newId) : null
+        )
         setIsPolling(true)
       },
       onError: (error) => {
@@ -119,7 +122,7 @@ export function PlagiarismCheckRequestButton({
   // the polled list, trackedStatus stays undefined so polling keeps running
   // instead of reading a previously Completed request.
   const trackedRequest = currentCheckId
-    ? checkRequests.find((req) => req.id === currentCheckId)
+    ? checkRequests.find((req) => Number(req.id) === currentCheckId)
     : undefined
   const trackedStatus = trackedRequest?.result as CheckResultStatus | undefined
   const hasExistingResults = checkRequests.length > 0

--- a/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/assignment/[assignmentId]/(overall)/@tabs/plagiarism/_components/PlagiarismCheckRequestButton.tsx
@@ -69,7 +69,7 @@ export function PlagiarismCheckRequestButton({
   // id of the check request created by this re-request. While polling, only this
   // request's status is tracked, so a previously Completed request can't end
   // polling immediately (race condition guard).
-  const [currentCheckId, setCurrentCheckId] = useState<string | null>(null)
+  const [currentCheckId, setCurrentCheckId] = useState<number | null>(null)
   const pollingStartedAt = useRef<number | null>(null)
 
   const [checkAssignmentSubmissions, { loading: mutationLoading }] =


### PR DESCRIPTION
### Description

#3617 에서 새로 생성된 요청이 폴링 쿼리에 반영되기 전, 최신 요청이 completed인 경우 요청 성공 여부에 관계없이 완료 메세지가 나오게 되므로, 생성 요청을 id 기반으로 추적하도록 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
