### PR TITLE
chore(infra): remove pg14 parameter group from aws terraform

### DIFF
--- a/infra/aws/storage/database.tf
+++ b/infra/aws/storage/database.tf
@@ -11,52 +11,6 @@ resource "random_password" "postgres_password" {
 
 }
 
-# TODO(TAS-2888): Remove this group after the retained PostgreSQL 14 old blue
-# instance is deleted, no earlier than 2026-09-03 23:40 KST and only with
-# separate approval.
-resource "aws_db_parameter_group" "postgres14_logical" {
-  name        = "codedang-postgres14-logical"
-  family      = "postgres14"
-  description = "PostgreSQL 14 source parameters for the PostgreSQL 18 blue-green migration"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "wal_sender_timeout"
-    value = "0"
-  }
-
-  parameter {
-    name         = "max_replication_slots"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_wal_senders"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  # Three user databases plus one table-synchronization reserve.
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "4"
-    apply_method = "pending-reboot"
-  }
-
-  # Eight parallel workers, four logical workers, one launcher, and three spare.
-  parameter {
-    name         = "max_worker_processes"
-    value        = "16"
-    apply_method = "pending-reboot"
-  }
-}
-
 resource "aws_db_parameter_group" "postgres18" {
   name        = "codedang-postgres18"
   family      = "postgres18"


### PR DESCRIPTION
### Description

blue db 삭제 후 불필요해진 postgres14의 파라미터 그룹을 삭제했습니다.

### Additional context

terraform plan을 실행하고 변경사항 없음이 뜨는 것을 확인 완료 하였습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused PostgreSQL 14 logical replication parameter group configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->