### PR TITLE
chore: add code owners for core services

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code ownership for services maintained by @lshtar13.
+/apps/backend/ @lshtar13
+/apps/iris/ @lshtar13
+/apps/plag/ @lshtar13

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Code ownership for services maintained by @lshtar13.
-/apps/backend/ @lshtar13
-/apps/iris/ @lshtar13
-/apps/plag/ @lshtar13
+# Code ownership for services maintained by @skkuding/backend-maintainers.
+/apps/backend/ @skkuding/backend-maintainers
+/apps/iris/ @skkuding/backend-maintainers
+/apps/plag/ @skkuding/backend-maintainers


### PR DESCRIPTION
## Summary
- assign @lshtar13 as code owner for /apps/backend/, /apps/iris/, and /apps/plag/

## Follow-up for repository administrators
To enforce these approvals on pull requests into main, enable Require a pull request before merging and Require review from Code Owners in the main branch protection rule (or an equivalent ruleset). @lshtar13 must have explicit write access to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ownership assignments for backend, iris, and plag application areas.
  * No user-facing functionality or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->