### PR TITLE
fix: align course q&a layout

### DIFF
--- a/apps/frontend/app/(client)/(main)/course/[courseId]/_components/CourseQnaTable.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/_components/CourseQnaTable.tsx
@@ -85,8 +85,8 @@ export function CourseQnaTable({ courseId }: CourseQnaTableProps) {
       columns={columns}
       defaultSortState={[{ id: 'createTime', desc: true }]}
     >
-      <div className="mb-6 flex items-center justify-between gap-4">
-        <div className="flex h-[44px] w-[390px] items-center rounded-full border border-gray-200 bg-white p-1 px-[5px] py-[5px]">
+      <div className="mb-6 flex flex-nowrap items-center justify-between gap-6">
+        <div className="flex h-[44px] min-w-0 max-w-[390px] flex-[3_1_0] items-center rounded-full border border-gray-200 bg-white p-1 px-[5px] py-[5px]">
           <button
             onClick={() => setFilterType('General')}
             className={cn(
@@ -111,7 +111,10 @@ export function CourseQnaTable({ courseId }: CourseQnaTableProps) {
           </button>
         </div>
 
-        <DataTableSearchBar columndId="title" />
+        <DataTableSearchBar
+          columndId="title"
+          containerClassName="w-full min-w-0 max-w-[280px] flex-[2_1_0]"
+        />
       </div>
       <DataTable
         getHref={(row: CourseQnaListItem) =>

--- a/apps/frontend/app/(client)/(main)/course/[courseId]/qna/page.tsx
+++ b/apps/frontend/app/(client)/(main)/course/[courseId]/qna/page.tsx
@@ -10,11 +10,11 @@ export default function QNA() {
   const courseId = Number(params.courseId)
   return (
     <div className="mt-20 flex flex-col gap-6 px-10">
-      <div className="mb-6 flex flex-nowrap items-center justify-between">
-        <span className="text-2xl font-semibold leading-[33.6px] tracking-[-0.48px]">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <span className="min-w-0 break-words text-2xl font-semibold leading-[33.6px] tracking-[-0.48px]">
           QUESTION & ANSWER
         </span>
-        <div className="mr-10 w-[84px]">
+        <div className="w-[120px] shrink-0">
           <QnAPostButton
             section="course"
             canCreateQnA={true}


### PR DESCRIPTION
Course Q&A 페이지에서 제목과 Post 버튼, 카테고리 탭과 SearchBar의 정렬이 어긋나는 문제를 수정했습니다.

- QUESTION & ANSWER 제목과 Post 버튼을 동일한 기준선에 정렬했습니다.
- GENERAL / PROBLEM 탭과 SearchBar가 같은 행에서 자연스럽게 배치되도록 수정했습니다.
- 화면 너비가 줄어들어도 각 컴포넌트가 겹치거나 영역 밖으로 밀려나지 않도록 너비 배분을 조정했습니다.


closes TAS-2825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Course Q&A pages now display up to 100 questions and answers.
  * Improved responsive sizing for Q&A filters and search.
  * Enhanced Q&A header layout for better title wrapping and consistent post button sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->