### PR TITLE
fix(fe): expand dashboard item click area to entire card

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentLink.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/AssignmentLink.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/libs/utils'
 import type { Assignment } from '@/types/type'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
@@ -8,12 +9,14 @@ interface AssignmentLinkProps {
   assignment: Assignment
   courseId: number
   isExercise?: boolean
+  className?: string
 }
 
 export function AssignmentLink({
   assignment,
   courseId,
-  isExercise = false
+  isExercise = false,
+  className
 }: AssignmentLinkProps) {
   const router = useRouter()
   const type = isExercise ? 'exercise' : 'assignment'
@@ -31,7 +34,7 @@ export function AssignmentLink({
   return (
     <div
       onClick={handleClick}
-      className="pointer-events-auto w-fit cursor-pointer"
+      className={cn('pointer-events-auto w-fit cursor-pointer', className)}
       role="button"
       tabIndex={0}
     >

--- a/apps/frontend/app/(client)/(main)/course/_components/Dashboard.tsx
+++ b/apps/frontend/app/(client)/(main)/course/_components/Dashboard.tsx
@@ -378,7 +378,7 @@ function CardSection({
                           key={row.id}
                           className="group relative w-full overflow-hidden rounded-md bg-neutral-100 transition hover:bg-neutral-200"
                         >
-                          <div className="relative flex items-center py-[10px]">
+                          <div className="flex items-center py-[10px]">
                             <div className="flex min-w-0 flex-1 items-center">
                               <div className="pl-[18px] pr-[10px]">
                                 <span className="bg-primary inline-block h-2 w-2 shrink-0 rounded-full" />
@@ -389,6 +389,7 @@ function CardSection({
                                   assignment={row.raw}
                                   courseId={courseId}
                                   isExercise={row.isExercise}
+                                  className="static after:absolute after:inset-0 after:cursor-pointer"
                                 />
                               </div>
                             </div>


### PR DESCRIPTION
### Description
<img width="2512" height="1012" alt="image" src="https://github.com/user-attachments/assets/e3de245b-17f2-4011-8546-7e00692f5836" />

대시보드의 Assignment/Exercise 카드에서 항목(과제/실습)의 클릭 가능 영역이 제목 텍스트에만 한정되어 있는 문제를 수정했습니다.

**Problem**
- 항목 행 전체가 회색 배경 + hover 효과로 버튼처럼 보이지만, 실제 클릭 핸들러는 `AssignmentLink` 내부의 `w-fit` div(제목 텍스트)에만 붙어 있음
- 제목 외 영역(여백, 마감일 `~ MM/DD`, 불릿)을 클릭하면 페이지 이동이 되지 않아 시각적 클릭 영역과 실제 클릭 영역이 불일치

**Solution**
- `AssignmentLink`에 optional `className` prop 추가
- 대시보드에서 `after:absolute after:inset-0`를 넘겨, `relative`인 행 컨테이너 전체를 덮는 클릭 레이어를 생성
- 행 내부 div의 불필요한 `relative`를 제거해 클릭 레이어 기준을 행 전체로 확장

**Verification**
- 대시보드에서 항목의 제목/여백/마감일 등 행 내 모든 영역 클릭 시 이동 확인
- 코스 페이지의 과제 아코디언에서 기존 동작(제목만 링크) 유지 확인

closes TAS-2782