### PR TITLE
feat(infra): migrate cloud-beaver pvc to longhorn

### DIFF
--- a/infra/k8s/cloud-beaver/deployment.yaml
+++ b/infra/k8s/cloud-beaver/deployment.yaml
@@ -24,4 +24,4 @@ spec:
       volumes:
         - name: cloud-beaver-data
           persistentVolumeClaim:
-            claimName: cloud-beaver-pvc
+            claimName: cloud-beaver-pvc-longhorn

--- a/infra/k8s/cloud-beaver/pvc-longhorn.yaml
+++ b/infra/k8s/cloud-beaver/pvc-longhorn.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cloud-beaver-pvc-longhorn
+  namespace: cloud-beaver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn


### PR DESCRIPTION
### Description

Migrates the stage CloudBeaver workload from the existing `local-path` PVC to a Longhorn-backed PVC.

This PR:
- Adds `cloud-beaver-pvc-longhorn` with `storageClassName: longhorn`
- Updates the CloudBeaver Deployment to mount `cloud-beaver-pvc-longhorn`
- Keeps the existing `cloud-beaver-pvc` manifest for rollback

The CloudBeaver workspace data was already copied from the existing PVC to the new Longhorn PVC in stage before this GitOps change.

### Additional context

CloudBeaver is currently deployed only to stage through `cloud-beaver-stage`, which syncs `infra/k8s/cloud-beaver` to the `stage` cluster.

Validation performed:
- Created `cloud-beaver-pvc-longhorn` in stage
- Copied CloudBeaver workspace data from `cloud-beaver-pvc` to `cloud-beaver-pvc-longhorn`
- Verified copied data with checksums
- Ran server-side dry run for the updated manifests

```bash
kubectl --context stage apply --dry-run=server \
  -f infra/k8s/cloud-beaver/pvc-longhorn.yaml \
  -f infra/k8s/cloud-beaver/deployment.yaml