### PR TITLE
fix(infra): support PostgreSQL TLS connections

### DIFF
--- a/apps/iris/src/loader/postgres.go
+++ b/apps/iris/src/loader/postgres.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
-	"strings"
 
 	_ "github.com/lib/pq"
 )
@@ -18,7 +18,11 @@ type Postgres struct {
 func NewPostgresDataSource(ctx context.Context) (*Postgres, error) {
 	// 새로운 ENV 추가 필요
 	connStr := os.Getenv("DATABASE_URL")
-	data := strings.Replace(connStr, "schema=public", "sslmode=disable", 1)
+	data, err := parseDatabaseURL(connStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access database: %w", err)
+	}
+
 	db, err := sql.Open("postgres", data)
 
 	if err != nil {
@@ -26,6 +30,32 @@ func NewPostgresDataSource(ctx context.Context) (*Postgres, error) {
 	}
 
 	return &Postgres{ctx, db}, nil
+}
+
+func parseDatabaseURL(databaseURL string) (string, error) {
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid database URL: %w", err)
+	}
+	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
+		return "", fmt.Errorf("invalid database URL scheme %q", parsed.Scheme)
+	}
+
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return "", fmt.Errorf("invalid database URL query: %w", err)
+	}
+	query.Del("schema")
+	switch sslMode := query.Get("sslmode"); sslMode {
+	case "":
+		query.Set("sslmode", "disable")
+	case "disable", "require", "verify-ca", "verify-full":
+	default:
+		return "", fmt.Errorf("unsupported sslmode %q", sslMode)
+	}
+
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }
 
 func (p *Postgres) Get(key string) ([]Element, error) {

--- a/apps/iris/src/loader/postgres_test.go
+++ b/apps/iris/src/loader/postgres_test.go
@@ -1,10 +1,7 @@
 package loader
 
 import (
-	"context"
-	"os"
 	"testing"
-	"time"
 )
 
 func TestParseDatabaseURL(t *testing.T) {
@@ -81,25 +78,5 @@ func TestParseDatabaseURL(t *testing.T) {
 				t.Errorf("parseDatabaseURL() = %q, want %q", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestPostgresConnection(t *testing.T) {
-	databaseURL := os.Getenv("POSTGRES_INTEGRATION_URL")
-	if databaseURL == "" {
-		t.Skip("POSTGRES_INTEGRATION_URL is not set")
-	}
-
-	t.Setenv("DATABASE_URL", databaseURL)
-	postgres, err := NewPostgresDataSource(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = postgres.client.Close() })
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := postgres.client.PingContext(ctx); err != nil {
-		t.Fatalf("connect to PostgreSQL: %v", err)
 	}
 }

--- a/apps/iris/src/loader/postgres_test.go
+++ b/apps/iris/src/loader/postgres_test.go
@@ -1,0 +1,105 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "loopback IPv4 defaults to disabled SSL",
+			input: "postgresql://user:pass@127.0.0.1:5432/db?schema=public&application_name=iris",
+			want:  "postgresql://user:pass@127.0.0.1:5432/db?application_name=iris&sslmode=disable",
+		},
+		{
+			name:  "loopback IPv6 defaults to disabled SSL",
+			input: "postgresql://user:pass@[::1]:5432/db",
+			want:  "postgresql://user:pass@[::1]:5432/db?sslmode=disable",
+		},
+		{
+			name:  "remote host defaults to disabled SSL",
+			input: "postgresql://user:pass@db.internal:5432/db?schema=public",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=disable",
+		},
+		{
+			name:    "unsupported prefer mode is rejected",
+			input:   "postgres://user:pass@10.0.0.2:5432/db?sslmode=prefer",
+			wantErr: true,
+		},
+		{
+			name:  "explicit disable is preserved",
+			input: "postgresql://user:pass@db.internal:5432/db?schema=public&sslmode=disable",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=disable",
+		},
+		{
+			name:  "explicit require is preserved",
+			input: "postgresql://user:pass@127.0.0.1:5432/db?sslmode=require",
+			want:  "postgresql://user:pass@127.0.0.1:5432/db?sslmode=require",
+		},
+		{
+			name:  "explicit verify-ca is preserved",
+			input: "postgresql://user:pass@db.internal:5432/db?sslmode=verify-ca",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=verify-ca",
+		},
+		{
+			name:  "explicit verify-full is preserved",
+			input: "postgresql://user:pass@db.internal:5432/db?sslmode=verify-full",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=verify-full",
+		},
+		{
+			name:    "non-PostgreSQL scheme is rejected",
+			input:   "mysql://user:pass@localhost:3306/db",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported SSL mode is rejected",
+			input:   "postgresql://user:pass@db.internal:5432/db?sslmode=allow",
+			wantErr: true,
+		},
+		{
+			name:    "malformed query is rejected",
+			input:   "postgresql://user:pass@db.internal:5432/db?schema=%zz",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDatabaseURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseDatabaseURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseDatabaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgresConnection(t *testing.T) {
+	databaseURL := os.Getenv("POSTGRES_INTEGRATION_URL")
+	if databaseURL == "" {
+		t.Skip("POSTGRES_INTEGRATION_URL is not set")
+	}
+
+	t.Setenv("DATABASE_URL", databaseURL)
+	postgres, err := NewPostgresDataSource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = postgres.client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := postgres.client.PingContext(ctx); err != nil {
+		t.Fatalf("connect to PostgreSQL: %v", err)
+	}
+}

--- a/apps/plag/src/loader/postgres.go
+++ b/apps/plag/src/loader/postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -19,7 +20,11 @@ type Postgres struct {
 func NewPostgresDataSource(ctx context.Context) (*Postgres, error) {
 	// 새로운 ENV 추가 필요
 	connStr := os.Getenv("DATABASE_URL")
-	data := strings.Replace(connStr, "schema=public", "sslmode=disable", 1)
+	data, err := parseDatabaseURL(connStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access database: %w", err)
+	}
+
 	db, err := sql.Open("postgres", data)
 
 	if err != nil {
@@ -27,6 +32,32 @@ func NewPostgresDataSource(ctx context.Context) (*Postgres, error) {
 	}
 
 	return &Postgres{ctx, db}, nil
+}
+
+func parseDatabaseURL(databaseURL string) (string, error) {
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid database URL: %w", err)
+	}
+	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
+		return "", fmt.Errorf("invalid database URL scheme %q", parsed.Scheme)
+	}
+
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return "", fmt.Errorf("invalid database URL query: %w", err)
+	}
+	query.Del("schema")
+	switch sslMode := query.Get("sslmode"); sslMode {
+	case "":
+		query.Set("sslmode", "disable")
+	case "disable", "require", "verify-ca", "verify-full":
+	default:
+		return "", fmt.Errorf("unsupported sslmode %q", sslMode)
+	}
+
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }
 
 func GetAllCodes(rows *sql.Rows, problemId string) ([]Element, error) {

--- a/apps/plag/src/loader/postgres_test.go
+++ b/apps/plag/src/loader/postgres_test.go
@@ -1,10 +1,7 @@
 package loader
 
 import (
-	"context"
-	"os"
 	"testing"
-	"time"
 )
 
 func TestParseDatabaseURL(t *testing.T) {
@@ -81,25 +78,5 @@ func TestParseDatabaseURL(t *testing.T) {
 				t.Errorf("parseDatabaseURL() = %q, want %q", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestPostgresConnection(t *testing.T) {
-	databaseURL := os.Getenv("POSTGRES_INTEGRATION_URL")
-	if databaseURL == "" {
-		t.Skip("POSTGRES_INTEGRATION_URL is not set")
-	}
-
-	t.Setenv("DATABASE_URL", databaseURL)
-	postgres, err := NewPostgresDataSource(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = postgres.client.Close() })
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := postgres.client.PingContext(ctx); err != nil {
-		t.Fatalf("connect to PostgreSQL: %v", err)
 	}
 }

--- a/apps/plag/src/loader/postgres_test.go
+++ b/apps/plag/src/loader/postgres_test.go
@@ -1,0 +1,105 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "loopback IPv4 defaults to disabled SSL",
+			input: "postgresql://user:pass@127.0.0.1:5432/db?schema=public&application_name=plag",
+			want:  "postgresql://user:pass@127.0.0.1:5432/db?application_name=plag&sslmode=disable",
+		},
+		{
+			name:  "loopback IPv6 defaults to disabled SSL",
+			input: "postgresql://user:pass@[::1]:5432/db",
+			want:  "postgresql://user:pass@[::1]:5432/db?sslmode=disable",
+		},
+		{
+			name:  "remote host defaults to disabled SSL",
+			input: "postgresql://user:pass@db.internal:5432/db?schema=public",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=disable",
+		},
+		{
+			name:    "unsupported prefer mode is rejected",
+			input:   "postgres://user:pass@10.0.0.2:5432/db?sslmode=prefer",
+			wantErr: true,
+		},
+		{
+			name:  "explicit disable is preserved",
+			input: "postgresql://user:pass@db.internal:5432/db?schema=public&sslmode=disable",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=disable",
+		},
+		{
+			name:  "explicit require is preserved",
+			input: "postgresql://user:pass@127.0.0.1:5432/db?sslmode=require",
+			want:  "postgresql://user:pass@127.0.0.1:5432/db?sslmode=require",
+		},
+		{
+			name:  "explicit verify-ca is preserved",
+			input: "postgresql://user:pass@db.internal:5432/db?sslmode=verify-ca",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=verify-ca",
+		},
+		{
+			name:  "explicit verify-full is preserved",
+			input: "postgresql://user:pass@db.internal:5432/db?sslmode=verify-full",
+			want:  "postgresql://user:pass@db.internal:5432/db?sslmode=verify-full",
+		},
+		{
+			name:    "non-PostgreSQL scheme is rejected",
+			input:   "mysql://user:pass@localhost:3306/db",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported SSL mode is rejected",
+			input:   "postgresql://user:pass@db.internal:5432/db?sslmode=allow",
+			wantErr: true,
+		},
+		{
+			name:    "malformed query is rejected",
+			input:   "postgresql://user:pass@db.internal:5432/db?schema=%zz",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDatabaseURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseDatabaseURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseDatabaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgresConnection(t *testing.T) {
+	databaseURL := os.Getenv("POSTGRES_INTEGRATION_URL")
+	if databaseURL == "" {
+		t.Skip("POSTGRES_INTEGRATION_URL is not set")
+	}
+
+	t.Setenv("DATABASE_URL", databaseURL)
+	postgres, err := NewPostgresDataSource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = postgres.client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := postgres.client.PingContext(ctx); err != nil {
+		t.Fatalf("connect to PostgreSQL: %v", err)
+	}
+}

--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -69,6 +69,6 @@ resource "aws_secretsmanager_secret" "database" {
 resource "aws_secretsmanager_secret_version" "database" {
   secret_id = aws_secretsmanager_secret.database.id
   secret_string = jsonencode({
-    url = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public&sslmode=require"
+    url = local.database_url
   })
 }

--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -69,6 +69,6 @@ resource "aws_secretsmanager_secret" "database" {
 resource "aws_secretsmanager_secret_version" "database" {
   secret_id = aws_secretsmanager_secret.database.id
   secret_string = jsonencode({
-    url = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public"
+    url = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public&sslmode=require"
   })
 }

--- a/infra/aws/storage/main.tf
+++ b/infra/aws/storage/main.tf
@@ -39,5 +39,6 @@ data "terraform_remote_state" "vpc" {
 }
 
 locals {
-  vpc = data.terraform_remote_state.vpc.outputs
+  vpc          = data.terraform_remote_state.vpc.outputs
+  database_url = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public&sslmode=require"
 }

--- a/infra/aws/storage/outputs.tf
+++ b/infra/aws/storage/outputs.tf
@@ -4,7 +4,7 @@ output "testcase_bucket" {
 }
 
 output "database_url" {
-  value     = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public"
+  value     = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public&sslmode=require"
   sensitive = true
 }
 

--- a/infra/aws/storage/outputs.tf
+++ b/infra/aws/storage/outputs.tf
@@ -4,7 +4,7 @@ output "testcase_bucket" {
 }
 
 output "database_url" {
-  value     = "postgres://${aws_db_instance.postgres.username}:${random_password.postgres_password.result}@${aws_db_instance.postgres.address}:${aws_db_instance.postgres.port}/skkuding?schema=public&sslmode=require"
+  value     = local.database_url
   sensitive = true
 }
 


### PR DESCRIPTION
### Description

AWS RDS가 TLS를 요구할 때 Iris와 Plag가 연결하지 못하는 문제를 해결합니다. 기존 문자열 치환은 `schema=public&sslmode=require`를 `sslmode=disable&sslmode=require`로 바꿔 TLS를 비활성화할 수 있었습니다.

PostgreSQL URL을 파싱해 Prisma 전용 `schema` 옵션만 제거하고 명시된 `sslmode`와 다른 쿼리 옵션은 보존합니다. AWS Secrets Manager와 Terraform 출력에는 `sslmode=require`를 명시했으며, URL 변환 동작을 단위 테스트로 검증했습니다.

### Additional context

[Amazon RDS for PostgreSQL 릴리스 일정](https://docs.aws.amazon.com/ko_kr/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html)

PostgreSQL 14는 연말에 지원 종료될 예정이며, 이에 대응하기 위해서는 최신 버전 DB로 넘어가야 합니다.

Amazon RDS for PostgreSQL 18로 업그레이드하면 rds.force_ssl이 기본적으로 활성화되어 TLS 연결이 요구됩니다. 이에 따라 DB 클라이언트가 TLS 연결을 지원하도록 설정해야 합니다. 이 PR은 이를 위해서 작성되었습니다.

PostgreSQL 14, 16, 18에 대해 테스트되었습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

Closes TAS-2788