### PR TITLE
fix(fe): forbid student id modification

### DIFF
--- a/apps/backend/apps/client/src/user/dto/updateUser.dto.ts
+++ b/apps/backend/apps/client/src/user/dto/updateUser.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsNumberString, Matches } from 'class-validator'
+import { IsEmpty, IsOptional, IsString, Matches } from 'class-validator'
 
 export class UpdateUserDto {
   @IsOptional()
@@ -14,9 +14,10 @@ export class UpdateUserDto {
   @IsString()
   readonly realName?: string
 
-  @IsOptional()
-  @IsNumberString()
-  readonly studentId?: string
+  // Student IDs are intentionally immutable after sign-up
+  // to keep whitelist matching reliable.
+  @IsEmpty({ message: 'studentId cannot be updated' })
+  readonly studentId?: never
 
   @IsOptional()
   @IsString()

--- a/apps/backend/apps/client/src/user/user.service.spec.ts
+++ b/apps/backend/apps/client/src/user/user.service.spec.ts
@@ -6,6 +6,7 @@ import { Test, type TestingModule } from '@nestjs/testing'
 import { faker } from '@faker-js/faker'
 import { Prisma, type User, type UserProfile } from '@prisma/client'
 import { expect } from 'chai'
+import { validate } from 'class-validator'
 import type { Request } from 'express'
 import { Exception } from 'handlebars'
 import { ExtractJwt } from 'passport-jwt'
@@ -23,6 +24,7 @@ import {
 import { PrismaService } from '@libs/prisma'
 import { EmailService } from '@client/email/email.service'
 import { GroupService } from '@client/group/group.service'
+import { UpdateUserDto } from './dto/updateUser.dto'
 import { UserService } from './user.service'
 
 const ID = 1
@@ -662,6 +664,50 @@ describe('UserService', () => {
     })
   })
 
+  describe('updateUser', () => {
+    beforeEach(() => {
+      db.user.update.resetHistory()
+      db.user.update.resolves(user)
+    })
+
+    it('should not update studentId', async () => {
+      const updateUserDto = {
+        realName: 'new name',
+        college: 'new college',
+        major: 'new major',
+        studentId: '2026123456'
+      }
+
+      await service.updateUser(
+        authRequestObject,
+        updateUserDto as unknown as UpdateUserDto
+      )
+
+      expect(db.user.update.calledOnce).to.be.true
+      expect(db.user.update.firstCall.firstArg).to.deep.equal({
+        where: { id: ID },
+        data: {
+          password: undefined,
+          college: updateUserDto.college,
+          major: updateUserDto.major,
+          userProfile: {
+            update: { realName: updateUserDto.realName }
+          }
+        },
+        select: {
+          studentId: true,
+          college: true,
+          major: true,
+          userProfile: {
+            select: {
+              realName: true
+            }
+          }
+        }
+      })
+    })
+  })
+
   describe('checkDuplicatedUsername', () => {
     it('username not duplicated', async () => {
       db.user.findUnique.resolves(null)
@@ -678,5 +724,21 @@ describe('UserService', () => {
         service.checkDuplicatedUsername(usernameDto)
       ).to.be.rejectedWith(DuplicateFoundException)
     })
+  })
+})
+
+describe('UpdateUserDto', () => {
+  it('should reject studentId updates', async () => {
+    const dto = Object.assign(new UpdateUserDto(), {
+      studentId: '2026123456'
+    })
+
+    const errors = await validate(dto)
+
+    expect(errors).to.have.lengthOf(1)
+    expect(errors[0].property).to.equal('studentId')
+    expect(errors[0].constraints?.isEmpty).to.equal(
+      'studentId cannot be updated'
+    )
   })
 })

--- a/apps/backend/apps/client/src/user/user.service.ts
+++ b/apps/backend/apps/client/src/user/user.service.ts
@@ -755,7 +755,7 @@ export class UserService {
    * 사용자의 정보를 업데이트합니다.
    *
    * @param {AuthenticatedRequest} req 인증된 사용자 정보가 포함된 HTTP 요청 객체
-   * @param updateUserDto 업데이트 하려는 사용자의 정보가 담긴 DTO 객체 (password, studentId, college, major, realName)
+   * @param updateUserDto 업데이트 하려는 사용자의 정보가 담긴 DTO 객체 (password, college, major, realName)
    * @throws {UnprocessableDataException} 현재 비밀번호를 입력하지 않으면 (빈 필드이면) 예외를 발생시킵니다.
    * @throws {EntityNotExistException} 사용자가 DB상에 존재하지 않을 경우 예외를 발생시킵니다.
    * @throws {UnidentifiedException} 잘못된 비밀번호를 입력했을 경우 예외를 발생시킵니다.
@@ -796,7 +796,6 @@ export class UserService {
 
     const updateData = {
       password: encryptedNewPassword,
-      studentId: updateUserDto.studentId,
       college: updateUserDto.college,
       major: updateUserDto.major,
       userProfile: {

--- a/apps/frontend/app/(client)/(main)/settings/_components/StudentIdSection.tsx
+++ b/apps/frontend/app/(client)/(main)/settings/_components/StudentIdSection.tsx
@@ -2,14 +2,9 @@ import { Input } from '@/components/shadcn/input'
 import { cn } from '@/libs/utils'
 import { useSettingsContext } from './context'
 
-interface StudentIdSectionProps {
-  studentId: string
-}
-
-export function StudentIdSection({ studentId }: StudentIdSectionProps) {
+export function StudentIdSection() {
   const {
     isLoading,
-    updateNow,
     defaultProfileValues,
     formState: { register, errors }
   } = useSettingsContext()
@@ -19,21 +14,13 @@ export function StudentIdSection({ studentId }: StudentIdSectionProps) {
       <label className="-mb-4 mt-2 text-xs">Student ID</label>
       <Input
         placeholder={(() => {
-          if (updateNow) {
-            return '2024123456'
-          }
           return isLoading ? 'Loading...' : defaultProfileValues.studentId
         })()}
-        disabled={!updateNow}
+        disabled={true}
         {...register('studentId')}
         className={cn(
           'text-neutral-600 placeholder:text-neutral-400 focus-visible:ring-0',
           (() => {
-            if (updateNow) {
-              return errors.studentId || !studentId
-                ? 'border-red-500'
-                : 'border-primary'
-            }
             return 'border-neutral-300 disabled:bg-neutral-200'
           })()
         )}

--- a/apps/frontend/app/(client)/(main)/settings/page.tsx
+++ b/apps/frontend/app/(client)/(main)/settings/page.tsx
@@ -282,7 +282,7 @@ export default function Page() {
           {/* Name */}
           <NameSection realName={realName} />
           {/* Student ID */}
-          <StudentIdSection studentId={studentId} />
+          <StudentIdSection />
           {/* Major */}
           <MajorSection />
           {/* Push Notifications */}


### PR DESCRIPTION
### Description

https://codedang.com/settings?updateNow=true 접속 시 학번 변경이 가능했던 문제를 수정합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Settings**
  - The Student ID field is now read-only and cannot be edited from the settings page.
  - Removed the temporary example value from the field placeholder.
  - Removed update-specific error and border styling previously shown while changing the Student ID.

- **Bug Fixes**
  - Student ID values are no longer accepted when updating user profile information.
  - Other profile fields continue to update without modifying the existing Student ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->