### PR TITLE
fix: derive pnpm version from root package manifest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,6 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers-extra/features/pnpm:2": {},
     "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/devcontainers/features/java:1": {

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -14,9 +14,7 @@ RUN apk add --no-cache bash
 COPY . /build
 WORKDIR /build
 
-# https://github.com/nodejs/corepack/issues/612 해결되면 다시 corepack 사용
-# RUN corepack enable
-RUN npm install -g pnpm
+RUN corepack enable
 RUN pnpm --filter="@codedang/backend" deploy out
 
 WORKDIR /build/out

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -165,6 +165,5 @@
     "typescript": "5.9.2",
     "uuidv7": "^1.0.2",
     "vitest": "^3.2.4"
-  },
-  "packageManager": "pnpm@10.14.0"
+  }
 }


### PR DESCRIPTION
### Description

- pnpm 버전을 루트 `package.json`의 `packageManager`로 단일화합니다.
- 백엔드 Docker 빌드도 Corepack을 사용하도록 변경합니다.
- 프론트엔드 중복 선언과 devcontainer의 미고정 pnpm 설치를 제거합니다.

### Additional context

- `node:22.18.0-alpine`에서 루트와 프론트엔드 경로 모두 pnpm `10.14.0` 해석을 확인했습니다.
- JSON, Prettier, `git diff --check` 검증을 통과했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Include relevant validation.

Closes TAS-2833