### PR TITLE
fix(be): handle assignment records in course assignments

### DIFF
--- a/apps/backend/apps/admin/src/group/group.service.spec.ts
+++ b/apps/backend/apps/admin/src/group/group.service.spec.ts
@@ -153,6 +153,7 @@ const db = {
   },
   assignmentProblem: {
     create: stub(),
+    createMany: stub(),
     findMany: stub()
   },
   assignmentRecord: {
@@ -378,36 +379,30 @@ describe('GroupService', () => {
 
     it('should duplicate course successfully', async () => {
       db.user.findUnique.resolves({ canCreateCourse: true })
+      const now = new Date()
+      // Origin assignment ids (501, 502) are intentionally different from the
+      // newly created assignment ids (999, 1000) below, so that assertions can
+      // prove the new Records reference the NEW assignment, not the original one.
       const groupWithAssignment = {
         ...group,
-        assignment: [{ id: 999 }, { id: 1000 }]
+        assignment: [
+          {
+            id: 501,
+            startTime: new Date(now.getTime() - 1000),
+            endTime: new Date(now.getTime() + 1000),
+            assignmentProblem: [{ order: 1, problemId: 11, score: 100 }]
+          },
+          {
+            id: 502,
+            startTime: new Date(now.getTime() - 1000),
+            endTime: new Date(now.getTime() + 1000),
+            assignmentProblem: [{ order: 1, problemId: 22, score: 50 }]
+          }
+        ]
       }
 
-      db.assignmentProblem.findMany.resolves([
-        { order: 1, problemId: 1, score: 100 }
-      ])
       db.group.findUniqueOrThrow.resolves(groupWithAssignment)
       db.group.create.resolves(groupWithAssignment)
-
-      db.assignment.findFirst.onFirstCall().resolves({
-        id: 999,
-        groupId,
-        startTime: new Date(Date.now() - 1000),
-        endTime: new Date(Date.now() + 1000),
-        createTime: new Date(),
-        updateTime: new Date(),
-        title: 'Original Assignment'
-      })
-
-      db.assignment.findFirst.onSecondCall().resolves({
-        id: 1000,
-        groupId,
-        startTime: new Date(Date.now() - 1000),
-        endTime: new Date(Date.now() + 1000),
-        createTime: new Date(),
-        updateTime: new Date(),
-        title: 'Original Assignment'
-      })
 
       db.assignment.create.onFirstCall().resolves({
         id: 999
@@ -415,6 +410,9 @@ describe('GroupService', () => {
       db.assignment.create.onSecondCall().resolves({
         id: 1000
       })
+
+      db.assignmentRecord.createMany.resolves({ count: 1 })
+      db.assignmentProblemRecord.createMany.resolves({ count: 1 })
 
       const result = await service.duplicateCourse(
         groupId,
@@ -424,7 +422,7 @@ describe('GroupService', () => {
 
       expect(result).to.deep.equal({
         duplicatedCourse: groupWithAssignment,
-        originAssignments: [999, 1000],
+        originAssignments: [501, 502],
         copiedAssignments: [999, 1000]
       })
 
@@ -439,6 +437,30 @@ describe('GroupService', () => {
       expect(createCallArgs.data.courseInfo.create.classNum).to.equal(
         duplicateInput.classNum
       )
+
+      // AssignmentRecord must be created against the NEW assignment id, not the
+      // original one, and must carry no score/finalScore/submission history.
+      expect(db.assignmentRecord.createMany.callCount).to.equal(2)
+      expect(db.assignmentRecord.createMany.getCall(0).args[0]).to.deep.equal({
+        data: [{ assignmentId: 999, userId }]
+      })
+      expect(db.assignmentRecord.createMany.getCall(1).args[0]).to.deep.equal({
+        data: [{ assignmentId: 1000, userId }]
+      })
+
+      // AssignmentProblemRecord must reference the new assignment id and copy
+      // only problemId - never score/isSubmitted/finalScore from the original.
+      expect(db.assignmentProblemRecord.createMany.callCount).to.equal(2)
+      expect(
+        db.assignmentProblemRecord.createMany.getCall(0).args[0]
+      ).to.deep.equal({
+        data: [{ assignmentId: 999, userId, problemId: 11 }]
+      })
+      expect(
+        db.assignmentProblemRecord.createMany.getCall(1).args[0]
+      ).to.deep.equal({
+        data: [{ assignmentId: 1000, userId, problemId: 22 }]
+      })
     })
   })
 })

--- a/apps/backend/apps/admin/src/group/group.service.ts
+++ b/apps/backend/apps/admin/src/group/group.service.ts
@@ -451,6 +451,20 @@ export class GroupService {
             })
           }
 
+          await tx.assignmentRecord.createMany({
+            data: [{ assignmentId: newAssignment.id, userId }]
+          })
+
+          if (assignmentProblem && assignmentProblem.length > 0) {
+            await tx.assignmentProblemRecord.createMany({
+              data: assignmentProblem.map((ap) => ({
+                assignmentId: newAssignment.id,
+                userId,
+                problemId: ap.problemId
+              }))
+            })
+          }
+
           return {
             originId,
             newId: newAssignment.id

--- a/apps/backend/apps/client/src/assignment/assignment.service.spec.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.spec.ts
@@ -238,4 +238,107 @@ describe('AssignmentService', () => {
       ).to.be.rejectedWith(ForbiddenAccessException)
     })
   })
+
+  describe('getMyAssignmentsSummary', () => {
+    const groupId = 1
+    // Seed data seeds many pre-existing isExercise:false assignments for
+    // groupId 1 (some without an AssignmentRecord for user01Id by design, to
+    // exercise the participation/un-registration APIs elsewhere in this file).
+    // Using isExercise:true isolates these tests from that shared fixture,
+    // since no seeded assignment sets isExercise to true.
+    const isExercise = true
+
+    it('should return a normal summary (not throw) for a course member whose AssignmentRecord is still in its initial zero state', async () => {
+      const now = new Date()
+      const newAssignment = await transaction.assignment.create({
+        data: {
+          title: 'Freshly duplicated assignment',
+          description: 'no submissions yet',
+          groupId,
+          startTime: new Date(now.getTime() - 1000),
+          endTime: new Date(now.getTime() + 100000),
+          isVisible: true,
+          isExercise
+        }
+      })
+      await transaction.assignmentRecord.create({
+        data: {
+          assignmentId: newAssignment.id,
+          userId: user01Id
+        }
+      })
+
+      const summary = await service.getMyAssignmentsSummary(
+        groupId,
+        user01Id,
+        isExercise
+      )
+
+      const entry = summary.find((s) => s.id === newAssignment.id)
+      expect(entry).to.exist
+      expect(entry?.problemCount).to.equal(0)
+      expect(entry?.submittedCount).to.equal(0)
+      expect(entry?.assignmentPerfectScore).to.equal(0)
+      expect(entry?.userAssignmentFinalScore).to.equal(null)
+    })
+
+    it('should use the record score as the final score when autoFinalizeScore is true', async () => {
+      const now = new Date()
+      const newAssignment = await transaction.assignment.create({
+        data: {
+          title: 'Auto-finalized assignment',
+          description: 'score is finalized automatically',
+          groupId,
+          startTime: new Date(now.getTime() - 1000),
+          endTime: new Date(now.getTime() + 100000),
+          isVisible: true,
+          isExercise,
+          autoFinalizeScore: true,
+          isFinalScoreVisible: true
+        }
+      })
+      await transaction.assignmentRecord.create({
+        data: {
+          assignmentId: newAssignment.id,
+          userId: user01Id,
+          score: 42
+        }
+      })
+
+      const summary = await service.getMyAssignmentsSummary(
+        groupId,
+        user01Id,
+        isExercise
+      )
+
+      const entry = summary.find((s) => s.id === newAssignment.id)
+      expect(entry).to.exist
+      expect(entry?.userAssignmentFinalScore?.toNumber()).to.equal(42)
+    })
+
+    it('should omit an assignment (not throw ForbiddenAccessException, not throw TypeError) when the course member has no AssignmentRecord for it', async () => {
+      const now = new Date()
+      const unregisteredAssignment = await transaction.assignment.create({
+        data: {
+          title: 'Assignment the user never registered for',
+          description: 'no AssignmentRecord exists for user01Id',
+          groupId,
+          startTime: new Date(now.getTime() - 1000),
+          endTime: new Date(now.getTime() + 100000),
+          isVisible: true,
+          isExercise
+        }
+      })
+      // Intentionally no transaction.assignmentRecord.create() for user01Id here.
+
+      const summary = await service.getMyAssignmentsSummary(
+        groupId,
+        user01Id,
+        isExercise
+      )
+
+      const entry = summary.find((s) => s.id === unregisteredAssignment.id)
+      expect(entry).to.not.exist
+    })
+  })
 })

--- a/apps/backend/apps/client/src/assignment/assignment.service.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.ts
@@ -563,13 +563,12 @@ export class AssignmentService {
    * 한 그룹에서 특정 유저의 모든 assignment 결과를 요약해 가져옵니다.
    * 요약한 내용에는 assignment 아이디, 문제/제출 수, 문제 별 점수의 총합, 최종 점수가 포함됩니다.
    * assignment의 isFinalScoreVisible가 false일 때 userAssignmentFinalScore는 null이 됩니다.
+   * 유저가 참여하지 않아 AssignmentRecord가 없는 assignment는 결과에서 제외됩니다.
    *
    * @param groupId 가져올 assignment가 속한 그룹 아이디
    * @param userId 유저 아이디
    * @param isExercise exercise를 가져올지 여부
    * @returns 한 그룹에서 특정 유저의 assignment 별 결과를 요약해 반환합니다.
-   * @throws {ForbiddenAccessException} 아래와 같은 경우 발생합니다.
-   * - 조회한 assignment에 유저가 포함되지 않았을 때
    */
   async getMyAssignmentsSummary(
     groupId: number,
@@ -625,14 +624,15 @@ export class AssignmentService {
       return []
     }
 
+    // Course 접근 권한은 GroupMemberGuard/UserGroup에서 검증하므로, 여기서는
+    // 참여하지 않아 AssignmentRecord가 없는 assignment를 결과에서 제외하기만 한다.
+    const participatingAssignments = assignments.filter(
+      (assignment) => assignment.assignmentRecord.length > 0
+    )
+
     // 각 assignment의  problem 별 점수 총합
-    const assignmentPerfectScoresMap = assignments.reduce(
+    const assignmentPerfectScoresMap = participatingAssignments.reduce(
       (map, { id, assignmentProblem, assignmentRecord }) => {
-        if (!assignmentRecord.length) {
-          throw new ForbiddenAccessException(
-            'User not participated in the assignment'
-          )
-        }
         assignmentRecord[0].finalScore =
           assignmentRecord[0].assignmentProblemRecord.reduce(
             (sum, { finalScore }) =>
@@ -649,7 +649,7 @@ export class AssignmentService {
       {}
     )
 
-    return assignments.map((assignment) => {
+    return participatingAssignments.map((assignment) => {
       if (assignment.autoFinalizeScore) {
         assignment.assignmentRecord[0].finalScore =
           assignment.assignmentRecord[0].score

--- a/apps/backend/apps/client/src/assignment/assignment.service.ts
+++ b/apps/backend/apps/client/src/assignment/assignment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 import {
   ConflictFoundException,
@@ -45,6 +45,8 @@ export interface ProblemScore {
 
 @Injectable()
 export class AssignmentService {
+  private readonly logger = new Logger(AssignmentService.name)
+
   constructor(private readonly prisma: PrismaService) {}
 
   /**
@@ -563,7 +565,9 @@ export class AssignmentService {
    * 한 그룹에서 특정 유저의 모든 assignment 결과를 요약해 가져옵니다.
    * 요약한 내용에는 assignment 아이디, 문제/제출 수, 문제 별 점수의 총합, 최종 점수가 포함됩니다.
    * assignment의 isFinalScoreVisible가 false일 때 userAssignmentFinalScore는 null이 됩니다.
-   * 유저가 참여하지 않아 AssignmentRecord가 없는 assignment는 결과에서 제외됩니다.
+   * 정상적인 Course Member라면 AssignmentRecord가 존재해야 하지만, 과거 데이터나
+   * 예외적인 흐름으로 인해 없을 수도 있습니다. 이 경우 요청을 실패시키지 않고
+   * 해당 assignment만 결과에서 제외합니다.
    *
    * @param groupId 가져올 assignment가 속한 그룹 아이디
    * @param userId 유저 아이디
@@ -624,11 +628,23 @@ export class AssignmentService {
       return []
     }
 
-    // Course 접근 권한은 GroupMemberGuard/UserGroup에서 검증하므로, 여기서는
-    // 참여하지 않아 AssignmentRecord가 없는 assignment를 결과에서 제외하기만 한다.
+    // Course 접근 권한은 GroupMemberGuard/UserGroup에서 검증한다. AssignmentRecord는
+    // 정상적으로는 항상 존재해야 하지만, 누락된 경우에도 403/500으로 실패시키지 않고
+    // 해당 assignment만 결과에서 제외한다. 다만 원칙적으로 없어서는 안 되는 상태이므로
+    // 서버에서 감지할 수 있도록 로그를 남긴다.
     const participatingAssignments = assignments.filter(
       (assignment) => assignment.assignmentRecord.length > 0
     )
+
+    const missingRecordAssignmentIds = assignments
+      .filter((assignment) => assignment.assignmentRecord.length === 0)
+      .map((assignment) => assignment.id)
+
+    if (missingRecordAssignmentIds.length > 0) {
+      this.logger.warn(
+        `getMyAssignmentsSummary - AssignmentRecord missing (userId=${userId}, groupId=${groupId}, assignmentIds=[${missingRecordAssignmentIds.join(', ')}])`
+      )
+    }
 
     // 각 assignment의  problem 별 점수 총합
     const assignmentPerfectScoresMap = participatingAssignments.reduce(


### PR DESCRIPTION
### Description

`duplicateCourse()`를 통해 생성된 강좌는 복제 과정에서 Record가 생성되지 않아, Record 기반으로 권한을 검증하는 `getMyAssignmentsSummary()`에서 오류가 발생합니다.

강좌에 소속된 멤버라면 제출 여부와 관계없이 `AssignmentRecord`가 존재해야 하므로, Course 복제 시 새로운 Record가 생성되도록 수정했습니다. 다만 Record의 존재 여부를 접근 권한 판단에 사용하는 것 자체가 적절하지 않다는 본질적인 문제도 존재합니다.

따라서 Course Assignment의 `AssignmentRecord` 기반 권한 검증 로직을 제거하고, Course 복제 시 Record가 생성되도록 수정했습니다.

추가적으로 Record가 없는 상태는 원칙적으로 발생하지 않아야 하지만, 예외적인 흐름이나 코드상의 오류로 발생할 가능성을 고려하여 예외 처리와 이상 상태를 감지하기 위한 `warn` 로그를 추가했습니다.

### Problem

#### 1. Service에서 `AssignmentRecord`를 이용한 불필요한 권한 검증

`getMyAssignmentsSummary()`에서는 `AssignmentRecord`의 존재 여부를 이용해 접근 권한을 추가로 검증하고 있었습니다.

하지만 Record 기반으로 권한을 판단하는 것 자체가 적절하지 않으며, Assignment API 진입 전 `GroupMemberGuard`가 `UserGroup`을 기준으로 Course Member 여부를 이미 검증하고 있습니다.

즉, 이미 Guard에서 권한 검증이 끝났음에도 Service에서 `AssignmentRecord`를 기준으로 다시 검증하면서 문제가 발생했습니다.

따라서 아래의 Record 기반 권한 검증을 제거했습니다.

```ts
if (!assignmentRecord.length) {
  throw new ForbiddenAccessException(
    'User not participated in the assignment'
  )
}
```

Course 접근 권한은 `GroupMemberGuard` / `UserGroup`에서 담당하도록 했습니다.

#### 2. `duplicateCourse()`에서 새로운 Record가 생성되지 않는 문제

Course를 복제할 때 기존 Assignment의 Record를 그대로 복제하지 않는 것은 올바른 동작입니다. 기존 과제의 점수, 최종 점수, 제출 상태 등의 기록까지 새로운 Course로 복사해서는 안 되기 때문입니다.

하지만 기존 Record를 복제하지 않는 것에서 끝나고, 새롭게 생성된 Assignment에 필요한 초기 `AssignmentRecord`와 `AssignmentProblemRecord`도 생성되지 않고 있었습니다.

정상적인 Course Member라면 각 Assignment에 대한 Record가 존재해야 하므로, `duplicateCourse()`에서 새 Assignment에 대한 초기 Record를 새롭게 생성하도록 수정했습니다.

- 새 Assignment에 대한 `AssignmentRecord` 생성
- 새 AssignmentProblem에 대한 `AssignmentProblemRecord` 생성
- 새로 생성된 Assignment ID를 참조
- 기존 score, finalScore, 제출 상태 등의 과거 기록은 복사하지 않음

#### 3. 예외적으로 `AssignmentRecord`가 누락된 경우의 처리

정상적인 Course Member라면 `AssignmentRecord`가 존재하는 것이 원칙입니다.

다만 과거 데이터나 예외적인 흐름, 코드상의 오류 등으로 Record가 누락되는 상황을 완전히 배제할 수는 없습니다.

이 경우 하나의 Assignment에 Record가 없다는 이유로 전체 summary 요청이 실패하지 않도록 수정했습니다.

```text
Assignment A → 정상 계산
Assignment B → 정상 계산
Assignment C → Record 없음 → summary에서 제외 + warn 로그
Assignment D → 정상 계산
```

Record가 없는 Assignment는 summary 결과에서 제외하고, `userId`, `groupId`, `assignmentId`를 `warn` 로그로 남겨 서버에서 이상 상태를 추적할 수 있도록 했습니다.

### Tests

- 정상적인 `AssignmentRecord`가 존재할 때 summary가 정상적으로 반환되는지 확인
- 기존 `autoFinalizeScore` 동작이 유지되는지 확인
- `AssignmentRecord`가 누락된 Assignment만 summary에서 제외되는지 확인
- Course 복제 시 새로운 `AssignmentRecord` / `AssignmentProblemRecord`가 생성되는지 확인
- 복제된 Record가 새로운 Assignment ID를 참조하며 기존 점수 및 제출 기록을 복사하지 않는지 확인

Closes TAS-2812

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Course duplication now preserves assignments and their associated problems for the duplicated user.
  - Assignment summaries no longer fail when users have no participation record; those assignments are excluded.
  - Assignment summaries now correctly handle empty results and automatically propagate final scores.

- **Tests**
  - Added coverage for course duplication, problem copying, empty summaries, score propagation, and assignments without participation records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->