### PR TITLE
fix(be): allow admins to delete course qna comments

### DIFF
--- a/apps/backend/apps/client/src/group/group.controller.ts
+++ b/apps/backend/apps/client/src/group/group.controller.ts
@@ -454,6 +454,7 @@ export class CourseController {
   ) {
     return await this.courseService.deleteCourseQnAComment(
       req.user.id,
+      req.user.role,
       courseId,
       qnaOrder,
       commentOrder

--- a/apps/backend/apps/client/src/group/group.service.ts
+++ b/apps/backend/apps/client/src/group/group.service.ts
@@ -2011,6 +2011,7 @@ export class CourseService {
   /**
    * @description Course Q&A의 댓글을 삭제합니다.
    * @param userId 현재 요청을 보낸 사용자 ID
+   * @param userRole 현재 요청을 보낸 사용자의 사이트 권한
    * @param courseId Course의 group ID
    * @param qnaOrder 댓글이 속한 Q&A의 order 번호
    * @param commentOrder 삭제할 댓글의 order 번호
@@ -2020,10 +2021,13 @@ export class CourseService {
    */
   async deleteCourseQnAComment(
     userId: number,
+    userRole: Role,
     courseId: number,
     qnaOrder: number,
     commentOrder: number
   ) {
+    const isSiteAdmin = userRole === Role.Admin || userRole === Role.SuperAdmin
+
     const groupId = courseId
     const group = await this.prisma.group.findUnique({
       where: { id: groupId, courseInfo: { isNot: null } }
@@ -2053,6 +2057,7 @@ export class CourseService {
     }
 
     const isCourseStaff =
+      isSiteAdmin ||
       (await this.prisma.userGroup.findFirst({
         where: { userId, groupId, isGroupLeader: true }
       })) !== null


### PR DESCRIPTION
### Description 

#### Problem

Course QnA 댓글은 기존에 **댓글 작성자 본인 또는 해당 Course의 Group Leader만 삭제할 수 있도록 구현**되어 있던 반면, 플랫폼 차원의 관리자인 **Admin/SuperAdmin은 QnA 댓글을 삭제할 수 없는 문제**가 있었습니다. (해당 문제는 Notice 댓글 삭제 권한을 추가하는 과정에서 발견하였습니다.)

따라서 기존 Notice 댓글 삭제 권한과 동일하게, QnA 댓글에서도 Admin/SuperAdmin이 다른 사용자의 댓글을 삭제할 수 있도록 권한을 추가했습니다.

#### Solution

기존 QnA 댓글 삭제 로직의 작성자 및 Group Leader 권한 검사는 유지하고, 사이트 Admin/SuperAdmin 권한을 추가했습니다.

다음 사용자가 QnA 댓글을 삭제할 수 있습니다.

- 댓글 작성자 본인
- 해당 Course의 Group Leader
- 사이트 Admin/SuperAdmin

Controller에서 현재 사용자의 `role`을 Service로 전달하고, Service에서 `Role.Admin` 또는 `Role.SuperAdmin`인지 확인하도록 수정했습니다.

기존 댓글 삭제 및 QnA의 `isResolved` 갱신 로직은 변경하지 않았습니다.

### Additional context
기존 Course Notice 댓글 삭제 로직의 Admin/SuperAdmin 권한 확인 방식을 참고했습니다.
리뷰 시 기존 댓글 작성자 및 Group Leader의 삭제 권한이 유지되는지와 Admin/SuperAdmin이 다른 사용자의 QnA 댓글을 삭제할 수 있는지 확인 부탁드립니다.
`tsc --noEmit` 타입 체크, Prettier, ESLint를 통과했습니다.

Closes TAS-2916

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Administrators and super administrators can now delete course Q&A comments without being course leaders.
  * Existing permissions continue to allow comment authors and course staff to delete comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->