### PR TITLE
fix(fe): return to course list from management sidebar

### DIFF
--- a/apps/frontend/app/admin/_components/ManagementSidebar.tsx
+++ b/apps/frontend/app/admin/_components/ManagementSidebar.tsx
@@ -119,7 +119,6 @@ interface ManagementSidebarProps {
 export function ManagementSidebar({ session }: ManagementSidebarProps) {
   const [isMainSidebarExpanded, setIsMainSidebarExpanded] = useState(true)
   const [isAnimationComplete, setIsAnimationComplete] = useState(true)
-  const [isCourseSidebarOpened, setIsCourseSidebarOpened] = useState(false)
   const [selectedCourseId, setSelectedCourseId] = useState<string>('')
   const [userPermissions, setUserPermissions] = useState({
     canCreateCourse: false,
@@ -200,8 +199,6 @@ export function ManagementSidebar({ session }: ManagementSidebarProps) {
     const hasCourse = Boolean(id)
 
     setSelectedCourseId(id)
-    setIsCourseSidebarOpened(hasCourse)
-
     if (hasCourse) {
       setIsMainSidebarExpanded(false)
     }
@@ -262,26 +259,9 @@ export function ManagementSidebar({ session }: ManagementSidebarProps) {
                     : pathname.startsWith(item.path)
                 }
                 isExpanded={isMainSidebarExpanded}
-                onClick={(e) => {
-                  const isCourseItem = item.path === '/admin/course'
-                  const isOnCourseDetail =
-                    pathname.startsWith('/admin/course/') &&
-                    isCourseSidebarOpened
-
-                  if (isCourseItem && isOnCourseDetail) {
-                    if (!isMainSidebarExpanded) {
-                      setIsMainSidebarExpanded(true)
-                    }
-                    e.preventDefault()
-                    return
-                  }
-
+                onClick={() => {
                   if (!isMainSidebarExpanded) {
                     setIsMainSidebarExpanded(true)
-                  }
-
-                  if (!isCourseItem) {
-                    setIsCourseSidebarOpened(false)
                   }
                 }}
               />
@@ -299,7 +279,6 @@ export function ManagementSidebar({ session }: ManagementSidebarProps) {
                       <Link
                         key={course.id}
                         href={`/admin/course/${course.id}`}
-                        onClick={() => setIsCourseSidebarOpened(true)}
                         className={cn(
                           'overflow-hidden text-ellipsis text-xs transition-colors',
                           params.courseId === course.id.toString()


### PR DESCRIPTION
### Description
Management 페이지에서 특정 Course 상세 화면에 진입한 뒤, 사이드바의 `Course` 메뉴를 다시 클릭하면 Course 목록 화면으로 돌아가도록 수정했습니다.

기존에는 Course 상세 화면에서 `Course` 메뉴를 클릭할 때 `e.preventDefault()`가 실행되어 `/admin/course`로의 이동이 막히고 있었습니다.

해당 페이지 이동 차단 로직을 제거하여, `Course` 메뉴 클릭 시 Link의 기본 동작에 따라 Course 목록 페이지로 이동하도록 변경했습니다.

또한 페이지 이동 차단 여부를 판단하는 데만 사용되던 `isCourseSidebarOpened` 상태와 관련 코드를 제거했습니다.

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.



closes TAS-2883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated management sidebar navigation so selecting course links no longer automatically opens the course sub-sidebar.
  - Course navigation now follows the standard main-sidebar expand-on-click behavior, providing a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->