### PR TITLE
fix(infra): restore production admin api ingress

### DIFF
--- a/infra/k8s/admin-api/overlays/production/ingress.yaml
+++ b/infra/k8s/admin-api/overlays/production/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admin-api-server-ingress
+  namespace: admin-api
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - codedang.com
+      secretName: admin-api-server-tls
+  rules:
+    - host: codedang.com
+      http:
+        paths:
+          - path: /graphql
+            pathType: Prefix
+            backend:
+              service:
+                name: admin-api-server
+                port:
+                  number: 3000
+          - path: /admin-api
+            pathType: Prefix
+            backend:
+              service:
+                name: admin-api-server
+                port:
+                  number: 3000

--- a/infra/k8s/admin-api/overlays/production/kustomization.yaml
+++ b/infra/k8s/admin-api/overlays/production/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: admin-api
 
 resources:
   - ../../base
+  - ingress.yaml
   - secrets/aws-credentials.yaml
   - secrets/database-credentials.yaml
   - secrets/security-keys.yaml


### PR DESCRIPTION
### Description

핫픽스
Gateway 전환 중 admin API 외부 경로가 중단되지 않도록 production overlay에 Ingress를 복구합니다.

### Additional context

HTTPRoute는 유지하며 production과 stage overlay 렌더링을 확인했습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit
Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** this PR is solving.
- [x] Render the affected production and stage overlays.
