### PR TITLE
refactor(iris): refactor response handling logic enabling flexible response typing

### DIFF
--- a/apps/iris/src/common/constants/constants.go
+++ b/apps/iris/src/common/constants/constants.go
@@ -56,15 +56,17 @@ const (
 
 const MAX_OUTPUT = 1048576 // 1MB
 
+type MessageType string
+
 const (
-	Judge        = "judge"
-	Submission   = "submission"
-	SpecialJudge = "specialJudge"
-	Run          = "run"
-	Interactive  = "interactive"
-	UserTestCase = "userTestCase"
-	Generate     = "generate"
-	Validate     = "validate"
-	Check        = "check"
-	Default      = "judge"
+	Judge        MessageType = "judge"
+	Submission   MessageType = "submission"
+	SpecialJudge MessageType = "specialJudge"
+	Run          MessageType = "run"
+	Interactive  MessageType = "interactive"
+	UserTestCase MessageType = "userTestCase"
+	Generate     MessageType = "generate"
+	Validate     MessageType = "validate"
+	Check        MessageType = "check"
+	Default      MessageType = Judge
 )

--- a/apps/iris/src/common/constants/constants.go
+++ b/apps/iris/src/common/constants/constants.go
@@ -55,3 +55,16 @@ const (
 )
 
 const MAX_OUTPUT = 1048576 // 1MB
+
+const (
+	Judge        = "judge"
+	Submission   = "submission"
+	SpecialJudge = "specialJudge"
+	Run          = "run"
+	Interactive  = "interactive"
+	UserTestCase = "userTestCase"
+	Generate     = "generate"
+	Validate     = "validate"
+	Check        = "check"
+	Default      = "judge"
+)

--- a/apps/iris/src/connector/rabbitmq/connector.go
+++ b/apps/iris/src/connector/rabbitmq/connector.go
@@ -105,12 +105,12 @@ func (c *connector) handle(message amqp.Delivery, ctx context.Context) {
 		resultChan <- response.Response{Message: response.NewJudgeResponse("", nil, fmt.Errorf("type(message property) must not be empty")).Marshal(), Type: constants.Default}
 		close(resultChan)
 	} else if message.MessageId == "" {
-		resultChan <- response.Response{Message: response.NewJudgeResponse("", nil, fmt.Errorf("message_id(message property) must not be empty")).Marshal(), Type: message.Type}
+		resultChan <- response.Response{Message: response.NewJudgeResponse("", nil, fmt.Errorf("message_id(message property) must not be empty")).Marshal(), Type: constants.MessageType(message.Type)}
 		close(resultChan)
 	} else {
 		go func() {
 			defer close(resultChan)
-			c.router.Route(message.Type, message.MessageId, message.Body, resultChan, spanCtx)
+			c.router.Route(constants.MessageType(message.Type), message.MessageId, message.Body, resultChan, spanCtx)
 		}()
 	}
 
@@ -128,7 +128,7 @@ drain:
 			break drain
 		}
 
