### PR TITLE
feat(fe): adds section column to course list table

### DIFF
--- a/apps/frontend/app/admin/_components/table/DataTableColumnHeader.tsx
+++ b/apps/frontend/app/admin/_components/table/DataTableColumnHeader.tsx
@@ -36,7 +36,12 @@ export function DataTableColumnHeader<TData, TValue>({
   // Title column
   if (!column.getCanSort()) {
     return (
-      <div className={cn('text-center font-normal text-[#8A8A8A]', className)}>
+      <div
+        className={cn(
+          'text-center text-base font-normal text-[#8A8A8A]',
+          className
+        )}
+      >
         {title}
       </div>
     )

--- a/apps/frontend/app/admin/course/_components/Columns.tsx
+++ b/apps/frontend/app/admin/course/_components/Columns.tsx
@@ -7,6 +7,7 @@ export interface DataTableCourse {
   id: number
   title: string
   code: string
+  classNum: number | null
   semester: string
   studentCount: number
 }
@@ -43,6 +44,14 @@ export const columns: ColumnDef<DataTableCourse>[] = [
       <DataTableColumnHeader column={column} title="Code" />
     ),
     cell: ({ row }) => row.getValue('code')
+  },
+  {
+    accessorKey: 'classNum',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Section" />
+    ),
+    cell: ({ row }) => row.getValue('classNum') ?? '-',
+    enableSorting: false
   },
 
   {

--- a/apps/frontend/app/admin/course/_components/GroupTable.tsx
+++ b/apps/frontend/app/admin/course/_components/GroupTable.tsx
@@ -28,6 +28,7 @@ export function GroupTable() {
         id: Number(course.id),
         title: course.groupName,
         code: course.courseInfo?.courseNum ?? '',
+        classNum: course.courseInfo?.classNum ?? null,
         semester: course.courseInfo?.semester ?? '',
         studentCount: course.memberNum
       })),


### PR DESCRIPTION
### Description

교수님 요청사항
admin/course 페이지에 분반 column 추가

### Additional context
datatableheader는 글자 크기 통일을 위 text-base만 추가했습니다~

closes TAS-2991
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a non-sortable **Section** column to the course administration table.
  - Displays the section number when available, or `-` when no section is assigned.

- **UI Improvements**
  - Increased the text size of unsortable column headers while preserving their existing alignment and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->