### PR TITLE
fix(fe): adjust responsive design

### DIFF
--- a/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/MiddleBanner.tsx
@@ -22,7 +22,7 @@ export function MiddleBanner() {
         </Button>
         <Button
           disabled
-          className="bg-color-common-100 hover:bg-color-neutral-99 flex h-10 w-fit rounded-full px-4 py-1 md:hidden"
+          className="bg-color-common-100 hover:bg-color-neutral-99 hidden h-10 w-fit rounded-full px-6 py-3 md:flex"
         >
           <span className="text-sub4_sb_14 text-color-neutral-40">
             문제 생성 바로가기

--- a/apps/frontend/app/(client)/(main)/_components/ServiceCards.tsx
+++ b/apps/frontend/app/(client)/(main)/_components/ServiceCards.tsx
@@ -64,8 +64,8 @@ export function ServiceCards() {
   return (
     <section className="font-pretendard flex w-full flex-col items-center px-5 md:px-0">
       <div className="flex w-full max-w-[1440px] flex-col gap-7 md:gap-6">
-        <div className="flex w-full flex-col gap-4 pb-5 pt-7 md:flex-row md:items-end md:justify-between">
-          <p className="text-head1_b_40 md:text-head1_b_40">
+        <div className="flex w-full flex-col gap-4 pb-5 pt-7 md:flex-row md:items-end md:justify-between md:pt-0">
+          <p className="text-head6_m_24 md:text-head1_b_40">
             코드당에는 어떤 기능이 있나요?
           </p>
 


### PR DESCRIPTION
### Description

problem card의 버튼과 padding을 메인 배너-텍스트 간 간격을 조정합니다!
@새연님 @재혁님 작업해주신 부분은 모바일 뷰에 그대로 유지했습니다~

<img width="613" height="288" alt="image" src="https://github.com/user-attachments/assets/5aa2bbdd-a42f-4bd6-8c15-c7feff4f0748" />


<img width="669" height="300" alt="image" src="https://github.com/user-attachments/assets/e0cda397-d2c7-4720-91ca-fbb0119e88bd" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2760