### PR TITLE
fix(infra): stop MinIO application normalization loop

### DIFF
--- a/infra/k8s/argocd/applications/minio-stage.yaml
+++ b/infra/k8s/argocd/applications/minio-stage.yaml
@@ -11,9 +11,6 @@ spec:
     path: infra/k8s/minio
     repoURL: https://github.com/skkuding/codedang
     targetRevision: main
-    directory:
-      # kustomization.yaml is ignored if recurse is true
-      recurse: false
   destination:
     namespace: minio
     name: stage

--- a/infra/k8s/argocd/applications/monitoring/minio.yaml
+++ b/infra/k8s/argocd/applications/monitoring/minio.yaml
@@ -29,9 +29,6 @@ spec:
         path: infra/k8s/monitoring/minio/overlays/{{.env}}
         repoURL: https://github.com/skkuding/codedang
         targetRevision: '{{.branch}}'
-        directory:
-          # kustomization.yaml is ignored if recurse is true
-          recurse: false
       destination:
         namespace: monitoring-minio
         name: '{{.env}}'


### PR DESCRIPTION
### Description

- MinIO Argo 정의에서 기본값인 `directory.recurse: false`를 제거합니다.
- API 정규화와 self-heal이 반복되는 sync loop를 방지합니다.

### Additional context

기존 설정은 `recurse: true`가 `kustomization.yaml`을 무시하는 것을 막기 위해 추가됐습니다. 하지만 Kustomize 자동 감지에는 `directory` 블록이 필요 없으며, Argo v3/SSA에서 기본값이 live spec에서 제거되면서 지속적인 diff가 발생했습니다.

Kustomize 렌더링 결과와 MinIO 워크로드에는 변화가 없습니다.

검증:

- Stage·Production MinIO Kustomize build
- Kubeconform
- `git diff --check`

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

Closes TAS-2836