-		if err := c.producer.Publish(result.Message, spanCtx, result.Type); err != nil {
+		if err := c.producer.Publish(result.Message, spanCtx, string(result.Type)); err != nil {
 			c.logger.LogWithContext(logger.ERROR, fmt.Sprintf("failed to publish result: %s: %s", string(result.Message), err), spanCtx)
 			// nack
 		} else {

--- a/apps/iris/src/connector/rabbitmq/connector.go
+++ b/apps/iris/src/connector/rabbitmq/connector.go
@@ -9,6 +9,7 @@ import (
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	instrumentation "github.com/skkuding/codedang/apps/iris/src"
+	"github.com/skkuding/codedang/apps/iris/src/common/constants"
 	"github.com/skkuding/codedang/apps/iris/src/router"
 	"github.com/skkuding/codedang/apps/iris/src/router/response"
 	"github.com/skkuding/codedang/apps/iris/src/service/logger"
@@ -99,12 +100,12 @@ func (c *connector) handle(message amqp.Delivery, ctx context.Context) {
 	spanCtx, cancel := context.WithTimeout(spanCtx, timeout)
 	defer cancel()
 
-	resultChan := make(chan []byte, 1)
+	resultChan := make(chan response.Response, 1)
 	if message.Type == "" {
-		resultChan <- response.NewJudgeResponse("", nil, fmt.Errorf("type(message property) must not be empty")).Marshal()
+		resultChan <- response.Response{Message: response.NewJudgeResponse("", nil, fmt.Errorf("type(message property) must not be empty")).Marshal(), Type: constants.Default}
 		close(resultChan)
 	} else if message.MessageId == "" {
-		resultChan <- response.NewJudgeResponse("", nil, fmt.Errorf("message_id(message property) must not be empty")).Marshal()
+		resultChan <- response.Response{Message: response.NewJudgeResponse("", nil, fmt.Errorf("message_id(message property) must not be empty")).Marshal(), Type: message.Type}
 		close(resultChan)
 	} else {
 		go func() {
@@ -115,7 +116,7 @@ func (c *connector) handle(message amqp.Delivery, ctx context.Context) {
 
 drain:
 	for {
-		var result []byte
+		var result response.Response
 		var open bool
 		select {
 		case result, open = <-resultChan:
@@ -127,11 +128,11 @@ drain:
 			break drain
 		}
 
-		if err := c.producer.Publish(result, spanCtx, message.Type); err != nil {
-			c.logger.LogWithContext(logger.ERROR, fmt.Sprintf("failed to publish result: %s: %s", string(result), err), spanCtx)
+		if err := c.producer.Publish(result.Message, spanCtx, result.Type); err != nil {
+			c.logger.LogWithContext(logger.ERROR, fmt.Sprintf("failed to publish result: %s: %s", string(result.Message), err), spanCtx)
 			// nack
 		} else {
-			c.logger.LogWithContext(logger.DEBUG, fmt.Sprintf("result published: %s", string(result)), spanCtx)
+			c.logger.LogWithContext(logger.DEBUG, fmt.Sprintf("result published: %s", string(result.Message)), spanCtx)
 		}
 	}
 

--- a/apps/iris/src/handler/judge/task.go
+++ b/apps/iris/src/handler/judge/task.go
@@ -54,7 +54,7 @@ func (t *Task) RunAction(ctx context.Context, messageID string, sendMessage hand
 		sendMessage(handler.ResultMessage{EncodedResponse: judgeResponse.Marshal()})
 	}
 	defer func() {
-		sendMessage(handler.ResultMessage{EncodedResponse: response.NewSubmissionResponse(messageID, judgeResults).Marshal()})
+		sendMessage(handler.ResultMessage{EncodedResponse: response.NewSubmissionResponse(messageID, judgeResults).Marshal()}, constants.Submission)
 	}()
 
 	validReq := t.req
@@ -102,7 +102,7 @@ func (t *Task) SendSetupFailure(messageID string, taskErr error, sendMessage han
 	sendMessage(handler.ResultMessage{EncodedResponse: judgeResponse.Marshal()})
 	sendMessage(handler.ResultMessage{
 		EncodedResponse: response.NewSubmissionResponse(messageID, []*response.JudgeResponse{judgeResponse}).Marshal(),
-	})
+	}, constants.Submission)
 }
 
 func (t *Task) judgeTestcase(ctx context.Context, idx int, validReq *JudgeRequest,

--- a/apps/iris/src/handler/result.go
+++ b/apps/iris/src/handler/result.go
@@ -1,9 +1,12 @@
 package handler
 
-import "github.com/skkuding/codedang/apps/iris/src/common/taskresult"
+import (
+	"github.com/skkuding/codedang/apps/iris/src/common/constants"
+	"github.com/skkuding/codedang/apps/iris/src/common/taskresult"
+)
 
 type ResultMessage = taskresult.Message
 
 // ResultSender delivers a task result to the caller-provided result sink.
 // The sender does not own the underlying channel or its lifecycle.
-type ResultSender func(ResultMessage, ...any)
+type ResultSender func(ResultMessage, ...constants.MessageType)

--- a/apps/iris/src/handler/result.go
+++ b/apps/iris/src/handler/result.go
@@ -6,4 +6,4 @@ type ResultMessage = taskresult.Message
 
 // ResultSender delivers a task result to the caller-provided result sink.
 // The sender does not own the underlying channel or its lifecycle.
-type ResultSender func(ResultMessage)
+type ResultSender func(ResultMessage, ...any)

--- a/apps/iris/src/handler/run/task.go
+++ b/apps/iris/src/handler/run/task.go
@@ -54,7 +54,7 @@ func (t *Task) RunAction(ctx context.Context, messageID string, sendMessage hand
 		sendMessage(handler.ResultMessage{EncodedResponse: judgeResponse.Marshal()})
 	}
 	defer func() {
-		sendMessage(handler.ResultMessage{EncodedResponse: response.NewSubmissionResponse(messageID, judgeResults).Marshal()})
+		sendMessage(handler.ResultMessage{EncodedResponse: response.NewSubmissionResponse(messageID, judgeResults).Marshal()}, constants.Submission)
 	}()
 
 	validReq := t.req
@@ -110,7 +110,7 @@ func (t *Task) SendSetupFailure(messageID string, taskErr error, sendMessage han
 	sendMessage(handler.ResultMessage{EncodedResponse: judgeResponse.Marshal()})
 	sendMessage(handler.ResultMessage{
 		EncodedResponse: response.NewSubmissionResponse(messageID, []*response.JudgeResponse{judgeResponse}).Marshal(),
-	})
+	}, constants.Submission)
 }
 
 type runTestcaseResult struct {

--- a/apps/iris/src/router/response/response.go
+++ b/apps/iris/src/router/response/response.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/skkuding/codedang/apps/iris/src/common/constants"
 	"github.com/skkuding/codedang/apps/iris/src/common/taskerror"
 )
 
 type Response struct {
 	Message []byte
-	Type    string
+	Type    constants.MessageType
 }
 
 func toolResult(err error) (taskerror.ResultCode, string) {

--- a/apps/iris/src/router/response/response.go
+++ b/apps/iris/src/router/response/response.go
@@ -7,8 +7,9 @@ import (
 	"github.com/skkuding/codedang/apps/iris/src/common/taskerror"
 )
 
-type Response interface {
-	Marshal() []byte
+type Response struct {
+	Message []byte
+	Type    string
 }
 
 func toolResult(err error) (taskerror.ResultCode, string) {

--- a/apps/iris/src/router/response/sender.go
+++ b/apps/iris/src/router/response/sender.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/skkuding/codedang/apps/iris/src/common/constants"
 	"github.com/skkuding/codedang/apps/iris/src/common/taskerror"
 	"github.com/skkuding/codedang/apps/iris/src/common/taskresult"
 	"github.com/skkuding/codedang/apps/iris/src/service/logger"
@@ -12,19 +13,23 @@ import (
 
 type encoder interface {
 	Marshal(result json.RawMessage, taskErr error) ([]byte, error)
+	MessageType() string
 }
 
 // Sender owns response encoding and cancellation-aware delivery for one routed message.
 type Sender struct {
 	ctx       context.Context
-	out       chan<- []byte
+	out       chan<- Response
 	path      string
 	messageID string
 	encoder   encoder
 	logger    logger.Logger
 }
 
-type judgeEncoder struct{ messageID string }
+type judgeEncoder struct {
+	messageID   string
+	messageType string
+}
 type generateEncoder struct {
 	messageID string
 	problemID int
@@ -40,7 +45,7 @@ type checkEncoder struct {
 
 // NewSender selects the response contract and owns delivery for one message.
 // problemId belongs only to tool contracts and is extracted by those encoders.
-func NewSender(ctx context.Context, out chan<- []byte, path, messageID string, data []byte, logger logger.Logger) (*Sender, error) {
+func NewSender(ctx context.Context, out chan<- Response, path, messageID string, data []byte, logger logger.Logger) (*Sender, error) {
 	encoder, err := newEncoder(path, messageID, data)
 	if encoder == nil {
 		return nil, err
@@ -50,27 +55,28 @@ func NewSender(ctx context.Context, out chan<- []byte, path, messageID string, d
 
 func newEncoder(path, messageID string, data []byte) (encoder, error) {
 	switch path {
-	case "judge", "specialJudge", "run", "userTestCase":
-		return judgeEncoder{messageID: messageID}, nil
-	case "generate":
+	case constants.Judge, constants.SpecialJudge, constants.Run, constants.UserTestCase:
+		return judgeEncoder{messageID: messageID, messageType: path}, nil
+	case constants.Generate:
 		return newGenerateEncoder(messageID, data)
-	case "validate":
+	case constants.Validate:
 		return newValidateEncoder(messageID, data)
-	case "check":
+	case constants.Check:
 		return newCheckEncoder(messageID, data)
 	default:
 		return nil, fmt.Errorf("unsupported response path: %s", path)
 	}
 }
 
-func (s *Sender) Send(result taskresult.Message) bool {
+func (s *Sender) Send(result taskresult.Message, messageType ...any) bool {
+	typeName := s.responseType(messageType...)
 	if result.EncodedResponse != nil {
-		return s.deliver(result.EncodedResponse)
+		return s.deliver(Response{Message: result.EncodedResponse, Type: typeName})
 	}
 
 	data, err := s.encoder.Marshal(result.Result, result.Err)
 	if err == nil {
-		return s.deliver(data)
+		return s.deliver(Response{Message: data, Type: typeName})
 	}
 
 	s.logger.Log(logger.ERROR, fmt.Sprintf("failed to marshal response for path %s with id %s: %v", s.path, s.messageID, err))
@@ -79,10 +85,23 @@ func (s *Sender) Send(result taskresult.Message) bool {
 		s.logger.Log(logger.ERROR, fmt.Sprintf("failed to marshal fallback response for path %s with id %s: %v", s.path, s.messageID, fallbackErr))
 		return false
 	}
-	return s.deliver(fallback)
+	return s.deliver(Response{Message: fallback, Type: typeName})
 }
 
-func (s *Sender) deliver(data []byte) bool {
+func (s *Sender) responseType(messageType ...any) string {
+	if len(messageType) == 0 {
+		return s.encoder.MessageType()
+	}
+
+	typeName, ok := messageType[0].(string)
+	if !ok || typeName == "" {
+		s.logger.Log(logger.WARN, fmt.Sprintf("invalid response type for path %s with id %s; using sender type", s.path, s.messageID))
+		return s.encoder.MessageType()
+	}
+	return typeName
+}
+
+func (s *Sender) deliver(data Response) bool {
 	select {
 	case s.out <- data:
 		return true
@@ -95,17 +114,25 @@ func (s judgeEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, er
 	return NewJudgeResponse(s.messageID, result, taskErr).Marshal(), nil
 }
 
+func (s judgeEncoder) MessageType() string { return s.messageType }
+
 func (s generateEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, error) {
 	return NewGenerateResponse(s.messageID, s.problemID, result, taskErr).Marshal()
 }
+
+func (s generateEncoder) MessageType() string { return constants.Generate }
 
 func (s validateEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, error) {
 	return NewValidateResponse(s.messageID, s.problemID, result, taskErr).Marshal()
 }
 
+func (s validateEncoder) MessageType() string { return constants.Validate }
+
 func (s checkEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, error) {
 	return NewCheckResponse(s.messageID, s.problemID, result, taskErr).Marshal()
 }
+
+func (s checkEncoder) MessageType() string { return constants.Check }
 
 func newGenerateEncoder(messageID string, data []byte) (encoder, error) {
 	problemID, err := problemIDFrom(data)

--- a/apps/iris/src/router/response/sender.go
+++ b/apps/iris/src/router/response/sender.go
@@ -13,14 +13,14 @@ import (
 
 type encoder interface {
 	Marshal(result json.RawMessage, taskErr error) ([]byte, error)
-	MessageType() string
+	MessageType() constants.MessageType
 }
 
 // Sender owns response encoding and cancellation-aware delivery for one routed message.
 type Sender struct {
 	ctx       context.Context
 	out       chan<- Response
-	path      string
+	path      constants.MessageType
 	messageID string
 	encoder   encoder
 	logger    logger.Logger
@@ -28,7 +28,7 @@ type Sender struct {
 
 type judgeEncoder struct {
 	messageID   string
-	messageType string
+	messageType constants.MessageType
 }
 type generateEncoder struct {
 	messageID string
@@ -45,7 +45,7 @@ type checkEncoder struct {
 
 // NewSender selects the response contract and owns delivery for one message.
 // problemId belongs only to tool contracts and is extracted by those encoders.
-func NewSender(ctx context.Context, out chan<- Response, path, messageID string, data []byte, logger logger.Logger) (*Sender, error) {
+func NewSender(ctx context.Context, out chan<- Response, path constants.MessageType, messageID string, data []byte, logger logger.Logger) (*Sender, error) {
 	encoder, err := newEncoder(path, messageID, data)
 	if encoder == nil {
 		return nil, err
@@ -53,10 +53,16 @@ func NewSender(ctx context.Context, out chan<- Response, path, messageID string,
 	return &Sender{ctx: ctx, out: out, path: path, messageID: messageID, encoder: encoder, logger: logger}, err
 }
 
-func newEncoder(path, messageID string, data []byte) (encoder, error) {
+func newEncoder(path constants.MessageType, messageID string, data []byte) (encoder, error) {
 	switch path {
-	case constants.Judge, constants.SpecialJudge, constants.Run, constants.UserTestCase:
-		return judgeEncoder{messageID: messageID, messageType: path}, nil
+	case constants.Judge:
+		return judgeEncoder{messageID: messageID, messageType: constants.Judge}, nil
+	case constants.SpecialJudge:
+		return judgeEncoder{messageID: messageID, messageType: constants.SpecialJudge}, nil
+	case constants.Run:
+		return judgeEncoder{messageID: messageID, messageType: constants.Run}, nil
+	case constants.UserTestCase:
+		return judgeEncoder{messageID: messageID, messageType: constants.UserTestCase}, nil
 	case constants.Generate:
 		return newGenerateEncoder(messageID, data)
 	case constants.Validate:
@@ -68,7 +74,7 @@ func newEncoder(path, messageID string, data []byte) (encoder, error) {
 	}
 }
 
-func (s *Sender) Send(result taskresult.Message, messageType ...any) bool {
+func (s *Sender) Send(result taskresult.Message, messageType ...constants.MessageType) bool {
 	typeName := s.responseType(messageType...)
 	if result.EncodedResponse != nil {
 		return s.deliver(Response{Message: result.EncodedResponse, Type: typeName})
@@ -88,17 +94,16 @@ func (s *Sender) Send(result taskresult.Message, messageType ...any) bool {
 	return s.deliver(Response{Message: fallback, Type: typeName})
 }
 
-func (s *Sender) responseType(messageType ...any) string {
+func (s *Sender) responseType(messageType ...constants.MessageType) constants.MessageType {
 	if len(messageType) == 0 {
 		return s.encoder.MessageType()
 	}
 
-	typeName, ok := messageType[0].(string)
-	if !ok || typeName == "" {
+	if len(messageType) != 1 || messageType[0] == "" {
 		s.logger.Log(logger.WARN, fmt.Sprintf("invalid response type for path %s with id %s; using sender type", s.path, s.messageID))
 		return s.encoder.MessageType()
 	}
-	return typeName
+	return messageType[0]
 }
 
 func (s *Sender) deliver(data Response) bool {
@@ -114,25 +119,25 @@ func (s judgeEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, er
 	return NewJudgeResponse(s.messageID, result, taskErr).Marshal(), nil
 }
 
-func (s judgeEncoder) MessageType() string { return s.messageType }
+func (s judgeEncoder) MessageType() constants.MessageType { return s.messageType }
 
 func (s generateEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, error) {
 	return NewGenerateResponse(s.messageID, s.problemID, result, taskErr).Marshal()
 }
 
-func (s generateEncoder) MessageType() string { return constants.Generate }
+func (s generateEncoder) MessageType() constants.MessageType { return constants.Generate }
 
 func (s validateEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, error) {
 	return NewValidateResponse(s.messageID, s.problemID, result, taskErr).Marshal()
 }
 
-func (s validateEncoder) MessageType() string { return constants.Validate }
+func (s validateEncoder) MessageType() constants.MessageType { return constants.Validate }
 
 func (s checkEncoder) Marshal(result json.RawMessage, taskErr error) ([]byte, error) {
 	return NewCheckResponse(s.messageID, s.problemID, result, taskErr).Marshal()
 }
 
-func (s checkEncoder) MessageType() string { return constants.Check }
+func (s checkEncoder) MessageType() constants.MessageType { return constants.Check }
 
 func newGenerateEncoder(messageID string, data []byte) (encoder, error) {
 	problemID, err := problemIDFrom(data)

--- a/apps/iris/src/router/response/sender_test.go
+++ b/apps/iris/src/router/response/sender_test.go
@@ -3,20 +3,22 @@ package response
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/skkuding/codedang/apps/iris/src/common/constants"
 )
 
 func TestNewEncoderUsesToolSpecificResponse(t *testing.T) {
 	tests := []struct {
-		path     string
+		path     constants.MessageType
 		toolType string
 	}{
-		{path: "generate", toolType: "generator"},
-		{path: "validate", toolType: "validator"},
-		{path: "check", toolType: "checker"},
+		{path: constants.Generate, toolType: "generator"},
+		{path: constants.Validate, toolType: "validator"},
+		{path: constants.Check, toolType: "checker"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
+		t.Run(string(tt.path), func(t *testing.T) {
 			encoder, err := newEncoder(tt.path, "message", []byte(`{"problemId": 42}`))
 			if err != nil {
 				t.Fatalf("newEncoder() error = %v", err)
@@ -42,7 +44,7 @@ func TestNewEncoderUsesToolSpecificResponse(t *testing.T) {
 }
 
 func TestNewEncoderRejectsUnsupportedPath(t *testing.T) {
-	encoder, err := newEncoder("unknown", "message", nil)
+	encoder, err := newEncoder(constants.MessageType("unknown"), "message", nil)
 	if encoder != nil {
 		t.Fatal("newEncoder() encoder must be nil for an unsupported path")
 	}

--- a/apps/iris/src/router/router.go
+++ b/apps/iris/src/router/router.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	instrumentation "github.com/skkuding/codedang/apps/iris/src"
+	"github.com/skkuding/codedang/apps/iris/src/common/constants"
 	"github.com/skkuding/codedang/apps/iris/src/handler"
 	"github.com/skkuding/codedang/apps/iris/src/handler/generate"
 	"github.com/skkuding/codedang/apps/iris/src/handler/judge"
@@ -17,19 +18,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const (
-	Judge        = "judge"
-	SpecialJudge = "specialJudge"
-	Run          = "run"
-	Interactive  = "interactive"
-	UserTestCase = "userTestCase"
-	Generate     = "generate"
-	Validate     = "validate"
-	Check        = "check"
-)
-
 type Router interface {
-	Route(path string, id string, data []byte, resultChan chan<- []byte, ctx context.Context)
+	Route(path string, id string, data []byte, resultChan chan<- response.Response, ctx context.Context)
 }
 
 type router struct {
@@ -40,6 +30,11 @@ type router struct {
 	validateTaskFactory *validate.Factory
 	logger              logger.Logger
 	tracer              trace.Tracer
+}
+
+type taskResult struct {
+	message     handler.ResultMessage
+	messageType []any
 }
 
 func NewRouter(
@@ -62,7 +57,7 @@ func NewRouter(
 	}
 }
 
-func (r *router) Route(path string, id string, data []byte, out chan<- []byte, ctx context.Context) {
+func (r *router) Route(path string, id string, data []byte, out chan<- response.Response, ctx context.Context) {
 	span := trace.SpanFromContext(ctx)
 	tracer := otel.GetTracerProvider().Tracer("Router Tracer")
 	newCtx, childSpan := tracer.Start(
@@ -79,21 +74,21 @@ func (r *router) Route(path string, id string, data []byte, out chan<- []byte, c
 	// var handlerResult json.RawMessage
 	// var err error
 
-	taskResultChan := make(chan handler.ResultMessage)
+	taskResultChan := make(chan taskResult)
 	var task handler.Task
 	var taskErr error
 
 	r.logger.Log(logger.INFO, fmt.Sprintf("%s message received", path))
 	switch path {
-	case Judge, SpecialJudge:
+	case constants.Judge, constants.SpecialJudge:
 		task, taskErr = r.judgeTaskFactory.Create(path, data)
-	case Run, UserTestCase:
+	case constants.Run, constants.UserTestCase:
 		task, taskErr = r.runTaskFactory.Create(path, data)
-	case Generate:
+	case constants.Generate:
 		task, taskErr = r.generateTaskFactory.Create(path, data)
-	case Validate:
+	case constants.Validate:
 		task, taskErr = r.validateTaskFactory.Create(path, data)
-	case Check:
+	case constants.Check:
 		// task, taskErr = r.checkTaskFactory.Create(path, data)
 		// TODO: implement check factory
 		taskErr = fmt.Errorf("check handler not implemented yet")
@@ -126,17 +121,17 @@ func (r *router) Route(path string, id string, data []byte, out chan<- []byte, c
 	r.logger.Log(logger.INFO, fmt.Sprintf("Running task for path %s with id %s", path, id))
 	go func() {
 		defer close(taskResultChan)
-		r.runner.Run(newCtx, id, task, func(result handler.ResultMessage) {
+		r.runner.Run(newCtx, id, task, func(result handler.ResultMessage, messageType ...any) {
 			select {
-			case taskResultChan <- result:
+			case taskResultChan <- taskResult{message: result, messageType: messageType}:
 			case <-newCtx.Done():
 			}
 		})
 	}()
 
 	for result := range taskResultChan {
-		r.errHandle(result.Err)
-		if !sender.Send(result) {
+		r.errHandle(result.message.Err)
+		if !sender.Send(result.message, result.messageType...) {
 			return
 		}
 	}

--- a/apps/iris/src/router/router.go
+++ b/apps/iris/src/router/router.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Router interface {
-	Route(path string, id string, data []byte, resultChan chan<- response.Response, ctx context.Context)
+	Route(path constants.MessageType, id string, data []byte, resultChan chan<- response.Response, ctx context.Context)
 }
 
 type router struct {
@@ -34,7 +34,7 @@ type router struct {
 
 type taskResult struct {
 	message     handler.ResultMessage
-	messageType []any
+	messageType []constants.MessageType
 }
 
 func NewRouter(
@@ -57,7 +57,7 @@ func NewRouter(
 	}
 }
 
-func (r *router) Route(path string, id string, data []byte, out chan<- response.Response, ctx context.Context) {
+func (r *router) Route(path constants.MessageType, id string, data []byte, out chan<- response.Response, ctx context.Context) {
 	span := trace.SpanFromContext(ctx)
 	tracer := otel.GetTracerProvider().Tracer("Router Tracer")
 	newCtx, childSpan := tracer.Start(
@@ -81,13 +81,13 @@ func (r *router) Route(path string, id string, data []byte, out chan<- response.
 	r.logger.Log(logger.INFO, fmt.Sprintf("%s message received", path))
 	switch path {
 	case constants.Judge, constants.SpecialJudge:
-		task, taskErr = r.judgeTaskFactory.Create(path, data)
+		task, taskErr = r.judgeTaskFactory.Create(string(path), data)
 	case constants.Run, constants.UserTestCase:
-		task, taskErr = r.runTaskFactory.Create(path, data)
+		task, taskErr = r.runTaskFactory.Create(string(path), data)
 	case constants.Generate:
-		task, taskErr = r.generateTaskFactory.Create(path, data)
+		task, taskErr = r.generateTaskFactory.Create(string(path), data)
 	case constants.Validate:
-		task, taskErr = r.validateTaskFactory.Create(path, data)
+		task, taskErr = r.validateTaskFactory.Create(string(path), data)
 	case constants.Check:
 		// task, taskErr = r.checkTaskFactory.Create(path, data)
 		// TODO: implement check factory
@@ -108,7 +108,15 @@ func (r *router) Route(path string, id string, data []byte, out chan<- response.
 	if taskErr != nil {
 		r.logger.Log(logger.ERROR, fmt.Sprintf("Error creating task for path %s: %v", path, taskErr))
 		r.errHandle(taskErr)
-		sender.Send(handler.ResultMessage{Err: taskErr})
+		if !sender.Send(handler.ResultMessage{Err: taskErr}) {
+			return
+		}
+		if isSubmissionTask(path) {
+			judgeResponse := response.NewJudgeResponse(id, nil, taskErr)
+			sender.Send(handler.ResultMessage{
+				EncodedResponse: response.NewSubmissionResponse(id, []*response.JudgeResponse{judgeResponse}).Marshal(),
+			}, constants.Submission)
+		}
 		return
 	}
 
@@ -121,7 +129,7 @@ func (r *router) Route(path string, id string, data []byte, out chan<- response.
 	r.logger.Log(logger.INFO, fmt.Sprintf("Running task for path %s with id %s", path, id))
 	go func() {
 		defer close(taskResultChan)
-		r.runner.Run(newCtx, id, task, func(result handler.ResultMessage, messageType ...any) {
+		r.runner.Run(newCtx, id, task, func(result handler.ResultMessage, messageType ...constants.MessageType) {
 			select {
 			case taskResultChan <- taskResult{message: result, messageType: messageType}:
 			case <-newCtx.Done():
@@ -136,6 +144,15 @@ func (r *router) Route(path string, id string, data []byte, out chan<- response.
 		}
 	}
 	r.logger.Log(logger.DEBUG, "Router done...")
+}
+
+func isSubmissionTask(path constants.MessageType) bool {
+	switch path {
+	case constants.Judge, constants.SpecialJudge, constants.Run, constants.UserTestCase:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *router) errHandle(err error) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR decouples Iris response message types from the type of the incoming RabbitMQ request.

Previously, the RabbitMQ connector published every response using the original request message type. This worked while a request produced only one kind of response, but it became incorrect for judge/run tasks: a single `judge` request can produce multiple per-testcase judge responses and one final submission response. Because the connector always reused the request type, both response kinds were published as `judge`.

As a result, the transport contract could not express the semantic difference between:

- a per-testcase judge result; and
- the final submission-complete result containing all judge results.

This PR makes the response type part of Iris’s outbound response flow.

### What changed

- Added `response.Response`, which carries both the encoded response body and its RabbitMQ message type.
- Updated `response.Sender` to construct and deliver `Response` values instead of raw `[]byte` payloads.
- Each response encoder now provides its own default response type when a task does not explicitly specify one.
  - Judge / SpecialJudge / Run / UserTestCase use their corresponding task response type.
  - Generate / Validate / Check use their corresponding tool response type.
- Updated the Router to preserve an explicitly supplied response type from a task and forward it to the Sender.
- Updated the RabbitMQ connector to publish `response.Response.Type` instead of always reusing `message.Type` from the inbound delivery.
- Marked final `SubmissionResponse` messages from Judge and Run tasks with the explicit `submission` type, including setup-failure paths.

With this change, a `judge` request can now publish:

1. `judge` messages for individual testcase results; and
2. a `submission` message for the final aggregated result.

This keeps response-type selection close to the task/response layer, while the RabbitMQ connector remains responsible only for transport and publishing.

### Additional context
This refactoring builds on the Sender-based response flow introduced by #3495.

The key design goal is to avoid making the RabbitMQ connector infer response semantics from the JSON body. The connector should not need to know whether a payload is a judge result, a submission completion message, or a Polygon tool result. Instead, the task/response layer determines the outbound type and passes it through Router → Sender → RabbitMQ producer.

Reviewers may want to focus on:

- whether the default response types assigned by each sender match the intended RabbitMQ contract;
- whether all final submission paths are explicitly marked as `submission`, including setup failures;
- whether preserving the task-provided response type through Router is preferable to connector-side payload inspection.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

closes TAS-2872

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent response type labels across judging, submission, validation, and execution workflows.
  * Improved response delivery by preserving message metadata during routing and messaging.
  * Added support for specifying response types when sending results.

* **Bug Fixes**
  * Improved handling of responses with missing type or message identifier information.
  * Ensured routed responses retain their original metadata.
  * Improved error handling when task-creation responses cannot be delivered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->