### PR TITLE
fix(be): remove transaction in getProblemTestcases

### DIFF
--- a/apps/backend/apps/admin/src/problem/services/testcase.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/testcase.service.ts
@@ -897,43 +897,48 @@ export class TestcaseService {
       throw new EntityNotExistException('Problem')
     }
 
-    const hiddenTestcases = await this.prisma.problemTestcase.findMany({
-      where: {
-        problemId,
-        isOutdated: false,
-        isHidden: true
-      },
-      select: {
-        id: true,
-        order: true,
-        isHidden: true,
-        scoreWeightDenominator: true,
-        scoreWeightNumerator: true,
-        ...(problem.isHiddenUploadedByZip ? {} : { input: true, output: true })
-      },
-      orderBy: {
-        order: 'asc'
-      }
-    })
-
-    const sampleTestcases = await this.prisma.problemTestcase.findMany({
-      where: {
-        problemId,
-        isOutdated: false,
-        isHidden: false
-      },
-      select: {
-        id: true,
-        order: true,
-        isHidden: true,
-        scoreWeightDenominator: true,
-        scoreWeightNumerator: true,
-        ...(problem.isSampleUploadedByZip ? {} : { input: true, output: true })
-      },
-      orderBy: {
-        order: 'asc'
-      }
-    })
+    const [hiddenTestcases, sampleTestcases] = await Promise.all([
+      this.prisma.problemTestcase.findMany({
+        where: {
+          problemId,
+          isOutdated: false,
+          isHidden: true
+        },
+        select: {
+          id: true,
+          order: true,
+          isHidden: true,
+          scoreWeightDenominator: true,
+          scoreWeightNumerator: true,
+          ...(problem.isHiddenUploadedByZip
+            ? {}
+            : { input: true, output: true })
+        },
+        orderBy: {
+          order: 'asc'
+        }
+      }),
+      this.prisma.problemTestcase.findMany({
+        where: {
+          problemId,
+          isOutdated: false,
+          isHidden: false
+        },
+        select: {
+          id: true,
+          order: true,
+          isHidden: true,
+          scoreWeightDenominator: true,
+          scoreWeightNumerator: true,
+          ...(problem.isSampleUploadedByZip
+            ? {}
+            : { input: true, output: true })
+        },
+        orderBy: {
+          order: 'asc'
+        }
+      })
+    ])
 
     return sampleTestcases.concat(hiddenTestcases)
   }

