### PR TITLE
fix(fe): add spacing between problem description and divider

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/EditorDescription.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/EditorDescription.tsx
@@ -40,7 +40,7 @@ export function EditorDescription({
         <div className="prose prose-invert mt-5 max-w-full text-sm leading-relaxed text-slate-300">
           <KatexContent content={problem.description} />
         </div>
-        <hr className="border-slate-700" />
+        <hr className="mt-5 border-slate-700" />
       </div>
 
       <div className="px-6">

--- a/apps/frontend/app/admin/_components/code-editor/EditorDescription.tsx
+++ b/apps/frontend/app/admin/_components/code-editor/EditorDescription.tsx
@@ -41,7 +41,7 @@ export function EditorDescription({
         <div className="prose prose-invert mt-5 max-w-full text-sm leading-relaxed text-slate-300">
           <KatexContent content={problem.description} />
         </div>
-        <hr className="border-slate-700" />
+        <hr className="mt-5 border-slate-700" />
       </div>
 
       <div className="px-6">


### PR DESCRIPTION
### Description

문제 상세 페이지에서 문제 설명과 바로 아래 구분선(hr) 사이 간격이 없어 붙어 보이던 것을 수정했습니다

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
<img width="638" height="405" alt="t2828" src="https://github.com/user-attachments/assets/ea5783d4-63f0-4567-82e2-5f43240da0b6" />


---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2828