### PR TITLE
fix(be): allow course staff to delete other users' course notice comm…

### DIFF
--- a/apps/backend/apps/client/src/group/group.service.spec.ts
+++ b/apps/backend/apps/client/src/group/group.service.spec.ts
@@ -9,7 +9,8 @@ import chaiExclude from 'chai-exclude'
 import * as sinon from 'sinon'
 import {
   ConflictFoundException,
-  EntityNotExistException
+  EntityNotExistException,
+  ForbiddenAccessException
 } from '@libs/exception'
 import {
   PrismaService,
@@ -346,6 +347,102 @@ describe('GroupService', () => {
       const res = await service.getGroupLeaders(2)
 
       expect(res).to.deep.equal(['instructor', 'user01'])
+    })
+  })
+
+  describe('deleteComment', () => {
+    let groupId: number
+    let courseNoticeId: number
+
+    beforeEach(async () => {
+      const group = await transaction.group.create({
+        data: {
+          groupName: 'test course',
+          description: 'test',
+          config: {
+            allowJoinFromSearch: true,
+            requireApprovalBeforeJoin: false,
+            allowJoinWithURL: true
+          }
+        }
+      })
+      groupId = group.id
+
+      const courseNotice = await transaction.courseNotice.create({
+        data: {
+          groupId,
+          title: 'test notice',
+          content: 'test content',
+          isPublic: true
+        }
+      })
+      courseNoticeId = courseNotice.id
+    })
+
+    it('should allow the author to delete their own comment', async () => {
+      const comment = await transaction.courseNoticeComment.create({
+        data: {
+          courseNoticeId,
+          createdById: 4,
+          content: 'test comment'
+        }
+      })
+
+      const res = await service.deleteComment({
+        userId: 4,
+        id: courseNoticeId,
+        commentId: comment.id
+      })
+
+      expect(res.id).to.equal(comment.id)
+
+      const found = await transaction.courseNoticeComment.findUnique({
+        where: { id: comment.id }
+      })
+      expect(found).to.be.null
+    })
+
+    it('should throw ForbiddenAccessException when a non-author, non-staff user tries to delete', async () => {
+      const comment = await transaction.courseNoticeComment.create({
+        data: {
+          courseNoticeId,
+          createdById: 4,
+          content: 'test comment'
+        }
+      })
+
+      await expect(
+        service.deleteComment({
+          userId: 7,
+          id: courseNoticeId,
+          commentId: comment.id
+        })
+      ).to.be.rejectedWith(ForbiddenAccessException)
+    })
+
+    it("should allow course staff to delete another user's comment", async () => {
+      await transaction.userGroup.create({
+        data: {
+          userId: 5,
+          groupId,
+          isGroupLeader: true
+        }
+      })
+      const comment = await transaction.courseNoticeComment.create({
+        data: {
+          courseNoticeId,
+          createdById: 4,
+          content: 'test comment'
+        }
+      })
+
+      const res = await service.deleteComment({
+        userId: 5,
+        id: courseNoticeId,
+        commentId: comment.id
+      })
+
+      expect(res.id).to.equal(comment.id)
     })
   })
 })

--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -1417,10 +1417,10 @@ export class GroupService {
     const comment = await this.prisma.courseNoticeComment.findUnique({
       where: {
         id: commentId,
-        courseNoticeId: id,
-        createdById: userId
+        courseNoticeId: id
       },
       select: {
+        createdById: true,
         replyOn: {
           select: {
             id: true,
@@ -1447,13 +1447,30 @@ export class GroupService {
       throw new EntityNotExistException('CourseNoticeComment')
     }
 
+    const courseNotice = await this.prisma.courseNotice.findUniqueOrThrow({
+      where: { id },
+      select: { groupId: true }
+    })
+
+    const isCourseStaff =
+      (await this.prisma.userGroup.findFirst({
+        where: {
+          userId,
+          groupId: courseNotice.groupId,
+          isGroupLeader: true
+        }
+      })) !== null
+
+    if (comment.createdById !== userId && !isCourseStaff) {
+      throw new ForbiddenAccessException('You are not allowed to delete')
+    }
+
     if (comment._count.CourseNoticeComment > 0) {
       // 답글이 존재할 때
       return await this.prisma.courseNoticeComment.update({
         where: {
           id: commentId,
-          courseNoticeId: id,
-          createdById: userId
+          courseNoticeId: id
         },
         data: {
           isDeleted: true,
@@ -1481,8 +1498,7 @@ export class GroupService {
     return await this.prisma.courseNoticeComment.delete({
       where: {
         id: commentId,
-        courseNoticeId: id,
-        createdById: userId
+        courseNoticeId: id
       }
     })
   }


### PR DESCRIPTION
…ents

### Description

`deleteComment`에서 `createdById: userId`가 Prisma `where` 조건에 포함되어 있어
댓글 작성자 본인만 댓글을 삭제할 수 있었습니다. 

이를 `deleteCourseQnAComment`의 기존 권한 처리 방식과 동일하게 수정하여,
댓글 작성자 본인 또는 해당 강좌의 course staff(`UserGroup.isGroupLeader`)가
댓글을 삭제할 수 있도록 변경했습니다.

또한 댓글 존재 여부와 삭제 권한 검사를 분리하고,
기존 soft delete 및 cascade delete 로직은 유지했습니다.

Closes TAS-2867

### Additional context

Course staff 여부를 확인하기 위해 `courseNotice.groupId`를 조회합니다.
현재 `isForbiddenNotice` 내부에서도 관련 조회가 수행되어 일부 중복이 있지만,
이번 PR에서는 권한 수정 범위를 최소화하기 위해 별도 리팩터링은 하지 않았습니다.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course staff can now delete comments posted by other users when authorized.
  * Comment authors can continue deleting their own comments.
  * Unauthorized users are prevented from deleting comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->