### PR TITLE
fix(be): replace course whitelist atomically

### DIFF
--- a/apps/backend/apps/admin/src/group/group.service.spec.ts
+++ b/apps/backend/apps/admin/src/group/group.service.spec.ts
@@ -164,12 +164,14 @@ const db = {
   getPaginator: PrismaService.prototype.getPaginator,
   $transaction: stub().callsFake(async (input) => {
     if (Array.isArray(input)) {
-      return input.map((query) => {
-        if (typeof query === 'function') {
-          return query(db)
-        }
-        return query
-      })
+      return Promise.all(
+        input.map((query) => {
+          if (typeof query === 'function') {
+            return query(db)
+          }
+          return query
+        })
+      )
     } else if (typeof input === 'function') {
       return input(db)
     }

--- a/apps/backend/apps/admin/src/group/group.service.spec.ts
+++ b/apps/backend/apps/admin/src/group/group.service.spec.ts
@@ -606,6 +606,8 @@ describe('WhitelistService', () => {
       const result = await service.createWhitelist(groupId, studentIds)
       expect(result).to.equal(studentIds.length)
 
+      expect(db.$transaction.called).to.be.true
+
       expect(
         db.groupWhitelist.deleteMany.calledWith({
           where: { groupId }

--- a/apps/backend/apps/admin/src/group/group.service.ts
+++ b/apps/backend/apps/admin/src/group/group.service.ts
@@ -867,19 +867,24 @@ export class WhitelistService {
   }
 
   async createWhitelist(groupId: number, studentIds: [string]) {
-    this.deleteWhitelist(groupId)
-
     const whitelistData = studentIds.map((studentId) => ({
       groupId,
       studentId
     }))
 
     try {
-      return (
-        await this.prisma.groupWhitelist.createMany({
+      // Replace the whitelist atomically so creation failure rolls back deletion
+      // and a delayed deletion cannot remove newly created entries.
+      const [, created] = await this.prisma.$transaction([
+        this.prisma.groupWhitelist.deleteMany({
+          where: { groupId }
+        }),
+        this.prisma.groupWhitelist.createMany({
           data: whitelistData
         })
-      ).count
+      ])
+
+      return created.count
     } catch (err) {
       if (err.code === 'P2002') {
         throw new UnprocessableDataException('Duplicate studentId(s) detected')


### PR DESCRIPTION
### Description

Course whitelist replacement previously started `deleteWhitelist()` without awaiting it, allowing the deletion to finish after `createMany()` and remove newly uploaded entries.

This PR replaces the whitelist with a Prisma array transaction that executes `deleteMany` and `createMany` atomically. A transaction is used instead of only awaiting the existing deletion because an awaited delete would fix ordering but could still leave the course without its previous whitelist when creation fails. The transaction guarantees both ordered replacement and rollback on partial failure.

The WhitelistService unit test now verifies that replacement uses `$transaction`.

### Additional context

- The change is limited to the backend group whitelist service and its unit test.
- Bruno collection changes are intentionally excluded.
- `git diff --check` passed.
- The targeted test could not be run locally because the checkout is missing the platform-specific Lefthook/pnpm runtime dependency.
closes TAS-2932
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Whitelist replacement is now atomic, preserving the existing whitelist if creating the new entries fails.
  - Improved reliability when duplicate student IDs or other creation errors occur.

- **Tests**
  - Added coverage confirming whitelist updates are processed within a transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->