### PR TITLE
feat(be): accept student id for course registration

### DIFF
--- a/apps/backend/apps/client/src/group/dto/join-course.dto.ts
+++ b/apps/backend/apps/client/src/group/dto/join-course.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumberString } from 'class-validator'
+
+export class JoinCourseDto {
+  @IsNumberString()
+  @IsNotEmpty()
+  readonly studentId: string
+}

--- a/apps/backend/apps/client/src/group/group.controller.spec.ts
+++ b/apps/backend/apps/client/src/group/group.controller.spec.ts
@@ -1,8 +1,10 @@
 import { Test, type TestingModule } from '@nestjs/testing'
 import { expect } from 'chai'
+import * as sinon from 'sinon'
 import { RolesService } from '@libs/auth'
-import { GroupController } from './group.controller'
-import { GroupService } from './group.service'
+import type { AuthenticatedRequest } from '@libs/auth'
+import { CourseController, GroupController } from './group.controller'
+import { CourseService, GroupService } from './group.service'
 
 describe('GroupController', () => {
   let controller: GroupController
@@ -21,5 +23,37 @@ describe('GroupController', () => {
 
   it('should be defined', () => {
     expect(controller).to.be.ok
+  })
+})
+
+describe('CourseController', () => {
+  const joinGroupById = sinon.stub()
+  let controller: CourseController
+
+  beforeEach(async () => {
+    joinGroupById.reset()
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CourseController],
+      providers: [
+        { provide: GroupService, useValue: { joinGroupById } },
+        { provide: CourseService, useValue: {} },
+        { provide: RolesService, useValue: {} }
+      ]
+    }).compile()
+
+    controller = module.get<CourseController>(CourseController)
+  })
+
+  it('should pass studentId to group service when joining a course', async () => {
+    const request = { user: { id: 7 } } as AuthenticatedRequest
+    joinGroupById.resolves({ userGroupData: {}, isJoined: true })
+
+    await controller.joinCourseById(request, 2, '123456', {
+      studentId: '2024000000'
+    })
+
+    expect(joinGroupById.calledOnceWithExactly(7, 2, '123456', '2024000000')).to
+      .be.true
   })
 })

--- a/apps/backend/apps/client/src/group/group.controller.ts
+++ b/apps/backend/apps/client/src/group/group.controller.ts
@@ -32,6 +32,7 @@ import type {
   CreateCourseNoticeCommentDto,
   UpdateCourseNoticeCommentDto
 } from './dto/courseNotice.dto'
