### PR TITLE
fix(be): allow course staff to delete course notice comments

### DIFF
--- a/apps/backend/apps/client/src/group/group.controller.ts
+++ b/apps/backend/apps/client/src/group/group.controller.ts
@@ -292,6 +292,7 @@ export class CourseController {
   ) {
     return await this.groupService.deleteComment({
       userId: req.user.id,
+      userRole: req.user.role,
       id,
       commentId
     })

--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -1414,7 +1414,9 @@ export class GroupService {
     id: number
     commentId: number
   }) {
-    if (await this.isForbiddenNotice({ id, userId })) {
+    const isSiteAdmin = userRole === Role.Admin || userRole === Role.SuperAdmin
+
+    if (!isSiteAdmin && (await this.isForbiddenNotice({ id, userId }))) {
       throw new ForbiddenAccessException('it is not accessible course notice')
     }
 
@@ -1457,8 +1459,7 @@ export class GroupService {
     }
 
     const isCourseStaff =
-      userRole === Role.Admin ||
-      userRole === Role.SuperAdmin ||
+      isSiteAdmin ||
       (await this.prisma.userGroup.findFirst({
         where: {
           userId,

--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -1405,10 +1405,12 @@ export class GroupService {
    */
   async deleteComment({
     userId,
+    userRole,
     id,
     commentId
   }: {
     userId: number
+    userRole: Role
     id: number
     commentId: number
   }) {
@@ -1455,6 +1457,8 @@ export class GroupService {
     }
 
     const isCourseStaff =
+      userRole === Role.Admin ||
+      userRole === Role.SuperAdmin ||
       (await this.prisma.userGroup.findFirst({
         where: {
           userId,

--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -1398,8 +1398,10 @@ export class GroupService {
    * @param {number} id 댓글이 달려있는 강의 공지사항의 아이디
    * @param {number} commentId 삭제하려는 댓글의 아이디
    * @returns
-   * @throws {NotFoundException}
-   * - 댓글 아이디, 강의 아이디, 유저 아이디가 일치하는 댓글이 없을 때
+   * @throws {EntityNotExistException}
+   * - 댓글 아이디, 강의 아이디가 일치하는 댓글이 없을 때
+   * @throws {ForbiddenAccessException}
+   * - 댓글 작성자 본인도, 강좌 담당자(Group Leader/Admin/SuperAdmin)도 아닐 때
    */
   async deleteComment({
     userId,
@@ -1417,10 +1419,15 @@ export class GroupService {
     const comment = await this.prisma.courseNoticeComment.findUnique({
       where: {
         id: commentId,
-        courseNoticeId: id,
-        createdById: userId
+        courseNoticeId: id
       },
       select: {
+        createdById: true,
+        courseNotice: {
+          select: {
+            groupId: true
+          }
+        },
         replyOn: {
           select: {
             id: true,
@@ -1447,13 +1454,26 @@ export class GroupService {
       throw new EntityNotExistException('CourseNoticeComment')
     }
 
+    const isCourseStaff =
+      (await this.prisma.userGroup.findFirst({
+        where: {
+          userId,
+          groupId: comment.courseNotice.groupId,
+          isGroupLeader: true
+        }
+      })) !== null
+
+    if (comment.createdById !== userId && !isCourseStaff) {
+      // 댓글 작성자 본인도 아니고, 강좌 담당자(Group Leader/Admin/SuperAdmin)도 아닐 때
+      throw new ForbiddenAccessException('it is not accessible comment')
+    }
+
     if (comment._count.CourseNoticeComment > 0) {
       // 답글이 존재할 때
       return await this.prisma.courseNoticeComment.update({
         where: {
           id: commentId,
-          courseNoticeId: id,
-          createdById: userId
+          courseNoticeId: id
         },
         data: {
           isDeleted: true,
@@ -1481,8 +1501,7 @@ export class GroupService {
     return await this.prisma.courseNoticeComment.delete({
       where: {
         id: commentId,
-        courseNoticeId: id,
-        createdById: userId
+        courseNoticeId: id
       }
     })
   }


### PR DESCRIPTION
### Description

#### Problem

강좌의 Notice 댓글은 기존에 **댓글 작성자 본인만 삭제할 수 있도록 구현**되어 있었습니다.

이로 인해 부적절한 댓글이 작성되더라도 교수님/조교님과 같은 Group Leader 에게 삭제 권한이 없다는 문제점이 있었습니다.
로직 분석 및 PR 리뷰 과정에서 코드당 플랫폼의 관리자인 Admin/SuperAdmin 또한 댓글을 삭제할 수 있는 기능이 없는 것을 추가적으로 확인하였습니다.

따라서, **댓글 작성자뿐만 아니라 Group Leader와 사이트 Admin/SuperAdmin도 다른 사용자의 Notice 댓글을 삭제할 수 있도록 권한을 추가**하고자 합니다.

#### Solution

QnA 댓글 삭제 로직에서는 댓글 작성자뿐만 아니라 `isGroupLeader: true`인 Course Staff도 다른 사용자의 댓글을 삭제할 수 있도록 구현되어 있습니다. (QnA에서 GroupLeader는 삭제 가능했지만 Admin/SuperAdmin은 Course와 마찬가지로 삭제 기능이 없는 문제가 동일하게 있었습니다.)

이를 참고하여 Notice 댓글에서도 댓글 조회와 권한 검증을 분리하고, 다음 사용자가 댓글을 삭제할 수 있도록 수정했습니다.

* 댓글 작성자 본인
* 해당 Course의 Group Leader
* 사이트 Admin/SuperAdmin

여기서 Group Leader는 특정 Course에 대한 권한이고, Admin/SuperAdmin은 플랫폼 차원의 Role이므로 별도의 권한으로 확인합니다.

기존에는 댓글 조회 단계에서 작성자 본인 여부를 함께 확인했지만, 이를 분리하여 다음 순서로 동작하도록 수정했습니다.

1. 해당 Notice에 댓글이 실제로 존재하는지 확인합니다.
2. 댓글 작성자가 현재 사용자인지 확인합니다.
3. 현재 사용자가 해당 Course의 Group Leader인지 확인합니다.
4. 현재 사용자가 사이트 Admin/SuperAdmin인지 확인합니다.
5. 댓글 작성자, Group Leader, Admin/SuperAdmin 중 어느 조건에도 해당하지 않는 경우에만 삭제를 제한합니다.

또한 Admin/SuperAdmin은 플랫폼 차원의 Role이므로, 해당 Course의 `UserGroup` membership이 없는 경우에도 private Notice의 댓글을 삭제할 수 있도록 접근 권한 검사를 수정했습니다.

### Additional context

* Course Staff 권한 검증에는 기존 QnA 댓글 삭제 로직의 Group Leader 확인 방식을 참고했습니다.
* Admin/SuperAdmin은 Group Leader와 별개의 플랫폼 차원 Role로 확인하도록 구현했습니다.
* 기존 Notice 대댓글의 soft delete 및 cascade delete 로직은 변경하지 않았습니다.
* 리뷰 시 댓글 작성자, Course Group Leader, Admin/SuperAdmin의 삭제 권한과 기존 댓글 삭제 로직에 영향이 없는지 확인 부탁드립니다.

Closes TAS-2867

---

### Before submitting the PR, please make sure you do the following

* [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
* [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
* [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
* [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment deletion permissions.
  * Comment authors, administrators, super administrators, and group leaders can now delete applicable comments.
  * Preserved soft deletion and cleanup of comment replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->