### PR TITLE
fix(fe): align real name validation with backend rules

### DIFF
--- a/apps/frontend/components/auth/SignUp/SignUpRegisterInfo.tsx
+++ b/apps/frontend/components/auth/SignUp/SignUpRegisterInfo.tsx
@@ -17,7 +17,7 @@ interface RegisterInfoInput {
 const schema = v.object({
   realName: v.pipe(
     v.string(),
-    v.minLength(1, 'Name is required'),
+    v.check((value) => value.trim().length > 0, 'Name is required'),
     v.regex(
       /^[가-힣a-zA-Z \s]+$/,
       'Name can only contain Korean, English letters, and spaces'

--- a/apps/frontend/components/auth/SignUp/SignUpRegisterInfo.tsx
+++ b/apps/frontend/components/auth/SignUp/SignUpRegisterInfo.tsx
@@ -15,7 +15,14 @@ interface RegisterInfoInput {
 }
 
 const schema = v.object({
-  realName: v.pipe(v.string(), v.minLength(1, 'Name is required')),
+  realName: v.pipe(
+    v.string(),
+    v.minLength(1, 'Name is required'),
+    v.regex(
+      /^[가-힣a-zA-Z \s]+$/,
+      'Name can only contain Korean, English letters, and spaces'
+    )
+  ),
   studentId: v.pipe(
     v.string(),
     v.length(10, 'Student ID must be 10 characters long')


### PR DESCRIPTION
### Description

기존: 공백만 검증
변경: `/^[가-힣a-zA-Z\s]+$/ `검증 추가

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved registration name validation to reject values containing only spaces.
  - Continued enforcing names made up of Korean characters, English letters, and spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->