### PR TITLE
fix(fe): resolve double sidebar

### DIFF
--- a/apps/frontend/app/admin/layout.tsx
+++ b/apps/frontend/app/admin/layout.tsx
@@ -73,7 +73,7 @@ export default async function Layout({
   return (
     <ClientApolloProvider session={session}>
       <div className="flex h-dvh bg-white">
-        <nav className="text-body2_m_14 bg-white p-2 pb-6 shadow-[8px_0_24px_rgba(0,0,0,0.06)]">
+        <nav className="text-body2_m_14 h-dvh overflow-y-auto bg-white p-2 pb-6 shadow-[8px_0_24px_rgba(0,0,0,0.06)]">
           {/* Todo: Group 기능 추가 시, Public Button 대신 GroupSelect 컴포넌트로 변경 */}
           {/* <GroupSelect /> */}
           {/* <Link href="/" className="ml-6">


### PR DESCRIPTION
모바일 화면에서 왼쪽 강의명 테이블의 스크롤바가 페이지 스크롤바 옆에 붙어 이중 슬라이드가 생기는 문제가 있었다.
<img width="426" height="462" alt="image" src="https://github.com/user-attachments/assets/04454274-c860-484e-9db1-ac307ef64670" />
<해결 전>


<img width="425" height="549" alt="image" src="https://github.com/user-attachments/assets/647e18e2-1983-48b2-ab0d-f2e9a823dbba" />
<해결 후>