### PR TITLE
fix(fe): expand username length limitation

### DIFF
--- a/apps/frontend/components/auth/SignUp/SignUpRegisterAccount.tsx
+++ b/apps/frontend/components/auth/SignUp/SignUpRegisterAccount.tsx
@@ -22,7 +22,7 @@ const schema = v.object({
   username: v.pipe(
     v.string(),
     v.minLength(3, 'Username must be at least 3 characters'),
-    v.maxLength(10, 'Username must be at most 10 characters'),
+    v.maxLength(50, 'Username must be at most 50 characters'),
     v.regex(
       /^[a-z0-9]+$/,
       'Username must contain only lowercase letters and numbers'
@@ -152,7 +152,7 @@ function SignUpRegisterAccountContent() {
                   }
                   return (
                     <AuthMessage
-                      message={'3-10 characters of small letters, numbers'}
+                      message={'3-50 characters of small letters, numbers'}
                       type={'info'}
                     />
                   )


### PR DESCRIPTION
### Description

이한국 교수님 요청사항 - 학생 이름 등록 시 기존 10자에서 50자로 길이 제한을 변경합니다.

- 아래 4번
<img width="716" height="289" alt="image" src="https://github.com/user-attachments/assets/92f05cdf-f55d-499f-b119-4fd5ff9fe7fa" />


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2934