### PR TITLE
refactor(be): improve prisma query handling

### DIFF
--- a/apps/backend/apps/admin/src/check/check-sub.service.ts
+++ b/apps/backend/apps/admin/src/check/check-sub.service.ts
@@ -130,9 +130,14 @@ export class CheckSubscriptionService implements OnModuleInit {
       memberIds: number[]
     }[]
   > {
-    return await Promise.all(
-      clusters.map(async (cluster) => {
-        const clusterId = await this.prisma.plagiarismCluster.create({
+    return await this.prisma.$transaction(async (tx) => {
+      const results: {
+        clusterId: number
+        memberIds: number[]
+      }[] = []
+
+      for (const cluster of clusters) {
+        const { id: clusterId } = await tx.plagiarismCluster.create({
           data: {
             averageSimilarity: cluster.averageSimilarity,
             strength: cluster.strength
@@ -142,21 +147,21 @@ export class CheckSubscriptionService implements OnModuleInit {
           }
         })
 
-        cluster.members.forEach(async (memberId) => {
-          await this.prisma.submissionCluster.create({
-            data: {
-              submissionId: memberId,
-              clusterId: clusterId.id
-            }
-          })
+        await tx.submissionCluster.createMany({
+          data: cluster.members.map((memberId) => ({
+            submissionId: memberId,
+            clusterId
+          }))
         })
 
-        return {
-          clusterId: clusterId.id,
+        results.push({
+          clusterId,
           memberIds: cluster.members
-        }
-      })
-    )
+        })
+      }
+
+      return results
+    })
   }
 
   @Span()

--- a/apps/backend/apps/admin/src/problem/services/testcase.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/testcase.service.ts
@@ -549,23 +549,27 @@ export class TestcaseService {
     // e.g) [aaa.(in|out), aab.(in|out), aac.(in|out), ...]
     const originalFileNames = Object.keys(testcaseIdMapper).sort()
 
-    await this.prisma.$transaction(async (tx) => {
-      for (const [idx, name] of originalFileNames.entries()) {
-        const id = testcaseIdMapper[name]
+    // TODO: Refactor with chunk (for enormous testCases(over PostgreSQL parameter limit))
+    const values = originalFileNames.map((name, index) => {
+      const id = testcaseIdMapper[name]
 
-        await tx.problemTestcase.update({
-          where: {
-            id,
-            isOutdated: false
-          },
-          data: { order: idx + 1 }
-        })
-      }
+      return Prisma.sql`(${id}, ${index + 1})`
     })
+
+    await this.prisma.$executeRaw`
+      UPDATE "ProblemTestcase" AS testcase
+      SET "order" = input."order"
+      FROM (
+        VALUES ${Prisma.join(values)}
+      ) AS input(id, "order")
+      WHERE testcase.id = input.id
+        AND testcase."isOutdated" = false
+    `
 
     const testcaseIds = originalFileNames.map((name) => ({
       testcaseId: testcaseIdMapper[name]
     }))
+
     return testcaseIds
   }
 

--- a/apps/backend/apps/admin/src/problem/services/testcase.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/testcase.service.ts
@@ -563,7 +563,7 @@ export class TestcaseService {
         VALUES ${Prisma.join(values)}
       ) AS input(id, "order")
       WHERE testcase.id = input.id
-        AND testcase."isOutdated" = false
+        AND testcase."is_outdated" = false
     `
 
     const testcaseIds = originalFileNames.map((name) => ({

--- a/apps/backend/apps/admin/src/problem/services/testcase.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/testcase.service.ts
@@ -557,7 +557,7 @@ export class TestcaseService {
     })
 
     await this.prisma.$executeRaw`
-      UPDATE "ProblemTestcase" AS testcase
+      UPDATE "problem_testcase" AS testcase
       SET "order" = input."order"
       FROM (
         VALUES ${Prisma.join(values)}

--- a/apps/backend/apps/admin/src/problem/services/testcase.service.ts
+++ b/apps/backend/apps/admin/src/problem/services/testcase.service.ts
@@ -549,15 +549,18 @@ export class TestcaseService {
     // e.g) [aaa.(in|out), aab.(in|out), aac.(in|out), ...]
     const originalFileNames = Object.keys(testcaseIdMapper).sort()
 
-    originalFileNames.forEach(async (name, index) => {
-      const id = testcaseIdMapper[name]
-      await this.prisma.problemTestcase.update({
-        where: {
-          id,
-          isOutdated: false
-        },
-        data: { order: index + 1 }
-      })
+    await this.prisma.$transaction(async (tx) => {
+      for (const [idx, name] of originalFileNames.entries()) {
+        const id = testcaseIdMapper[name]
+
+        await tx.problemTestcase.update({
+          where: {
+            id,
+            isOutdated: false
+          },
+          data: { order: idx + 1 }
+        })
+      }
     })
 
     const testcaseIds = originalFileNames.map((name) => ({


### PR DESCRIPTION
### Description

**Changes**

1. `Array.prototype.forEach` does not await asynchronous callbacks, which makes it difficult to properly handle query results and detect failures.
2. Avoid using `Promise.all` for database queries, as concurrent execution can increase connection pool usage.
3. Use Prisma transactions with sequential queries to ensure atomicity and better connection management.

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating clusters and assigning members, ensuring related updates complete together.
  * Improved testcase ZIP uploads by applying testcase ordering consistently.
  * Prevented incomplete or partially applied changes during cluster creation and testcase processing.
* **Performance**
  * Streamlined bulk processing for faster cluster updates and testcase ZIP uploads.
  * Improved responsiveness when handling larger sets of cluster members or testcases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->