--- a/apps/backend/apps/admin/src/problem/services/testcase.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/testcase.service.ts
@@ -889,58 +889,52 @@ export class TestcaseService {
    * @returns 조건에 부합하는 테스트케이스들의 배열
    */
   async getProblemTestcases(problemId: number) {
-    return await this.prisma.$transaction(async (tx) => {
-      const problem = await tx.problem.findUnique({
-        where: { id: problemId },
-        select: { isHiddenUploadedByZip: true, isSampleUploadedByZip: true }
-      })
-      if (!problem) {
-        throw new EntityNotExistException('Problem')
-      }
-
-      const hiddenTestcases = await tx.problemTestcase.findMany({
-        where: {
-          problemId,
-          isOutdated: false,
-          isHidden: true
-        },
-        select: {
-          id: true,
-          order: true,
-          isHidden: true,
-          scoreWeightDenominator: true,
-          scoreWeightNumerator: true,
-          ...(problem.isHiddenUploadedByZip
-            ? {}
-            : { input: true, output: true })
-        },
-        orderBy: {
-          order: 'asc'
-        }
-      })
-
-      const sampleTestcases = await tx.problemTestcase.findMany({
-        where: {
-          problemId,
-          isOutdated: false,
-          isHidden: false
-        },
-        select: {
-          id: true,
-          order: true,
-          isHidden: true,
-          scoreWeightDenominator: true,
-          scoreWeightNumerator: true,
-          ...(problem.isSampleUploadedByZip
-            ? {}
-            : { input: true, output: true })
-        },
-        orderBy: {
-          order: 'asc'
-        }
-      })
-
-      return sampleTestcases.concat(hiddenTestcases)
+    const problem = await this.prisma.problem.findUnique({
+      where: { id: problemId },
+      select: { isHiddenUploadedByZip: true, isSampleUploadedByZip: true }
     })
+    if (!problem) {
+      throw new EntityNotExistException('Problem')
+    }
+
+    const hiddenTestcases = await this.prisma.problemTestcase.findMany({
+      where: {
+        problemId,
+        isOutdated: false,
+        isHidden: true
+      },
+      select: {
+        id: true,
+        order: true,
+        isHidden: true,
+        scoreWeightDenominator: true,
+        scoreWeightNumerator: true,
+        ...(problem.isHiddenUploadedByZip ? {} : { input: true, output: true })
+      },
+      orderBy: {
+        order: 'asc'
+      }
+    })
+
+    const sampleTestcases = await this.prisma.problemTestcase.findMany({
+      where: {
+        problemId,
+        isOutdated: false,
+        isHidden: false
+      },
+      select: {
+        id: true,
+        order: true,
+        isHidden: true,
+        scoreWeightDenominator: true,
+        scoreWeightNumerator: true,
+        ...(problem.isSampleUploadedByZip ? {} : { input: true, output: true })
+      },
+      orderBy: {
+        order: 'asc'
+      }
+    })
+
+    return sampleTestcases.concat(hiddenTestcases)
   }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

현재 FE에서 `GET_PROBLEM_TESTCASE_WITHOUT_IO` 쿼리를 사용해 admin-api의 `getProblemTestcases` 함수를 호출합니다.

`getProblemTestcases` 는 `problemId` 를 인자로 받아 문제와 문제의 테스트케이스(Input/Output 포함)를 return 하는데, 다음과 같은 쿼리를 순서대로 실행합니다.

1. 문제 정보 조회
2. 히든 테스트 케이스 조회
3. 샘플 테스트 케이스 조회

위 3개의 쿼리가 현재 Prisma의 Transaction으로 묶여 있는데, 특정 문제의 경우 테스트 케이스의 IO 사이즈가 너무 커서 DB에서 데이터를 가져오는 중 Timeout이 발생합니다. (Prisma Transaction의 경우 기본 Timeout 제한이 5초로 설정되어 있음)

해당 문제의 해결 방안으로는 다음이 있을 것 같습니다.

1. `Transaction` 제거
    
    위 3개의 쿼리가 모두 조회 쿼리라 `Transaction` 을 제거해도 크게 문제는 없을 것 같습니다. `Transaction` 을 제거하면 5초 제한에는 걸리지 않으나, 결국 문제의 테스트 케이스들을 모두 가져와야 하는 것은 동일해서 소요 시간이 오래 걸리는 문제는 여전히 존재합니다.
    
    → 몇몇 동시성 문제가 발생할 수는 있으나, 이는 사실 Transaction을 사용해도 동일하게 발생하는 문제입니다. (ex. 1번 쿼리와 2번 쿼리 사이에 `isHiddenUploadedByZip` 필드의 값이 갑자기 변하는 경우)
    
2. 테스트 케이스 조회 함수 분리
    
    문제 + 테스트 케이스를 함께 조회할 때, IO 포함 유무를 반영한 별도의 함수를 만들어서 나누어도 될 것 같습니다. (예시: 처음부터 IO를 DB에서 조회하지 않는 함수 별도 생성) 하지만 이 방법도 결국에는 IO를 포함해서 반환하는 함수를 호출할 경우 시간이 오래 걸린다는 문제가 있습니다.
    
3. Transaction 타임 아웃 증가
    
    같은 이유로 그닥 효율적인 방안은 아닌 것 같습니다.
    

일단 해당 PR에서는 `Transaction`을 제거해서 Timeout이 발생하지 않는 방향으로 해결하였습니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

<img width="1632" height="1672" alt="image" src="https://github.com/user-attachments/assets/3a8b2e15-6635-4103-86b2-33b84423e564" />

DB 쿼리 **1회**만으로 **5초 이상** 소요

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
