### PR TITLE
fix(infra): align stage database capacity with production

### DIFF
--- a/apps/backend/libs/prisma/src/prisma.service.ts
+++ b/apps/backend/libs/prisma/src/prisma.service.ts
@@ -16,10 +16,16 @@ export class PrismaService
 {
   private readonly logger = new Logger(PrismaService.name)
   constructor(private config: ConfigService) {
+    const databaseUrl = config.get<string>('DATABASE_URL')
+    const connectionLimit = config.get<string>('DATABASE_CONNECTION_LIMIT')
+
     super({
       datasources: {
         db: {
-          url: config.get('DATABASE_URL')
+          url:
+            databaseUrl && connectionLimit
+              ? `${databaseUrl}${databaseUrl.includes('?') ? '&' : '?'}connection_limit=${connectionLimit}`
+              : databaseUrl
         }
       },
       log: [

--- a/apps/iris/src/loader/postgres.go
+++ b/apps/iris/src/loader/postgres.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/lib/pq"
@@ -27,6 +28,13 @@ func NewPostgresDataSource(logProvider logger.Logger) (*Postgres, error) {
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to access database: %w", err)
+	}
+	if connectionLimit := os.Getenv("DATABASE_CONNECTION_LIMIT"); connectionLimit != "" {
+		maxOpenConnections, err := strconv.Atoi(connectionLimit)
+		if err != nil || maxOpenConnections <= 0 {
+			return nil, fmt.Errorf("invalid database connection limit %q", connectionLimit)
+		}
+		db.SetMaxOpenConns(maxOpenConnections)
 	}
 
 	return &Postgres{client: db, logger: logProvider}, nil

--- a/apps/plag/src/loader/postgres.go
+++ b/apps/plag/src/loader/postgres.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	_ "github.com/lib/pq"
@@ -29,6 +30,13 @@ func NewPostgresDataSource(ctx context.Context) (*Postgres, error) {
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to access database: %w", err)
+	}
+	if connectionLimit := os.Getenv("DATABASE_CONNECTION_LIMIT"); connectionLimit != "" {
+		maxOpenConnections, err := strconv.Atoi(connectionLimit)
+		if err != nil || maxOpenConnections <= 0 {
+			return nil, fmt.Errorf("invalid database connection limit %q", connectionLimit)
+		}
+		db.SetMaxOpenConns(maxOpenConnections)
 	}
 
 	return &Postgres{ctx, db}, nil

--- a/infra/k8s/admin-api/base/configmap.yaml
+++ b/infra/k8s/admin-api/base/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: admin-api-env
   namespace: admin-api
 data:
+  DATABASE_CONNECTION_LIMIT: '225'
   NODEMAILER_FROM: 'Codedang <noreply@codedang.com>'
   REDIS_HOST: 'redis.redis.svc.cluster.local'
   REDIS_PORT: '6379'

--- a/infra/k8s/client-api/base/configmap.yaml
+++ b/infra/k8s/client-api/base/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: client-api-env
   namespace: client-api
 data:
+  DATABASE_CONNECTION_LIMIT: '225'
   NODEMAILER_FROM: 'Codedang <noreply@codedang.com>'
   RABBITMQ_API_URL: 'http://rabbitmq.rabbitmq.svc.cluster.local:15672/api'
   RABBITMQ_DEFAULT_VHOST: 'vh'

--- a/infra/k8s/iris/base/configmap.yaml
+++ b/infra/k8s/iris/base/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: iris
 data:
   APP_ENV: 'stage' # Running in 'stage' temporarily because of errors from entrypoint.sh
+  DATABASE_CONNECTION_LIMIT: '225'
   TESTCASE_BUCKET_NAME: 'codedang-testcase'
   RABBITMQ_HOST: 'rabbitmq.rabbitmq.svc.cluster.local'
   RABBITMQ_PORT: '5671'

--- a/infra/k8s/plag/base/configmap.yaml
+++ b/infra/k8s/plag/base/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: plag
 data:
   APP_ENV: 'stage' # Running in 'stage' to match consistency with iris
+  DATABASE_CONNECTION_LIMIT: '225'
   CHECK_RESULT_BUCKET_NAME: 'codedang-plag-checks'
   RABBITMQ_HOST: 'rabbitmq.rabbitmq.svc.cluster.local'
   RABBITMQ_PORT: '5671'

--- a/infra/k8s/postgres/deployment-v18.yaml
+++ b/infra/k8s/postgres/deployment-v18.yaml
@@ -19,6 +19,10 @@ spec:
       containers:
         - name: postgres
           image: postgres:18.4-alpine@sha256:b6a16ed0eb96e2c362811f7eeb951eac8b459e7b40be4149ea5444aa7c65569b
+          args:
+            - -c
+            # Matches the production db.t4g.small RDS default.
+            - max_connections=225
           ports:
             - containerPort: 5432
           env:
@@ -58,7 +62,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: '1'
-              memory: 1Gi
+              memory: 2Gi
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql


### PR DESCRIPTION
### Description

- stage PostgreSQL의 `max_connections`를 production RDS와 동일한 225로 설정합니다.
- 컨테이너 메모리 제한을 production DB 사양과 동일한 2Gi로 조정합니다.
- `prisma`, `iris`, `plag`, `admin-api`, `client-api` 에도 백엔드에서 요청한 대로 pod당 225개 연결 한도를 둡니다.

### Additional context

RAM 할당량 및 `max_connections` 값은 production의 `db.t4g.small` RDS 기본 파라미터를 기준으로 설정했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the Contributing Guidelines
- [x] Follow the Commit Convention
- [x] Provide a description of what this PR solves
- [ ] Include relevant tests

Closes TAS-2886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Increased the PostgreSQL connection limit to support more simultaneous connections.
  * Increased the database container memory limit from 1 GiB to 2 GiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->