### PR TITLE
feat(be): add retry count manage logic

### DIFF
--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -340,9 +340,6 @@ export class GroupService {
     invitation: string,
     studentId: string
   ): Promise<{ userGroupData: Partial<UserGroup>; isJoined: boolean }> {
-    // The enrollment verification task will use this value for roster matching.
-    void studentId
-
     const invitedGroupId = await this.cacheManager.get<number>(
       invitationCodeKey(invitation)
     )
@@ -421,6 +418,13 @@ export class GroupService {
       })
 
       if (whitelistExists) {
+        const joinRequestCount = await this.getUserRetryCount(userId, groupId)
+
+        // 15분 이내 3회 이상 재시도 시 요청을 거부합니다.
+        if (joinRequestCount >= 3) {
+          throw new ForbiddenAccessException('Join request count exceed')
+        }
+
         const user = await this.prisma.user.findUniqueOrThrow({
           where: { id: userId },
           select: {
@@ -436,6 +440,9 @@ export class GroupService {
         })
 
         if (!isUserWhitelisted) {
+          const newUserRequestCount = joinRequestCount + 1
+          await this.updateRetryCount(userId, groupId, newUserRequestCount)
+
           throw new ForbiddenAccessException('Whitelist violation')
         }
       }
@@ -521,15 +528,6 @@ export class GroupService {
       studentRetryKey(userId, courseId)
     )
     return count || 0
-  }
-
-  async canUserRetry(userId: number, courseId: number) {
-    const count = await this.getUserRetryCount(userId, courseId)
-
-    if (count >= 3) {
-      return false
-    }
-    return true
   }
 
   async updateRetryCount(userId: number, courseId: number, count: number) {


### PR DESCRIPTION
### Description

커밋이 꼬인 관계로... redis key 설정 및 cache 관련 함수 설정 로직은 [t2831-implement-course-register](https://github.com/skkuding/codedang/tree/t2831-implement-course-register)에 들어있습니다.

- retry count를 확인하고 실패 시, update하는 로직을 수행합니다.

### Additional context

? retry count 확인 로직 위치가 적당한지 확인해주시면 감사하겠습니다!

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
