### PR TITLE
fix: show middle banner button on mobile

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
@@ -12,7 +12,6 @@ export function MiddleBanner() {
             '학습 목적에 맞게 문제를 설계하고 협업자를 초대하여 피드백을 받아\n효과적인 코딩 문제를 구성해보세요.'
           }
         </p>
-        {/* TODO: problem/create 페이지 작업 완료 시 아래 버튼으로 복구 */}
         <Button
           disabled
           className="bg-color-common-100 hover:bg-color-neutral-99 flex h-10 w-fit rounded-full px-4 py-1 md:hidden"

--- a/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@/components/shadcn/button'
-import Link from 'next/link'
 
 export function MiddleBanner() {
   return (
@@ -18,17 +17,15 @@ export function MiddleBanner() {
           disabled
           className="bg-color-common-100 hover:bg-color-neutral-99 flex h-10 w-fit rounded-full px-4 py-1 md:hidden"
         >
-          <Link href="/problem/create">
-            <span className="text-sub4_sb_14 text-color-neutral-40">
-              문제 생성 바로가기
-            </span>
-          </Link>
+          <span className="text-sub4_sb_14 text-color-neutral-40">
+            문제 생성 바로가기
+          </span>
         </Button>
         <Button
           disabled
-          className="bg-color-common-100 hover:bg-color-neutral-99 hidden h-12 w-fit rounded-full px-6 py-3 md:flex"
+          className="bg-color-common-100 hover:bg-color-neutral-99 flex h-10 w-fit rounded-full px-4 py-1 md:hidden"
         >
-          <span className="text-sub3_sb_16 text-color-neutral-40">
+          <span className="text-sub4_sb_14 text-color-neutral-40">
             문제 생성 바로가기
           </span>
         </Button>

--- a/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/components/shadcn/button'
-
-// import Link from 'next/link'
+import Link from 'next/link'
 
 export function MiddleBanner() {
   return (
@@ -15,17 +14,16 @@ export function MiddleBanner() {
           }
         </p>
         {/* TODO: problem/create 페이지 작업 완료 시 아래 버튼으로 복구 */}
-        {/* <Button
+        <Button
           disabled
-          asChild
-          className="bg-color-common-100 hover:bg-color-neutral-99 hidden h-12 w-fit rounded-full px-6 py-3 md:flex"
+          className="bg-color-common-100 hover:bg-color-neutral-99 flex h-10 w-fit rounded-full px-4 py-1 md:hidden"
         >
           <Link href="/problem/create">
-            <span className="text-sub3_sb_16 text-color-common-0">
+            <span className="text-sub4_sb_14 text-color-neutral-40">
               문제 생성 바로가기
             </span>
           </Link>
-        </Button> */}
+        </Button>
         <Button
           disabled
           className="bg-color-common-100 hover:bg-color-neutral-99 hidden h-12 w-fit rounded-full px-6 py-3 md:flex"


### PR DESCRIPTION
1. 메인 페이지 중간 배너의 ‘문제 생성 바로가기’ 버튼을 모바일 화면에 추가했습니다.
2. 모바일 화면에서만 버튼이 표시되도록 반응형 스타일을 적용했습니다.
3. 모바일 환경에 맞게 버튼 크기와 글자 크기를 조정했습니다.
## 반영된 사진
<img width="567" height="810" alt="스크린샷 2026-06-29 오후 7 01 35" src="https://github.com/user-attachments/assets/b2ea9965-e9bc-4e5e-994d-ba92a7410069" />

closes TAS-2756