### PR TITLE
fix(infra): use port 9000 and stage host for choesuna-react-app

### DIFF
--- a/infra/k8s/onboarding/choesuna-react-app/deployment.yaml
+++ b/infra/k8s/onboarding/choesuna-react-app/deployment.yaml
@@ -18,4 +18,4 @@ spec:
         - name: choesuna-react-app
           image: okteto/example-react:latest
           ports:
-            - containerPort: 3000
+            - containerPort: 9000

--- a/infra/k8s/onboarding/choesuna-react-app/ingress.yaml
+++ b/infra/k8s/onboarding/choesuna-react-app/ingress.yaml
@@ -3,10 +3,16 @@ kind: Ingress
 metadata:
   name: choesuna-react-app
   namespace: onboarding
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
 spec:
   ingressClassName: traefik
+  tls:
+    - hosts:
+        - choesuna-react-app.stage.codedang.com
+      secretName: choesuna-react-app-tls
   rules:
-    - host: choesuna-react-app.first-task.codedang.com
+    - host: choesuna-react-app.stage.codedang.com
       http:
         paths:
           - path: /
@@ -15,4 +21,4 @@ spec:
               service:
                 name: choesuna-react-app
                 port:
-                  number: 3000
+                  number: 9000

--- a/infra/k8s/onboarding/choesuna-react-app/service.yaml
+++ b/infra/k8s/onboarding/choesuna-react-app/service.yaml
@@ -7,5 +7,5 @@ spec:
   selector:
     app: choesuna-react-app
   ports:
-    - port: 3000
-      targetPort: 3000
+    - port: 9000
+      targetPort: 9000


### PR DESCRIPTION
okteto/example-react 이미지는 3000이 아닌 9000 포트를 사용해야 하므로 deployment/service/ingress의 포트를 9000으로 맞춘다.

또한 ingress host가 실제 생성된 Route53 레코드(`choesuna-react-app.stage.codedang.com`)와 달라 라우팅이 되지 않던 문제를 수정하고, 다른 팀원 예시와 동일하게 cert-manager 기반 TLS 설정을 추가한다.

Closes TAS-2811