### PR TITLE
fix(infra): add kakao callback env (stage, prod)

### DIFF
--- a/infra/k8s/client-api/overlays/production/configmap.yaml
+++ b/infra/k8s/client-api/overlays/production/configmap.yaml
@@ -5,3 +5,5 @@ metadata:
   namespace: client-api
 data:
   KAKAO_CALLBACK_URL: 'https://codedang.com/api/auth/kakao-callback'
+  KAKAO_LINK_CALLBACK_URL: 'https://codedang.com/api/auth/kakao-link-callback'
+  FRONTEND_URL: 'https://codedang.com'

--- a/infra/k8s/client-api/overlays/stage/configmap.yaml
+++ b/infra/k8s/client-api/overlays/stage/configmap.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   MINIO_ENDPOINT_URL: 'https://minio.stage.codedang.com'
   KAKAO_CALLBACK_URL: 'https://stage.codedang.com/api/auth/kakao-callback'
+  KAKAO_LINK_CALLBACK_URL: 'https://stage.codedang.com/api/auth/kakao-link-callback'
+  FRONTEND_URL: 'https://stage.codedang.com'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

카카오 소셜 로그인 콜백 redirect 구현에 필요한 환경변수 2개를 stage/production의 `ConfigMap`에 추가합니다.

- `FRONTEND_URL`: 카카오 OAuth 콜백 처리 후 프론트엔드로 redirect 시 사용
- `KAKAO_LINK_CALLBACK_URL`: 소셜 계정 연동 전용 카카오 OAuth callback URL

https://github.com/skkuding/codedang/pull/3627
현재 화이트리스트 및 카카오 로그인 구현을 위한 위 PR에서 해당 env가 사용될 예정입니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
