### PR TITLE
fix(infra): improve rabbitmq metrics alerting

### DIFF
--- a/infra/k8s/monitoring/grafana/base/alerting/values.yaml
+++ b/infra/k8s/monitoring/grafana/base/alerting/values.yaml
@@ -9,6 +9,11 @@ alerting:
             type: discord
             settings:
               url: $__env{DISCORD_WEBHOOK_URL}
+              # title/message are Go templates evaluated by Grafana at notification
+              # time. The outer {{ `...` }} escapes the inner Go-template actions so
+              # the Helm chart's `tpl` pass leaves them intact for Grafana to compile.
+              title: '{{ `{{ template "discord.title" . }}` }}'
+              message: '{{ `{{ template "discord.message" . }}` }}'
 
   notification-policies.yaml:
     apiVersion: 1
@@ -20,11 +25,55 @@ alerting:
         group_interval: 5m
         repeat_interval: 24h
         routes:
+          # Noisy monitoring-system states (no data / eval error) repeat at most weekly.
+          # These synthetic alerts replace the original alertname, so match on alertname.
           - receiver: discord
             matchers:
-              - severity = critical
-            repeat_interval: 1h
+              - alertname = DatasourceNoData
+            repeat_interval: 7d
+          - receiver: discord
+            matchers:
+              - alertname = DatasourceError
+            repeat_interval: 7d
           - receiver: discord
             matchers:
               - grafana_state_reason = Error
             repeat_interval: 7d
+          # RabbitMQ queue alerts: split by queue for queue-level visibility
+          - receiver: discord
+            matchers:
+              - service = rabbitmq
+            group_by: ['grafana_folder', 'alertname', 'queue']
+          - receiver: discord
+            matchers:
+              - severity = critical
+            repeat_interval: 1h
+
+  templates.yaml:
+    apiVersion: 1
+    templates:
+      - orgID: 1
+        name: discord.title
+        template: |
+          {{ `{{ define "discord.title" }}` }}[{{ `{{ .Status }}` }}] {{ `{{ or .CommonLabels.alertname "Grafana alert" }}` }}{{ `{{ end }}` }}
+      - orgID: 1
+        name: discord.message
+        template: |
+          {{ `{{ define "discord.message" }}` }}
+          Severity: {{ `{{ or .CommonLabels.severity "unknown" }}` }}
+          Service: {{ `{{ or .CommonLabels.service "unknown" }}` }}
+          Environment: {{ `{{ or .CommonLabels.environment "unknown" }}` }}
+
+          {{ `{{ range .Alerts }}` }}
+          {{ `{{ if eq .Labels.alertname "DatasourceNoData" }}` }}
+          Summary: Grafana no-data state for {{ `{{ or .Labels.rulename .Labels.alertname "unknown rule" }}` }}
+          Description: Grafana did not receive data from datasource {{ `{{ or .Labels.datasource_uid "unknown" }}` }} for query {{ `{{ or .Labels.ref_id "unknown" }}` }}. This may be a stale no-data resolution or a missing scrape target; check the dedicated scrape-health alert for the service.
+          {{ `{{ else if eq .Labels.alertname "DatasourceError" }}` }}
+          Summary: Grafana datasource error for {{ `{{ or .Labels.rulename .Labels.alertname "unknown rule" }}` }}
+          Description: Grafana could not evaluate query {{ `{{ or .Labels.ref_id "unknown" }}` }} from datasource {{ `{{ or .Labels.datasource_uid "unknown" }}` }}. Check datasource connectivity and query health.
+          {{ `{{ else }}` }}
+          Summary: {{ `{{ or .Annotations.summary .Labels.alertname "Grafana alert" }}` }}
+          Description: {{ `{{ or .Annotations.description "No description provided." }}` }}
+          {{ `{{ end }}` }}
+          {{ `{{ end }}` }}
+          {{ `{{ end }}` }}

--- a/infra/k8s/monitoring/grafana/overlays/production/alerting/values.yaml
+++ b/infra/k8s/monitoring/grafana/overlays/production/alerting/values.yaml
@@ -50,6 +50,7 @@ alerting:
             for: 5m
             labels:
               severity: warning
+              environment: production
             annotations:
               summary: 'RDS 남은 디스크 < 2GB'
               description: |
@@ -99,6 +100,7 @@ alerting:
             for: 10m
             labels:
               severity: warning
+              environment: production
             annotations:
               summary: 'RDS DB 커넥션 > 150'
               description: |
@@ -148,6 +150,7 @@ alerting:
             for: 5m
             labels:
               severity: warning
+              environment: production
             annotations:
               summary: '노드 {{ `{{ $labels.instance }}` }} 메모리 사용률 높음'
               description: |
@@ -193,6 +196,7 @@ alerting:
             for: 5m
             labels:
               severity: warning
+              environment: production
             annotations:
               summary: '노드 {{ `{{ $labels.instance }}` }} 디스크 사용률 높음'
               description: |
@@ -238,6 +242,7 @@ alerting:
             for: 2m
             labels:
               severity: critical
+              environment: production
             annotations:
               summary: '노드 {{ `{{ $labels.node }}` }} Ready 상태 아님'
               description: |
@@ -289,8 +294,12 @@ alerting:
                           - 100
                         type: gt
             for: 5m
+            noDataState: OK
+            execErrState: Error
             labels:
               severity: warning
+              service: rabbitmq
+              environment: production
             annotations:
               summary: '큐 {{ `{{ $labels.queue }}` }} Ready 메시지 적체'
               description: |
