### PR TITLE
fix(fe): add padding

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/ServiceCards.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/ServiceCards.tsx
@@ -65,7 +65,7 @@ export function ServiceCards() {
     <section className="font-pretendard flex w-full flex-col items-center px-5 md:px-0">
       <div className="flex w-full max-w-[1440px] flex-col gap-7 md:gap-6">
         <div className="flex w-full flex-col gap-4 pb-5 pt-7 md:flex-row md:items-end md:justify-between">
-          <p className="text-head4_sb_20 md:text-head1_b_40">
+          <p className="text-head1_b_40 md:text-head1_b_40">
             코드당에는 어떤 기능이 있나요?
           </p>
 

--- a/apps/frontend/app/(client)/(main)/_components/ServiceCards.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/ServiceCards.tsx
@@ -64,8 +64,8 @@ export function ServiceCards() {
   return (
     <section className="font-pretendard flex w-full flex-col items-center px-5 md:px-0">
       <div className="flex w-full max-w-[1440px] flex-col gap-7 md:gap-6">
-        <div className="flex w-full flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <p className="text-title2_m_20 md:text-head1_b_40">
+        <div className="flex w-full flex-col gap-4 pb-5 pt-7 md:flex-row md:items-end md:justify-between">
+          <p className="text-head4_sb_20 md:text-head1_b_40">
             코드당에는 어떤 기능이 있나요?
           </p>
 


### PR DESCRIPTION

메인 페이지에서 모바일화면으로 넘어갈 때 '코드당에는 어떤 기능이 있나요?' 워딩의 디자인이 바뀌지 않게 고쳤고, 위아래 패딩을 넣었다.

<img width="514" height="883" alt="스크린샷 2026-06-29 오후 7 02 14" src="https://github.com/user-attachments/assets/ff720879-6799-4628-b8a3-13a28751de8d" />

closes TAS-2758