### PR TITLE
fix(be): client contest record authorization

### DIFF
--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -274,9 +274,8 @@ export class ContestService {
           invitationCode: true
         }
       }),
-      this.prisma.contestRecord.findFirst({
-        where: { userId, contestId },
-        select: { id: true }
+      this.prisma.userContest.findFirst({
+        where: { contestId, userId, role: ContestRole.Participant }
       })
     ])
 

--- a/apps/backend/apps/client/src/contest/contest.service.ts
+++ b/apps/backend/apps/client/src/contest/contest.service.ts
@@ -63,13 +63,11 @@ export class ContestService {
 
     const registeredContestIds = new Set<number>()
     if (userId) {
-      const userRecords = await this.prisma.contestRecord.findMany({
-        where: { userId },
+      const userContests = await this.prisma.userContest.findMany({
+        where: { userId, role: ContestRole.Participant },
         select: { contestId: true }
       })
-      userRecords.forEach((record) =>
-        registeredContestIds.add(record.contestId)
-      )
+      userContests.forEach((uc) => registeredContestIds.add(uc.contestId))
     }
 
     const searchFilter = search

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -996,25 +996,25 @@ model PushSubscription {
 }
 
 model CourseQnA {
-  id          Int         @id @default(autoincrement())
-  order       Int
-  createdById Int?        @map("created_by_id")
-  groupId     Int         @map("group_id")
-  problemId   Int?        @map("problem_id")
-  assignmentId Int?       @map("assignment_id")
-  title       String
-  content     String
-  category    QnACategory @default(General)
-  isResolved  Boolean     @default(false) @map("is_resolved")
-  isPrivate   Boolean     @default(false) @map("is_private")
-  createTime  DateTime    @default(now()) @map("create_time")
-  readBy      Int[]       @map("read_by")
+  id           Int         @id @default(autoincrement())
+  order        Int
+  createdById  Int?        @map("created_by_id")
+  groupId      Int         @map("group_id")
+  problemId    Int?        @map("problem_id")
+  assignmentId Int?        @map("assignment_id")
+  title        String
+  content      String
+  category     QnACategory @default(General)
+  isResolved   Boolean     @default(false) @map("is_resolved")
+  isPrivate    Boolean     @default(false) @map("is_private")
+  createTime   DateTime    @default(now()) @map("create_time")
+  readBy       Int[]       @map("read_by")
 
-  createdBy User?              @relation("CreatedByUserCourseQnA", fields: [createdById], references: [id], onDelete: SetNull)
-  group     Group              @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  problem   Problem?           @relation("ProblemToCourseQnA", fields: [problemId], references: [id], onDelete: Cascade)
-  assignment Assignment?       @relation(fields: [assignmentId], references: [id], onDelete: SetNull)
-  comments  CourseQnAComment[]
+  createdBy  User?              @relation("CreatedByUserCourseQnA", fields: [createdById], references: [id], onDelete: SetNull)
+  group      Group              @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  problem    Problem?           @relation("ProblemToCourseQnA", fields: [problemId], references: [id], onDelete: Cascade)
+  assignment Assignment?        @relation(fields: [assignmentId], references: [id], onDelete: SetNull)
+  comments   CourseQnAComment[]
 
   @@unique([groupId, order])
   @@map("course_qna")

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -996,25 +996,25 @@ model PushSubscription {
 }
 
 model CourseQnA {
-  id           Int         @id @default(autoincrement())
-  order        Int
-  createdById  Int?        @map("created_by_id")
-  groupId      Int         @map("group_id")
-  problemId    Int?        @map("problem_id")
-  assignmentId Int?        @map("assignment_id")
-  title        String
-  content      String
-  category     QnACategory @default(General)
-  isResolved   Boolean     @default(false) @map("is_resolved")
-  isPrivate    Boolean     @default(false) @map("is_private")
-  createTime   DateTime    @default(now()) @map("create_time")
-  readBy       Int[]       @map("read_by")
+  id          Int         @id @default(autoincrement())
+  order       Int
+  createdById Int?        @map("created_by_id")
+  groupId     Int         @map("group_id")
+  problemId   Int?        @map("problem_id")
+  assignmentId Int?       @map("assignment_id")
+  title       String
+  content     String
+  category    QnACategory @default(General)
+  isResolved  Boolean     @default(false) @map("is_resolved")
+  isPrivate   Boolean     @default(false) @map("is_private")
+  createTime  DateTime    @default(now()) @map("create_time")
+  readBy      Int[]       @map("read_by")
 
-  createdBy  User?              @relation("CreatedByUserCourseQnA", fields: [createdById], references: [id], onDelete: SetNull)
-  group      Group              @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  problem    Problem?           @relation("ProblemToCourseQnA", fields: [problemId], references: [id], onDelete: Cascade)
-  assignment Assignment?        @relation(fields: [assignmentId], references: [id], onDelete: SetNull)
-  comments   CourseQnAComment[]
+  createdBy User?              @relation("CreatedByUserCourseQnA", fields: [createdById], references: [id], onDelete: SetNull)
+  group     Group              @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  problem   Problem?           @relation("ProblemToCourseQnA", fields: [problemId], references: [id], onDelete: Cascade)
+  assignment Assignment?       @relation(fields: [assignmentId], references: [id], onDelete: SetNull)
+  comments  CourseQnAComment[]
 
   @@unique([groupId, order])
   @@map("course_qna")


### PR DESCRIPTION
### Description


Endpoint | 함수 | 참가 여부 판단 기준 | Record 기반 여부 | 수정
-- | -- | -- | -- | --
POST /contest/:id/participation | registerContest() | ContestRecord로 이미 참가했는지 확인 | 예 | UserContest의 role 검증 후 불러오는 방식으로 수정.
GET /contest/:id | getContest() | UserContest로 참가자/운영진 여부 계산 | 아니오 |  수정대상 x
DELETE /contest/:id/participation | unregisterContest() | UserContest와 ContestRecord를 함께 삭제 | 부분적 사용 |  수정대상 x
GET /contest/:id/leaderboard | getContestLeaderboard() | ContestRecord에서 참가자 점수·순위 조회 | 아니오. 통계 데이터 |  수정대상 x
GET /contest/:id/statistics/user/:userId | getContestUserStatistics() | 대상자의 ContestRecord 존재 여부 확인 | 아니오. 실제로 Record를 기반으로 통계 데이터를 만들기 때문에 검증 필요. |  수정대상 x



---

### Before submitting the PR, please make sure you do the following

- [ v] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ v] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ v] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.
- [ v] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contest registration status checks for more accurate participant recognition.
  - Strengthened duplicate-registration validation to prevent incorrect registration results.

- **Style**
  - Reformatted course Q&A data definitions for improved readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->