### PR TITLE
feat(iris): implement pprof tool

### DIFF
--- a/apps/iris/main.go
+++ b/apps/iris/main.go
@@ -56,9 +56,10 @@ func main() {
 	ctx := context.Background()
 	if env == "stage" {
 		logProvider.Log(logger.INFO, "Running in stage mode")
-		http.HandleFunc("/health", healthCheckHandler)
+		healthMux := http.NewServeMux()
+		healthMux.HandleFunc("/health", healthCheckHandler)
 		go func() {
-			if err := http.ListenAndServe("0.0.0.0:3404", nil); err != nil {
+			if err := http.ListenAndServe("0.0.0.0:3404", healthMux); err != nil {
 				logProvider.Log(logger.ERROR, fmt.Sprintf("Failed to start health checker: %v", err))
 			}
 		}()

--- a/apps/iris/main.go
+++ b/apps/iris/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/skkuding/codedang/apps/iris/src/service/testcase"
 	"github.com/skkuding/codedang/apps/iris/src/utils"
 	"go.opentelemetry.io/otel"
+
+	_ "net/http/pprof"
 )
 
 type Env string
@@ -61,6 +63,13 @@ func main() {
 			}
 		}()
 	}
+
+	go func() {
+		logProvider.Log(logger.INFO, "Intializing pprof listening on :6060")
+		if err := http.ListenAndServe("0.0.0.0:6060", nil); err != nil {
+			logProvider.Log(logger.ERROR, fmt.Sprintf("Failed to start pprof: %v", err))
+		}
+	}()
 
 	disableInstrumentation := utils.Getenv("DISABLE_INSTRUMENTATION", "false") == "true"
 	if !disableInstrumentation {

--- a/infra/aws/dns/pprof.tf
+++ b/infra/aws/dns/pprof.tf
@@ -1,0 +1,17 @@
+# Purpose: Iris pprof profiling endpoint
+
+resource "aws_route53_record" "pprof" {
+  name    = "pprof.codedang.com"
+  zone_id = data.aws_route53_zone.codedang.zone_id
+  type    = "A"
+  records = local.prod_cluster_ip
+  ttl     = 300
+}
+
+resource "aws_route53_record" "pprof_stage" {
+  name    = "pprof.stage.codedang.com"
+  zone_id = data.aws_route53_zone.codedang.zone_id
+  type    = "A"
+  records = local.stage_cluster_ip
+  ttl     = 300
+}

--- a/infra/k8s/internal/base/gateway.yaml
+++ b/infra/k8s/internal/base/gateway.yaml
@@ -58,6 +58,7 @@ spec:
                   - client-api
                   - frontend
                   - headlamp
+                  - iris
                   - monitoring-grafana
                   - monitoring-prometheus
                   - n8n
@@ -83,6 +84,7 @@ spec:
                 values:
                   - cloud-beaver
                   - headlamp
+                  - iris
                   - minio
                   - monitoring-grafana
                   - monitoring-prometheus

--- a/infra/k8s/iris/base/HTTPRoutes.yaml
+++ b/infra/k8s/iris/base/HTTPRoutes.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: iris-pprof-httproute
+  namespace: iris
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: kube-system
+      sectionName: https-wildcard
+  hostnames:
+    - pprof.codedang.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /debug/pprof
+      backendRefs:
+        - name: iris-pprof
+          port: 6060

--- a/infra/k8s/iris/base/kustomization.yaml
+++ b/infra/k8s/iris/base/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: iris
 resources:
   - configmap.yaml
   - deployment.yaml
+  - HTTPRoutes.yaml
   - namespace.yaml
   - rabbitmq-credentials.yaml
   - service.yaml

--- a/infra/k8s/iris/base/kustomization.yaml
+++ b/infra/k8s/iris/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - deployment.yaml
   - namespace.yaml
   - rabbitmq-credentials.yaml
+  - service.yaml
 
 commonAnnotations:
   managed-by: kustomize

--- a/infra/k8s/iris/base/service.yaml
+++ b/infra/k8s/iris/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: iris-pprof
+  namespace: iris
+spec:
+  selector:
+    app: iris
+  ports:
+    - port: 6060
+      targetPort: 6060

--- a/infra/k8s/iris/overlays/stage/HTTPRoutes.yaml
+++ b/infra/k8s/iris/overlays/stage/HTTPRoutes.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: iris-pprof-httproute
+  namespace: iris
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: kube-system
+      sectionName: https-stage-wildcard
+  hostnames:
+    - pprof.stage.codedang.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /debug/pprof
+      backendRefs:
+        - name: iris-pprof
+          port: 6060

--- a/infra/k8s/iris/overlays/stage/kustomization.yaml
+++ b/infra/k8s/iris/overlays/stage/kustomization.yaml
@@ -20,3 +20,7 @@ patches:
     target:
       kind: Deployment
       name: iris
+  - path: HTTPRoutes.yaml
+    target:
+      kind: HTTPRoute
+      name: iris-pprof-httproute


### PR DESCRIPTION
### Description

- Iris에 프로파일링을 위한 pprof를 추가합니다.
- 6060 port를 cluster internal하게 open하였습니다. 

### Additional context

- 추후 authentik을 추가하여 pprof에 접근가능하게 할 예정입니다.

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

closes TAS-2972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a profiling and diagnostics endpoint for the Iris service, accessible through `/debug/pprof`.
  - Exposed the endpoint through dedicated production and staging URLs.
  - Added Kubernetes routing and service configuration to support access to the diagnostics endpoint.
  - Added startup and failure logging for the diagnostics server.
  - Improved health-check routing isolation in staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->