### PR TITLE
fix(fe): prevent contest delete modal from opening without selection

### DIFF
--- a/apps/frontend/app/admin/_components/table/DataTableDeleteButton.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableDeleteButton.tsx
@@ -92,33 +92,33 @@ export function DataTableDeleteButton<TData extends { id: number }, TPromise>({
   }
 
   return (
-    <AlertModal
-      trigger={
-        <Button
-          variant="outline"
-          type="button"
-          onClick={handleDeleteButtonClick}
-          className={className}
-        >
-          <FaTrash fontSize={13} color={'#8A8A8A'} />
-        </Button>
-      }
-      open={isDialogOpen}
-      onOpenChange={setIsDialogOpen}
-      type={'warning'}
-      showIcon={!deleteItems}
-      title={`Delete ${target}?`}
-      primaryButton={{
-        text: 'Delete',
-        onClick: handleDeleteRows
-      }}
-      {...(deleteItems
-        ? {}
-        : {
-            description: `Are you sure you want to permanently delete ${table.getSelectedRowModel().rows.length} ${target}(s)?`
-          })}
-    >
-      {deleteItems && <ModalList items={deleteItems} />}
-    </AlertModal>
+    <>
+      <Button
+        variant="outline"
+        type="button"
+        onClick={handleDeleteButtonClick}
+        className={className}
+      >
+        <FaTrash fontSize={13} color={'#8A8A8A'} />
+      </Button>
+      <AlertModal
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        type={'warning'}
+        showIcon={!deleteItems}
+        title={`Delete ${target}?`}
+        primaryButton={{
+          text: 'Delete',
+          onClick: handleDeleteRows
+        }}
+        {...(deleteItems
+          ? {}
+          : {
+              description: `Are you sure you want to permanently delete ${table.getSelectedRowModel().rows.length} ${target}(s)?`
+            })}
+      >
+        {deleteItems && <ModalList items={deleteItems} />}
+      </AlertModal>
+    </>
   )
 }


### PR DESCRIPTION
### Description
어드민 페이지의 데이터 테이블에서, 선택된 항목이 없을 때 휴지통 버튼을 누르면 에러 토스트( Please select at least one... )와 함께 삭제 경고 모달 창이 동시에 강제로 열려버리는 버그를 수정했습니다.
  
### Additional context
https://github.com/skkuding/codedang/pull/3639 와 동일한 task -> PR close

Closes TAS-2759