### PR TITLE
feat(fe): show course information with tab title

### DIFF
--- a/apps/frontend/app/admin/course/[courseId]/(detail)/assignment/[assignmentId]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/(detail)/assignment/[assignmentId]/(overall)/layout.tsx
@@ -4,6 +4,7 @@ import { CountdownStatus } from '@/components/CountdownStatus'
 import { DurationDisplay } from '@/components/DurationDisplay'
 import { Button } from '@/components/shadcn/button'
 import { GET_ASSIGNMENT } from '@/graphql/assignment/queries'
+import { GET_COURSE } from '@/graphql/course/queries'
 import PenIcon from '@/public/icons/pen.svg'
 import { useQuery } from '@apollo/client'
 import Link from 'next/link'
@@ -21,6 +22,21 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
     }
   }).data?.getAssignment
 
+  const { data, loading } = useQuery(GET_COURSE, {
+    variables: { groupId: Number(courseId) },
+    skip: !courseId
+  })
+
+  const currentCourse = data?.getCourse
+
+  const courseNum = currentCourse?.courseInfo?.courseNum
+  const classNum = currentCourse?.courseInfo?.classNum
+  const courseSemester = currentCourse?.courseInfo?.semester
+
+  const courseCode = courseNum ? `${courseNum}-${classNum}` : courseId
+  const courseTitle =
+    currentCourse?.groupName || (loading ? '로딩 중...' : '과목 정보 없음')
+
   return (
     <main className="flex flex-col gap-6 px-20 py-16">
       <div className="flex items-center justify-between">
@@ -29,6 +45,7 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
             <FaAngleLeft className="h-12 hover:text-gray-700/80" />
           </Link>
           <span className="text-4xl font-bold">{assignmentData?.title}</span>
+          <p className="text-body1_m_16 text-color-neutral-50">{`[${courseCode}] ${courseTitle} ㆍ ${courseSemester}`}</p>
         </div>
         <Link
           href={

--- a/apps/frontend/app/admin/course/[courseId]/(detail)/exercise/[exerciseId]/(overall)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/(detail)/exercise/[exerciseId]/(overall)/layout.tsx
@@ -4,6 +4,7 @@ import { CountdownStatus } from '@/components/CountdownStatus'
 import { DurationDisplay } from '@/components/DurationDisplay'
 import { Button } from '@/components/shadcn/button'
 import { GET_ASSIGNMENT } from '@/graphql/assignment/queries'
+import { GET_COURSE } from '@/graphql/course/queries'
 import PenIcon from '@/public/icons/pen.svg'
 import { useQuery } from '@apollo/client'
 import Link from 'next/link'
@@ -21,6 +22,21 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
     }
   }).data?.getAssignment
 
+  const { data, loading } = useQuery(GET_COURSE, {
+    variables: { groupId: Number(courseId) },
+    skip: !courseId
+  })
+
+  const currentCourse = data?.getCourse
+
+  const courseNum = currentCourse?.courseInfo?.courseNum
+  const classNum = currentCourse?.courseInfo?.classNum
+  const courseSemester = currentCourse?.courseInfo?.semester
+
+  const courseCode = courseNum ? `${courseNum}-${classNum}` : courseId
+  const courseTitle =
+    currentCourse?.groupName || (loading ? '로딩 중...' : '과목 정보 없음')
+
   return (
     <main className="flex flex-col gap-6 px-20 py-16">
       <div className="flex items-center justify-between">
@@ -29,6 +45,7 @@ export default function Layout({ tabs }: { tabs: React.ReactNode }) {
             <FaAngleLeft className="h-12 hover:text-gray-700/80" />
           </Link>
           <span className="text-4xl font-bold">{assignmentData?.title}</span>
+          <p className="text-body1_m_16 text-color-neutral-50">{`[${courseCode}] ${courseTitle} ㆍ ${courseSemester}`}</p>
         </div>
         <Link
           href={

--- a/apps/frontend/app/admin/course/[courseId]/(overview)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/(overview)/layout.tsx
@@ -76,11 +76,6 @@ export default function CourseDetailLayout({
       <div className="pb-[71px] pl-[86px] pr-[106px] pt-[80px]">
         <h1 className="text-head3_sb_28">{activeTabName}</h1>
         <p className="text-body1_m_16 text-color-neutral-50">{`[${courseCode}] ${courseTitle} ㆍ ${courseSemester}`}</p>
-        <p className="text-body1_m_16 text-color-neutral-50 h-6">
-          {activeTabName === 'HOME'
-            ? null
-            : tabs.find((tab) => tab.title === activeTabName)?.description}
-        </p>
 
         <div className="mx-auto my-10 w-full">
           <div className="w-full">

--- a/apps/frontend/app/admin/course/[courseId]/(overview)/layout.tsx
+++ b/apps/frontend/app/admin/course/[courseId]/(overview)/layout.tsx
@@ -26,6 +26,7 @@ export default function CourseDetailLayout({
 
   const courseNum = currentCourse?.courseInfo?.courseNum
   const classNum = currentCourse?.courseInfo?.classNum
+  const courseSemester = currentCourse?.courseInfo?.semester
 
   const courseCode = courseNum ? `${courseNum}-${classNum}` : courseId
   const courseTitle =
@@ -74,9 +75,10 @@ export default function CourseDetailLayout({
     <div className="flex w-full flex-col">
       <div className="pb-[71px] pl-[86px] pr-[106px] pt-[80px]">
         <h1 className="text-head3_sb_28">{activeTabName}</h1>
-        <p className="text-body1_m_16 text-color-neutral-50">
+        <p className="text-body1_m_16 text-color-neutral-50">{`[${courseCode}] ${courseTitle} ㆍ ${courseSemester}`}</p>
+        <p className="text-body1_m_16 text-color-neutral-50 h-6">
           {activeTabName === 'HOME'
-            ? `[${courseCode}] ${courseTitle}`
+            ? null
             : tabs.find((tab) => tab.title === activeTabName)?.description}
         </p>
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
admin/course 페이지에서 개별 탭의 설명 대신 과목 정보를 표시합니다.
개별 assignment/exercise 페이지에서도 제목 옆에 과목 정보를 표시합니다.
course 정보 쿼리는 overview 레이아웃에 있던 거 그대로 가져왔어요. 쿼리문 수정할 수 있을 거 같긴 한데 일단 기능 구현만 했습니다 나중에 할게요

### Additional context

교수님 요청사항

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Course pages now display the course code, title, and semester in page headers.
  * Assignment and exercise pages show course details beneath the page title.
  * Loading and fallback text is provided when course information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->