### PR TITLE
fix(infra): add onboarding namespace

### DIFF
--- a/infra/k8s/onboarding/namespace.yaml
+++ b/infra/k8s/onboarding/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: onboarding


### PR DESCRIPTION
## What changed

- Added `infra/k8s/onboarding/namespace.yaml` for the `onboarding` namespace.

## Why

- The onboarding namespace did not have a declarative Namespace manifest in the repository.

## Impact

- The onboarding namespace can now be created and managed from the repository manifest.

## Validation

- `kubectl create --dry-run=client --validate=false -f infra/k8s/onboarding/namespace.yaml -o yaml`
- Pre-commit Prettier check
- Commit message validation