+import { JoinCourseDto } from './dto/join-course.dto'
 import {
   CreateCourseQnADto,
   CreateCourseQnACommentDto,
@@ -112,12 +113,14 @@ export class CourseController {
   async joinCourseById(
     @Req() req: AuthenticatedRequest,
     @Param('groupId', GroupIDPipe) groupId: number,
-    @Query('invitation') invitation: string
+    @Query('invitation') invitation: string,
+    @Body() joinCourseDto: JoinCourseDto
   ) {
     return await this.groupService.joinGroupById(
       req.user.id,
       groupId,
-      invitation
+      invitation,
+      joinCourseDto.studentId
     )
   }
 

--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -252,7 +252,12 @@ describe('GroupService', () => {
     it('should return {isJoined: true} when group not set as requireApprovalBeforeJoin', async () => {
       groupId = await createTestGroup()
       sandbox.stub(cache, 'get').resolves(groupId)
-      const res = await service.joinGroupById(userId, groupId, 'invitationCode')
+      const res = await service.joinGroupById(
+        userId,
+        groupId,
+        'invitationCode',
+        '2024000000'
+      )
       const userGroupData: UserGroupData = {
         userId,
         groupId,
@@ -285,7 +290,7 @@ describe('GroupService', () => {
       })
 
       await expect(
-        service.joinGroupById(userId, groupId, 'invitationCode')
+        service.joinGroupById(userId, groupId, 'invitationCode', '2024000000')
       ).to.be.rejectedWith(ConflictFoundException)
     })
   })

--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -316,6 +316,7 @@ export class GroupService {
    * @param userId - 사용자 ID
    * @param groupId - 가입할 그룹 ID
    * @param invitation - (선택) 초대 코드
+   * @param studentId - 학생이 입력한 학번
    * @returns 가입 결과 (바로 가입되었는지 `isJoined: true`, 요청 상태인지 `isJoined: false`)
    *
    * @throws ForbiddenAccessException - 초대 코드가 유효하지 않거나, 화이트리스트에 없는 경우
@@ -329,8 +330,12 @@ export class GroupService {
   async joinGroupById(
     userId: number,
     groupId: number,
-    invitation: string
+    invitation: string,
+    studentId: string
   ): Promise<{ userGroupData: Partial<UserGroup>; isJoined: boolean }> {
+    // The enrollment verification task will use this value for roster matching.
+    void studentId
+
     const invitedGroupId = await this.cacheManager.get<number>(
       invitationCodeKey(invitation)
     )

--- a/collection/client/Course/Join course by id/Succeed.bru
+++ b/collection/client/Course/Join course by id/Succeed.bru
@@ -6,7 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/course/2/join?invitation
-  body: none
+  body: json
   auth: none
 }
 
@@ -14,10 +14,16 @@ params:query {
   invitation: 
 }
 
+body:json {
+  {
+    "studentId": "2024100001"
+  }
+}
+
 assert {
   res.status: eq 201
   res("userGroupData").userId: isNumber
-  res("userGroupData").groupId: eq 4
+  res("userGroupData").groupId: eq 2
   res("userGroupData").isGroupLeader: eq false
   res("userGroupData").createTime: isString
   res("userGroupData").updateTime: isString
@@ -33,7 +39,7 @@ script:pre-request {
   const authorization = bru.getVar("jwtToken");
   try {
     await axios.delete(
-      baseUrl + "/group/2/leave",
+      baseUrl + "/course/2/leave",
       { headers: { authorization } }
     )
   } catch (error) {}
@@ -44,6 +50,7 @@ docs {
   ---
   - URL param으로 전달된 `groupId`에 해당하는 Group에 가입합니다.
   - URL Query로 `invitation` 초대 코드를 전달할 수 있습니다.
+  - JSON body로 학생이 입력한 `studentId`를 전달합니다.
   - 가입된 Group의 정보를 반환합니다.
   - Instructor가 학번 whitelist를 설정한 경우 초대 코드가 있어도 못 들어갈 수 있습니다.
 }

--- a/collection/client/Course/Join course by id/[400] Invalid Student ID.bru
+++ b/collection/client/Course/Join course by id/[400] Invalid Student ID.bru
@@ -1,0 +1,35 @@
+meta {
+  name: [400] Invalid Student ID
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/course/2/join?invitation
+  body: json
+  auth: none
+}
+
+params:query {
+  invitation:
+}
+
+body:json {
+  {
+    "studentId": "invalid-id"
+  }
+}
+
+assert {
+  res.status: eq 400
+}
+
+script:pre-request {
+  await require("./login").loginUser(req);
+}
+
+docs {
+  # Join Group by Id - Invalid Student ID
+  ---
+  - 숫자 문자열이 아닌 `studentId`를 전달하면 `400 Bad Request`를 반환합니다.
+}

--- a/collection/client/Course/Join course by id/[400] Missing Student ID.bru
+++ b/collection/client/Course/Join course by id/[400] Missing Student ID.bru
@@ -1,0 +1,33 @@
+meta {
+  name: [400] Missing Student ID
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/course/2/join?invitation
+  body: json
+  auth: none
+}
+
+params:query {
+  invitation:
+}
+
+body:json {
+  {}
+}
+
+assert {
+  res.status: eq 400
+}
+
+script:pre-request {
+  await require("./login").loginUser(req);
+}
+
+docs {
+  # Join Group by Id - Missing Student ID
+  ---
+  - `studentId`가 누락되면 `400 Bad Request`를 반환합니다.
+}


### PR DESCRIPTION
학생이 강의 등록을 요청할 때 입력한 학번을 백엔드에서 전달받을 수 있도록 수강 등록 API를 수정합니다.

  기존 API는 초대 코드만 전달받았기 때문에, 후속 수강생 명단 검증 로직에서 학생이 입력한 학번을 사용할 수 없었습니다. 이번 PR에서는 학번을
  request body로 받아 검증한 뒤 서비스 계층까지 전달합니다.

  이 PR은 전체 강의 등록 개선 Task의 하위 작업이며, `t2831-implement-course-register` 브랜치를 대상으로 합니다.

  Closes TAS-2848

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