@@ -298,6 +307,55 @@ alerting:
                 Ready 메시지: {{ `{{ $values.B.Value }}` }}개 (임계 100, 5분 지속)
                 의미: Consumer가 메시지 처리를 못 따라가고 있음
                 조치: Iris/Plag pod 상태 및 로그 확인
+
+          - uid: rabbitmq-metrics-scrape-down
+            title: RabbitMQ metrics scrape down
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: up{job="rabbitmq"}
+                  intervalMs: 60000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+              - refId: C
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 1
+                        type: lt
+            for: 5m
+            noDataState: Alerting
+            execErrState: Error
+            labels:
+              severity: warning
+              service: rabbitmq
+              environment: production
+            annotations:
+              summary: RabbitMQ metrics scrape down
+              description: |
+                Prometheus cannot scrape RabbitMQ metrics.
+                Expected target: rabbitmq prometheus-tls endpoint.
+                Check ServiceMonitor port, RabbitMQ endpoint, TLS config, and pod health.
 
           - uid: rabbitmq-unacked-messages-high
             title: RabbitMQ 미확인 메시지 적체
@@ -335,8 +393,12 @@ alerting:
                           - 50
                         type: gt
             for: 5m
+            noDataState: OK
+            execErrState: Error
             labels:
               severity: warning
+              service: rabbitmq
+              environment: production
             annotations:
               summary: '큐 {{ `{{ $labels.queue }}` }} 미확인 메시지 적체'
               description: |

--- a/infra/k8s/monitoring/grafana/overlays/stage/alerting/values.yaml
+++ b/infra/k8s/monitoring/grafana/overlays/stage/alerting/values.yaml
@@ -46,6 +46,7 @@ alerting:
             for: 5m
             labels:
               severity: warning
+              environment: stage
             annotations:
               summary: '노드 {{ `{{ $labels.instance }}` }} 메모리 사용률 높음'
               description: |
@@ -91,6 +92,7 @@ alerting:
             for: 5m
             labels:
               severity: warning
+              environment: stage
             annotations:
               summary: '노드 {{ `{{ $labels.instance }}` }} 디스크 사용률 높음'
               description: |
@@ -136,6 +138,7 @@ alerting:
             for: 2m
             labels:
               severity: critical
+              environment: stage
             annotations:
               summary: '노드 {{ `{{ $labels.node }}` }} Ready 상태 아님'
               description: |
@@ -187,8 +190,12 @@ alerting:
                           - 100
                         type: gt
             for: 5m
+            noDataState: OK
+            execErrState: Error
             labels:
               severity: warning
+              service: rabbitmq
+              environment: stage
             annotations:
               summary: '큐 {{ `{{ $labels.queue }}` }} Ready 메시지 적체'
               description: |
@@ -196,6 +203,55 @@ alerting:
                 Ready 메시지: {{ `{{ $values.B.Value }}` }}개 (임계 100, 5분 지속)
                 의미: Consumer가 메시지 처리를 못 따라가고 있음
                 조치: Iris/Plag pod 상태 및 로그 확인
+
+          - uid: rabbitmq-metrics-scrape-down
+            title: RabbitMQ metrics scrape down
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: up{job="rabbitmq"}
+                  intervalMs: 60000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+              - refId: C
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 1
+                        type: lt
+            for: 5m
+            noDataState: Alerting
+            execErrState: Error
+            labels:
+              severity: warning
+              service: rabbitmq
+              environment: stage
+            annotations:
+              summary: RabbitMQ metrics scrape down
+              description: |
+                Prometheus cannot scrape RabbitMQ metrics.
+                Expected target: rabbitmq prometheus-tls endpoint.
+                Check ServiceMonitor port, RabbitMQ endpoint, TLS config, and pod health.
 
           - uid: rabbitmq-unacked-messages-high
             title: RabbitMQ 미확인 메시지 적체
@@ -233,8 +289,12 @@ alerting:
                           - 50
                         type: gt
             for: 5m
+            noDataState: OK
+            execErrState: Error
             labels:
               severity: warning
+              service: rabbitmq
+              environment: stage
             annotations:
               summary: '큐 {{ `{{ $labels.queue }}` }} 미확인 메시지 적체'
               description: |

--- a/infra/k8s/rabbitmq/base/service-monitor.yaml
+++ b/infra/k8s/rabbitmq/base/service-monitor.yaml
@@ -14,5 +14,8 @@ spec:
       app.kubernetes.io/component: rabbitmq
       app.kubernetes.io/name: rabbitmq
   endpoints:
-    - port: prometheus
+    - port: prometheus-tls
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
       interval: 15s


### PR DESCRIPTION
### Description

RabbitMQ `ServiceMonitor`가 존재하지 않는 `prometheus` 포트를 바라봐 Prometheus 스크랩이 실패하고, Grafana가 `DatasourceNoData` 알림을 `[no value]`로 전송하던 문제를 해결합니다.

- RabbitMQ 스크랩 포트를 `prometheus-tls`로 변경
- RabbitMQ backlog 알림의 `noDataState`를 `OK`로 설정
- RabbitMQ scrape health 전용 알림 추가
- Discord 알림 템플릿과 라우팅 개선

### Additional context

Stage에서 ServiceMonitor와 Grafana alerting 설정을 임시 적용해 검증했습니다. RabbitMQ 메트릭은 정상 수집되며, Grafana RabbitMQ 알림 3개 모두 `inactive` / `ok` 상태였습니다. 테스트 후 Grafana GitOps self-heal은 복구했습니다.

Closes TAS-2769

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.