### PR TITLE
fix(fe): improve finished contest button UI

### DIFF
--- a/apps/frontend/app/(client)/(code-editor)/_components/FinishedNoticePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/FinishedNoticePanel.tsx
@@ -60,7 +60,7 @@ function VisitProblemButton({ problemId }: VisitProblemButtonProps) {
     <Link href={`/problem/${problemId}`}>
       <Button
         type="button"
-        className="h-10 w-48 shrink-0 gap-[5px] rounded-[4px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
+        className="h-10 shrink-0 gap-[5px] rounded-full border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
       >
         <VisitIcon width={20} height={20} />
         Visit Public Problem

--- a/apps/frontend/app/(client)/(code-editor)/_components/FinishedNoticePanel.tsx
+++ b/apps/frontend/app/(client)/(code-editor)/_components/FinishedNoticePanel.tsx
@@ -60,7 +60,7 @@ function VisitProblemButton({ problemId }: VisitProblemButtonProps) {
     <Link href={`/problem/${problemId}`}>
       <Button
         type="button"
-        className="h-10 shrink-0 gap-[5px] rounded-full border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
+        className="h-10 shrink-0 gap-[5px] border border-blue-500 bg-blue-100 font-sans text-blue-500 hover:bg-blue-300"
       >
         <VisitIcon width={20} height={20} />
         Visit Public Problem


### PR DESCRIPTION
### Description

대회 종료 화면에 표시되는 `Visit Public Problem` 버튼의 UI를 개선했습니다.

- `View Leaderboard` 버튼과 동일하게 `rounded-full`을 적용했습니다.
- 버튼의 고정 너비를 제거해 콘텐츠에 따라 너비가 조절되도록 변경했습니다.
- 버튼 너비 부족으로 아이콘이 압축되거나 잘리는 문제를 해결했습니다.

### Screenshots

#### 수정 전

<img width="900" alt="수정 전 대회 종료 화면" src="https://github.com/user-attachments/assets/95f21d7b-1fb3-49eb-8253-eed6d214a240" />

#### 수정 후

<img width="900" alt="수정 후 대회 종료 화면" src="https://github.com/user-attachments/assets/3e3406a9-76a4-4edf-af78-64fabcea98ac" />

### Testing

- 로컬 환경에서 대회 종료 화면을 확인했습니다.
- 두 버튼의 테두리가 동일하게 둥글게 표시되는 것을 확인했습니다.
- `Visit Public Problem` 버튼의 아이콘이 잘리지 않고 표시되는 것을 확인했습니다.


---

### Before submitting the PR, please make sure you do the following

- [x] [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)를 확인했습니다.
- [x] [브랜치 및 PR 규칙](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch)과 [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)을 준수했습니다.
- [x] PR에서 해결하는 작업에 대한 설명을 작성했습니다.
- [x] 관련 테스트를 추가하거나 수행했습니다.

closes TAS-2826