### PR TITLE
chore(infra): reconcile production database upgrade

### DIFF
--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -11,17 +11,103 @@ resource "random_password" "postgres_password" {
 
 }
 
+# TODO(TAS-2888): Remove this group after the retained PostgreSQL 14 old blue
+# instance is deleted, no earlier than 2026-09-03 23:40 KST and only with
+# separate approval.
+resource "aws_db_parameter_group" "postgres14_logical" {
+  name        = "codedang-postgres14-logical"
+  family      = "postgres14"
+  description = "PostgreSQL 14 source parameters for the PostgreSQL 18 blue-green migration"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "wal_sender_timeout"
+    value = "0"
+  }
+
+  parameter {
+    name         = "max_replication_slots"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_wal_senders"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  # Three user databases plus one table-synchronization reserve.
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "4"
+    apply_method = "pending-reboot"
+  }
+
+  # Eight parallel workers, four logical workers, one launcher, and three spare.
+  parameter {
+    name         = "max_worker_processes"
+    value        = "16"
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_db_parameter_group" "postgres18" {
+  name        = "codedang-postgres18"
+  family      = "postgres18"
+  description = "PostgreSQL 18 target parameters for the blue-green migration"
+
+  parameter {
+    name         = "rds.force_ssl"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  # TODO(TAS-2888): Review removal of the migration-only replication tuning
+  # below after the seven-day stability window and Terraform reconciliation.
+  # Resetting static parameters may require a separately approved reboot.
+  parameter {
+    name  = "wal_receiver_timeout"
+    value = "0"
+  }
+
+  parameter {
+    name         = "max_replication_slots"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "4"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_worker_processes"
+    value        = "16"
+    apply_method = "pending-reboot"
+  }
+}
+
 resource "aws_db_instance" "postgres" {
   identifier = "terraform-20250506182211604800000001"
 
   db_name = "codedang_db"
   engine  = "postgres"
   # Pinned version — check for updates quarterly: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/
-  engine_version             = "14.22"
+  engine_version             = "18.4"
   auto_minor_version_upgrade = false
-  allocated_storage          = 10
-  max_allocated_storage      = 25
+  allocated_storage          = 30
+  max_allocated_storage      = 100
+  storage_type               = "gp3"
   instance_class             = "db.t4g.small"
+  parameter_group_name       = aws_db_parameter_group.postgres18.name
 
   username = var.postgres_username
   password = random_password.postgres_password.result

--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -68,14 +68,6 @@ resource "aws_db_parameter_group" "postgres18" {
     apply_method = "pending-reboot"
   }
 
-  # TODO(TAS-2888): Review removal of the migration-only replication tuning
-  # below after the seven-day stability window and Terraform reconciliation.
-  # Resetting static parameters may require a separately approved reboot.
-  parameter {
-    name  = "wal_receiver_timeout"
-    value = "0"
-  }
-
   parameter {
     name         = "max_replication_slots"
     value        = "20"


### PR DESCRIPTION
### Description

- 운영 RDS의 PostgreSQL 18.4 Blue/Green 전환 결과를 Terraform에 반영합니다.
- PostgreSQL 18 운영 파라미터 그룹과 보관 중인 PostgreSQL 14 논리 복제 파라미터 그룹을 관리합니다.
- 운영 DB 스토리지를 30 GiB gp3, autoscaling 최대 100 GiB로 맞춥니다.
- 전환 완료 후 `wal_receiver_timeout`을 RDS 기본값 30초로 복원합니다.

### Additional context

- timeout 복원 plan은 파라미터 그룹 in-place 변경 1건이며 리소스 교체·삭제가 없습니다.
- 적용 후 전체 `terraform plan` 결과는 `No changes`입니다.
- 운영 DB는 `available`, 파라미터 그룹은 `in-sync` 상태입니다.
- PostgreSQL 14 파라미터 그룹은 old blue 보관 기간 종료 후 별도 승인으로 제거합니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [x] Run relevant validation: `terraform fmt -check`, `terraform validate`, and full `terraform plan`.

Closes TAS-2888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Upgraded the application database to PostgreSQL 18.4.
  * Increased available database storage capacity from 10–25 GB to 30–100 GB.
  * Added migration and compatibility settings to support a controlled database upgrade with minimal disruption.
  * Improved database replication configuration for the upgrade process and ongoing PostgreSQL 18 operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->